### PR TITLE
khepri_path: Call realpath/1 in pattern_includes_root_node/1

### DIFF
--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -341,6 +341,9 @@ realpath([Component | Rest], Result) ->
 realpath([], Result) ->
     lists:reverse(Result).
 
-pattern_includes_root_node([#if_name_matches{regex = any}]) -> true;
-pattern_includes_root_node([#if_path_matches{regex = any}]) -> true;
-pattern_includes_root_node(_)                               -> false.
+pattern_includes_root_node(Path) ->
+    pattern_includes_root_node1(realpath(Path)).
+
+pattern_includes_root_node1([#if_name_matches{regex = any}]) -> true;
+pattern_includes_root_node1([#if_path_matches{regex = any}]) -> true;
+pattern_includes_root_node1(_)                               -> false.

--- a/test/queries.erl
+++ b/test/queries.erl
@@ -168,10 +168,10 @@ query_many_nodes_recursively_test() ->
                      payload = ?DATA_PAYLOAD(pouet_value)}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
-    Ret = khepri_machine:find_matching_nodes(
-            Root,
-            [#if_path_matches{regex = any}],
-            #{}),
+    Ret1 = khepri_machine:find_matching_nodes(
+             Root,
+             [#if_path_matches{regex = any}],
+             #{}),
 
     ?assertEqual(
        {ok, #{[] => #{payload_version => 1,
@@ -196,7 +196,13 @@ query_many_nodes_recursively_test() ->
                                 payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}},
-       Ret).
+       Ret1),
+
+    Ret2 = khepri_machine:find_matching_nodes(
+             Root,
+             [?ROOT_NODE, #if_path_matches{regex = any}],
+             #{}),
+    ?assertEqual(Ret1, Ret2).
 
 query_many_nodes_recursively_using_regex_test() ->
     Commands = [#put{path = [foo, bar],

--- a/test/simple_get.erl
+++ b/test/simple_get.erl
@@ -52,7 +52,10 @@ get_many_nodes_test_() ->
          ok,
          khepri:create(?FUNCTION_NAME, [baz], baz_value)),
       ?_assertEqual(
-         {ok, #{[foo] => #{payload_version => 1,
+         {ok, #{[] => #{payload_version => 1,
+                        child_list_version => 3,
+                        child_list_length => 2},
+                [foo] => #{payload_version => 1,
                            child_list_version => 1,
                            child_list_length => 1},
                 [baz] => #{data => baz_value,
@@ -110,7 +113,10 @@ list_existing_node_test_() ->
          ok,
          khepri:create(?FUNCTION_NAME, [baz], baz_value)),
       ?_assertEqual(
-         {ok, #{[foo] => #{payload_version => 1,
+         {ok, #{[] => #{payload_version => 1,
+                        child_list_version => 3,
+                        child_list_length => 2},
+                [foo] => #{payload_version => 1,
                            child_list_version => 1,
                            child_list_length => 1},
                 [baz] => #{data => baz_value,


### PR DESCRIPTION
This cleans any use of `?ROOT_NODE` or `?THIS_NODE` in the path. Otherwise the function would return a different result if these macros were prepended to `?STAR` or `?STAR_STAR` for instance, even though the meaning of the path is exactly the same.

I'm still not very happy with this heuristic to determine if the root node properties should be included in a get. Another solution would be to require an explicit `?ROOT_NODE` in the path to include its properties in the result.