### PR TITLE
Transaction: Add `khepri_tx:is_transaction()` helper

### DIFF
--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -57,7 +57,8 @@
          list/1,
          find/2,
          delete/1,
-         abort/1]).
+         abort/1,
+         is_transaction/0]).
 
 %% For internal user only.
 -export([to_standalone_fun/2,
@@ -158,6 +159,12 @@ delete(PathPattern) ->
 
 abort(Reason) ->
     throw({aborted, Reason}).
+
+-spec is_transaction() -> boolean().
+
+is_transaction() ->
+    State = erlang:get(?TX_STATE_KEY),
+    is_record(State, khepri_machine).
 
 -spec to_standalone_fun(Fun, ReadWrite) -> StandaloneFun | no_return() when
       Fun :: fun(),
@@ -349,6 +356,7 @@ is_remote_call_valid(khepri_tx, list, _) -> true;
 is_remote_call_valid(khepri_tx, find, _) -> true;
 is_remote_call_valid(khepri_tx, delete, _) -> true;
 is_remote_call_valid(khepri_tx, abort, _) -> true;
+is_remote_call_valid(khepri_tx, is_transaction, _) -> true;
 
 is_remote_call_valid(_, module_info, _) -> false;
 

--- a/test/transactions.erl
+++ b/test/transactions.erl
@@ -72,6 +72,29 @@ fun_extraction_test() ->
             end
     end.
 
+is_transaction_test_() ->
+    [?_assertNot(khepri_tx:is_transaction()),
+     {setup,
+      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+      [?_assertEqual(
+          {atomic, true},
+          begin
+              Fun = fun() ->
+                            khepri_tx:is_transaction()
+                    end,
+              khepri_machine:transaction(?FUNCTION_NAME, Fun, ro)
+          end),
+       ?_assertEqual(
+          {atomic, true},
+          begin
+              Fun = fun() ->
+                            khepri_tx:is_transaction()
+                    end,
+              khepri_machine:transaction(?FUNCTION_NAME, Fun, rw)
+          end)]}
+    ].
+
 noop_in_ro_transaction_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -44,7 +44,8 @@ allowed_khepri_tx_api_test() ->
            _ = khepri_tx:list([foo]),
            _ = khepri_tx:find([foo], ?STAR),
            _ = khepri_tx:delete([foo]),
-           _ = khepri_tx:abort(error)
+           _ = khepri_tx:abort(error),
+           _ = khepri_tx:is_transaction()
        end).
 
 denied_khepri_tx_run_3_test() ->


### PR DESCRIPTION
Like its Mnesia equivalent, it returns `true` when running in a transaction, `false` otherwise.