### PR TITLE
Transactions: Support `set_tuple_element` Erlang instruction

### DIFF
--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -247,6 +247,8 @@ ensure_instruction_is_permitted(send) ->
     throw(sending_message_denied);
 ensure_instruction_is_permitted({select_val, _, _, {list, _}}) ->
     ok;
+ensure_instruction_is_permitted({set_tuple_element, _, _, _}) ->
+    ok;
 ensure_instruction_is_permitted({swap, _, _}) ->
     ok;
 ensure_instruction_is_permitted({test, _, _, _}) ->


### PR DESCRIPTION
I couldn't figure out a testcase using this instruction, but a transaction in RabbitMQ happens to use one.

This was reported by @mkuratczyk.

Fixes #13.