### PR TITLE
Rename "keep until" conditions to "keep while" conditions

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -171,9 +171,9 @@ tree nodes `stock' and `wood' were created if they were missing. After
 `<<"walnut">>' is removed, they will stay in the tree with possibly neither
 payload nor child nodes.
 
-Khepri has the concept of <em>`keep_until' conditions</em>. A `keep_until'
+Khepri has the concept of <em>`keep_while' conditions</em>. A `keep_while'
 condition is like the conditions which can be used inside path pattern. When a
-node is inserted or updated, it is possible to set `keep_until' conditions:
+node is inserted or updated, it is possible to set `keep_while' conditions:
 when these conditions evaluate to false, the tree node is removed from the
 tree.
 
@@ -182,10 +182,10 @@ to make sure it is removed after its last child node is removed:
 ```
 %% We keep [stock, wood] as long as its child nodes count is strictly greater
 %% then zero.
-KeepUntilCondition = #{[stock, wood] => #if_child_list_length{count = {gt, 0}}}.
+KeepWhileCondition = #{[stock, wood] => #if_child_list_length{count = {gt, 0}}}.
 '''
 
-`keep_until' conditions on self (like the example above) are not evaluated on
+`keep_while' conditions on self (like the example above) are not evaluated on
 the first insert though.
 
 == Khepri API ==

--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -23,8 +23,8 @@
 
 -record(put, {path :: khepri_path:pattern(),
               payload = none :: khepri_machine:payload(),
-              extra = #{} :: #{keep_until =>
-                               khepri_machine:keep_untils_map()}}).
+              extra = #{} :: #{keep_while =>
+                               khepri_machine:keep_while_conds_map()}}).
 
 -record(delete, {path :: khepri_path:pattern()}).
 

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -1009,14 +1009,14 @@ info(StoreId) ->
     Nodes = lists:sort([Node || {_, Node} <- members(StoreId)]),
     lists:foreach(fun(Node) -> io:format("~ts~n", [Node]) end, Nodes),
 
-    case khepri_machine:get_keep_untils_state(StoreId) of
-        {ok, KeepUntils} when KeepUntils =/= #{} ->
+    case khepri_machine:get_keep_while_conds_state(StoreId) of
+        {ok, KeepWhileConds} when KeepWhileConds =/= #{} ->
             io:format("~n\033[1;32m== LIFETIME DEPS ==\033[0m~n", []),
-            WatcherList = lists:sort(maps:keys(KeepUntils)),
+            WatcherList = lists:sort(maps:keys(KeepWhileConds)),
             lists:foreach(
               fun(Watcher) ->
                       io:format("~n\033[1m~p depends on:\033[0m~n", [Watcher]),
-                      WatchedsMap = maps:get(Watcher, KeepUntils),
+                      WatchedsMap = maps:get(Watcher, KeepWhileConds),
                       Watcheds = lists:sort(maps:keys(WatchedsMap)),
                       lists:foreach(
                         fun(Watched) ->

--- a/src/khepri_condition.erl
+++ b/src/khepri_condition.erl
@@ -7,7 +7,7 @@
 
 %% @doc Condition support.
 %%
-%% Conditions can be used in path patterns and `keep_until' conditions.
+%% Conditions can be used in path patterns and `keep_while' conditions.
 %%
 %% A condition is an Erlang record defining a specific property. Some of them
 %% have arguments to further define the condition.
@@ -222,7 +222,7 @@
                                          if_child_list_version() |
                                          if_child_list_length().
 
--type keep_until() :: #{khepri_path:path() => condition()}.
+-type keep_while() :: #{khepri_path:path() => condition()}.
 
 -export([compile/1,
          applies_to_grandchildren/1,
@@ -236,7 +236,7 @@
 
 -export_type([condition/0,
               comparison_op/1,
-              keep_until/0]).
+              keep_while/0]).
 
 -spec compile(Condition) -> Condition when
       Condition :: khepri_path:pattern_component().

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -14,6 +14,7 @@
 -record(khepri_machine,
         {config = #config{} :: khepri_machine:machine_config(),
          root = #node{stat = ?INIT_NODE_STAT} :: khepri_machine:tree_node(),
-         keep_untils = #{} :: khepri_machine:keep_untils_map(),
-         keep_untils_revidx = #{} :: khepri_machine:keep_untils_revidx(),
+         keep_while_conds = #{} :: khepri_machine:keep_while_conds_map(),
+         keep_while_conds_revidx = #{}
+           :: khepri_machine:keep_while_conds_revidx(),
          metrics = #{}}).

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -90,7 +90,7 @@ put(PathPattern, Payload) ->
 -spec put(PathPattern, Payload, Extra) -> Result when
       PathPattern :: khepri_path:pattern(),
       Payload :: khepri_machine:payload(),
-      Extra :: #{keep_until => khepri_condition:keep_until()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Result :: khepri_machine:result().
 %% @doc Creates or modifies a specific tree node in the tree structure.
 

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -104,8 +104,8 @@ get_store_info_on_running_store_test_() ->
              ?capturedOutput
          end)]}.
 
-get_store_info_with_keep_untils_test_() ->
-    KeepUntil = #{[?THIS_NODE] => #if_child_list_length{count = {gt, 0}}},
+get_store_info_with_keep_while_conds_test_() ->
+    KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = {gt, 0}}},
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -113,7 +113,7 @@ get_store_info_with_keep_untils_test_() ->
          {ok, #{[foo] => #{}}},
          khepri_machine:put(
            ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value),
-           #{keep_until => KeepUntil})),
+           #{keep_while => KeepWhile})),
       ?_assertEqual(
          "\n"
          "\033[1;32m== CLUSTER MEMBERS ==\033[0m\n"

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -63,8 +63,8 @@ delete_a_node_test_() ->
             khepri_machine:get(?FUNCTION_NAME, [foo]))}]}
      ]}.
 
-query_keep_untils_state_test_() ->
-    KeepUntil = #{[?THIS_NODE] => #if_child_list_length{count = {gt, 0}}},
+query_keep_while_conds_state_test_() ->
+    KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = {gt, 0}}},
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -76,8 +76,8 @@ query_keep_untils_state_test_() ->
                    ?FUNCTION_NAME,
                    [foo],
                    ?DATA_PAYLOAD(foo_value),
-                   #{keep_until => KeepUntil}),
-             khepri_machine:get_keep_untils_state(?FUNCTION_NAME)
+                   #{keep_while => KeepWhile}),
+             khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME)
          end)]}.
 
 use_an_invalid_path_test_() ->


### PR DESCRIPTION
The reason is that we want to "keep a node while a condition remains true". It is clearer than "keep a node until a condition becomes false" which was my initial thinking.