### PR TITLE
GitHub Actions: Cache Dialyzer PLT files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
+        id: install-erlang
         with:
           otp-version: ${{matrix.otp_version}}
           rebar3-version: '3.16.1'
+
+      - name: Restore Dialyzer PLT files from cache
+        uses: actions/cache@v2
+        if: ${{ matrix.otp_version == env.LATEST_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
+        with:
+          path: _build/default/rebar3_*_plt
+          key: dialyzer-plt-cache-${{ steps.install-erlang.outputs.otp-version }}-${{ runner.os }}-v1
 
       - name: Compile
         run: rebar3 compile

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,31 +1,41 @@
 %% vim:ft=erlang:
 
-case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
-    {"true", Token} when is_list(Token) ->
-        CONFIG1 = [
-                   %% FIXME: We need to use a fork of the plugin until the
-                   %% following pull request is merged:
-                   %% https://github.com/markusn/coveralls-erl/pull/36
-                   %% {plugins, [coveralls]},
-                   {plugins, [{coveralls,
-                               {git,
-                                "https://github.com/RoadRunnr/coveralls-erl.git",
-                                {branch, "feature/git-info"}}}]},
-                   {coveralls_coverdata, "_build/test/cover/eunit.coverdata"},
-                   {coveralls_service_name , "github"},
-                   {coveralls_parallel, true},
-                   {coveralls_repo_token, Token},
-                   {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
-                   {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")},
-                   {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
-                   {coveralls_flag_name, os:getenv("COVERALLS_FLAG_NAME")}| CONFIG],
-        case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
-             andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
-            [_, "pull", PRNO, _] ->
-                [{coveralls_service_pull_request, PRNO} | CONFIG1];
-            _ ->
-                CONFIG1
-        end;
-    _ ->
-        CONFIG
+begin
+    RunInGitHubActions = "true" =:= os:getenv("GITHUB_ACTIONS"),
+
+    %% Coveralls.
+    CONFIG1 =
+    case {RunInGitHubActions, os:getenv("GITHUB_TOKEN")} of
+        {true, Token} when is_list(Token) ->
+            Cfg2 = [
+                    %% FIXME: We need to use a fork of the plugin
+                    %% until the following pull request is merged:
+                    %% https://github.com/markusn/coveralls-erl/pull/36
+                    %% {plugins, [coveralls]},
+                    {plugins,
+                     [{coveralls,
+                       {git,
+                        "https://github.com/RoadRunnr/coveralls-erl.git",
+                        {branch, "feature/git-info"}}}]},
+                    {coveralls_coverdata, "_build/test/cover/eunit.coverdata"},
+                    {coveralls_service_name , "github"},
+                    {coveralls_parallel, true},
+                    {coveralls_repo_token, Token},
+                    {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
+                    {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")},
+                    {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
+                    {coveralls_flag_name, os:getenv("COVERALLS_FLAG_NAME")}
+                    | CONFIG],
+            case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
+                 andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
+                [_, "pull", PRNO, _] ->
+                    [{coveralls_service_pull_request, PRNO} | Cfg2];
+                _ ->
+                    Cfg2
+            end;
+        _ ->
+            CONFIG
+    end,
+
+    CONFIG1
 end.


### PR DESCRIPTION
They are expensive to generate and they are perfect candidates for caching because they do not change for a given version of Erlang.

The `rebar.config.script` file was reorganized because an earlier version of that patch depended on a change in that file. This is no longer needed, but I kept the reorganization to make it easier to extend `rebar.config.script` in the future.