### PR TITLE
Fix R/W auto detection with lambdas in the transaction function's environment

### DIFF
--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -502,7 +502,14 @@ when_readwrite_mode_is_true_test() ->
        is_function(khepri_tx:to_standalone_fun(
                      fun dict:new/0,
                      rw),
-                   0)).
+                   0)),
+
+    Fun = fun() -> khepri_tx:delete([foo]) end,
+    ?assert(
+       is_record(khepri_tx:to_standalone_fun(
+                   fun() -> Fun() end,
+                   rw),
+                 standalone_fun)).
 
 when_readwrite_mode_is_false_test() ->
     ?assert(
@@ -548,6 +555,13 @@ when_readwrite_mode_is_false_test() ->
        is_function(khepri_tx:to_standalone_fun(
                      fun dict:new/0,
                      ro),
+                   0)),
+
+    Fun = fun() -> khepri_tx:delete([foo]) end,
+    ?assert(
+       is_function(khepri_tx:to_standalone_fun(
+                     fun() -> Fun() end,
+                     ro),
                    0)).
 
 when_readwrite_mode_is_auto_test() ->
@@ -590,4 +604,11 @@ when_readwrite_mode_is_auto_test() ->
        is_function(khepri_tx:to_standalone_fun(
                      fun dict:new/0,
                      auto),
-                   0)).
+                   0)),
+
+    Fun = fun() -> khepri_tx:delete([foo]) end,
+    ?assert(
+       is_record(khepri_tx:to_standalone_fun(
+                   fun() -> Fun() end,
+                   auto),
+                 standalone_fun)).


### PR DESCRIPTION
This fixes the auto detection of R/W nature when a transaction function has another lambda in its environment.

Here is an example added to the testsuite:

```erlang
Fun = fun() -> khepri_tx:delete([foo]) end,
khepri_tx:to_standalone_fun(
  fun() -> Fun() end,
  auto),
standalone_fun)).
```

In this scenario, the lambda passed to `khepri_tx:transaction/2` is considered read-only because it doesn't call `khepri_tx:put/2` or `khepri_tx:delete/1`. However, it calls another lambda from its environment which calls one of these functions.

Before this patch, this was undetected because the `validate()` callback was called for the top-level lambda first. The callback would considered the lambda read-only and stop, skipping the second lambda from the environment entirely.

Now, the code analyzes the top-level lambda and its environment before calling the callback. This way, it can inspect what the lambdas from the environment do too.

To do that, the `to_standalone_fun/2` and `to_standalone_env/1` were modified to be able to return the updated state. This allows the calls and errors reported for lambdas inside the environment to be used in the callback.

The callback itself is only called once at the end of the analysis, not for every single lambdas we find.

While here, it was renamed from `validate` to `is_standalone_fun_still_needed`. I'm still not very happy with the names of all those callbacks, but at least they tell what they do.

Also, the error processing was moved from the callback implementation in `khepri_tx` to a function in `khepri_fun` which is always called, regardless of the presence of the callback or not.