### PR TITLE
Replace macros by records to represent payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ khepri:transaction(
                 %% There is less than 100 pieces of wood, or there is none
                 %% at all (the node does not exist in Khepri). We need to
                 %% request a new order.
-                {ok, _} = khepri_tx:put([order, wood], ?DATA_PAYLOAD(1000)),
+                {ok, _} = khepri_tx:put(
+                            [order, wood],
+                            #kpayload_data{data = 1000}),
                 true
         end
     end).

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -91,8 +91,8 @@ the future.
 
 Payloads are represented using macros or helper functions:
 <ul>
-<li>`?NO_PAYLOAD' and {@link khepri:no_payload/0}</li>
-<li>`?DATA_PAYLOAD(Term)' and {@link khepri:data_payload/1}</li>
+<li>`none' and {@link khepri:no_payload/0}</li>
+<li>`#kpayload_data{data = Term}' and {@link khepri:data_payload/1}</li>
 </ul>
 
 Functions in {@link khepri_machine} have no assumption on the type of the
@@ -222,7 +222,9 @@ specific use cases may need to rely on that low-level API.
 %% Unlike the high-level API's `khepri:insert/2' function, this low-level %
 %% insert returns whatever it replaced (if anything). In this case, there was
 %% nothing before, so the returned value is pretty empty.
-Ret1 = khepri_machine:put(StoreId, [stock, wood, <<"lime tree">>], ?DATA_PAYLOAD(150)),
+Ret1 = khepri_machine:put(
+         StoreId, [stock, wood, <<"lime tree">>],
+         #kpayload_data{data = 150}),
 {ok, #{}} = Ret1,
 
 Ret2 = khepri_machine:get(StoreId, [stock, wood, <<"lime tree">>]),

--- a/include/khepri.hrl
+++ b/include/khepri.hrl
@@ -33,12 +33,10 @@
 -define(IS_PATH_PATTERN(Path),
         (Path =:= [] orelse ?IS_PATH_CONDITION(hd(Path)))).
 
--define(NO_PAYLOAD, none).
--define(DATA_PAYLOAD(Data), {data, Data}).
--define(IS_PAYLOAD(Payload), (Payload =:= none orelse
-                              (is_tuple(Payload) andalso
-                               size(Payload) =:= 2 andalso
-                               element(1, Payload) =:= data))).
+-record(kpayload_data, {data :: khepri_machine:data()}).
+
+-define(IS_KHEPRI_PAYLOAD(Payload), (Payload =:= none orelse
+                                     is_record(Payload, kpayload_data))).
 
 %% -------------------------------------------------------------------
 %% Path conditions.

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -632,7 +632,7 @@ compare_and_swap(StoreId, Path, DataPattern, Data) ->
 %% @private
 
 do_put(StoreId, Path, Data) ->
-    case khepri_machine:put(StoreId, Path, ?DATA_PAYLOAD(Data)) of
+    case khepri_machine:put(StoreId, Path, #kpayload_data{data = Data}) of
         {ok, _} -> ok;
         Error   -> Error
     end.
@@ -654,7 +654,7 @@ clear_payload(Path) ->
       Path :: khepri_path:pattern() | string().
 %% @doc Clears the payload of an existing specific tree node in the tree structure.
 %%
-%% In other words, the payload is set to `?NO_PAYLOAD'.
+%% In other words, the payload is set to `none'.
 %%
 %% The `Path' can be provided as a list of node names and conditions or as a
 %% string. See {@link khepri_path:from_string/1}.
@@ -669,7 +669,7 @@ clear_payload(Path) ->
 
 clear_payload(StoreId, Path) ->
     Path1 = khepri_path:maybe_from_string(Path),
-    case khepri_machine:put(StoreId, Path1, ?NO_PAYLOAD) of
+    case khepri_machine:put(StoreId, Path1, none) of
         {ok, _} -> ok;
         Error   -> Error
     end.
@@ -967,23 +967,24 @@ clear_store(StoreId) ->
     delete(StoreId, [?STAR]).
 
 -spec no_payload() -> none.
-%% @doc Returns `?NO_PAYLOAD'.
+%% @doc Returns `none'.
 %%
-%% This is a helper for cases where using macros is inconvenient, like in an
+%% This is a helper for cases where using records is inconvenient, like in an
 %% Erlang shell.
 
 no_payload() ->
-    ?NO_PAYLOAD.
+    none.
 
--spec data_payload(Term) -> {data, Term} when
-      Term :: khepri_machine:data().
-%% @doc Returns `?DATA_PAYLOAD(Term)'.
+-spec data_payload(Term) -> Payload when
+      Term :: khepri_machine:data(),
+      Payload :: #kpayload_data{}.
+%% @doc Returns `#kpayload_data{data = Term}'.
 %%
 %% This is a helper for cases where using macros is inconvenient, like in an
 %% Erlang shell.
 
 data_payload(Term) ->
-    ?DATA_PAYLOAD(Term).
+    #kpayload_data{data = Term}.
 
 %% -------------------------------------------------------------------
 %% Public helpers.

--- a/src/khepri_condition.erl
+++ b/src/khepri_condition.erl
@@ -345,17 +345,17 @@ is_met(
   _Child) ->
     eval_regex(Cond, SourceRegex, CompiledRegex, ChildName);
 is_met(#if_has_data{has_data = true},
-       _ChildName, #node{payload = {data, _}}) ->
+       _ChildName, #node{payload = #kpayload_data{data = _}}) ->
     true;
 is_met(#if_has_data{has_data = false} = Cond,
-       _ChildName, #node{payload = {data, _}}) ->
+       _ChildName, #node{payload = #kpayload_data{data = _}}) ->
     {false, Cond};
 is_met(#if_has_data{has_data = true} = Cond, _ChildName, _Child) ->
     {false, Cond};
 is_met(#if_has_data{has_data = false}, _ChildName, _Child) ->
     true;
 is_met(#if_data_matches{compiled = CompMatchSpec} = Cond,
-       _ChildName, #node{payload = {data, Data}}) ->
+       _ChildName, #node{payload = #kpayload_data{data = Data}}) ->
     case term_matches(Data, CompMatchSpec) of
         true  -> true;
         false -> {false, Cond}

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -94,7 +94,7 @@ put(PathPattern, Payload) ->
       Result :: khepri_machine:result().
 %% @doc Creates or modifies a specific tree node in the tree structure.
 
-put(PathPattern, Payload, Extra) when ?IS_PAYLOAD(Payload) ->
+put(PathPattern, Payload, Extra) when ?IS_KHEPRI_PAYLOAD(Payload) ->
     ensure_path_pattern_is_valid(PathPattern),
     ensure_updates_are_allowed(),
     State = get_tx_state(),

--- a/test/conditions.erl
+++ b/test/conditions.erl
@@ -180,11 +180,11 @@ if_has_data_matching_test() ->
        {false, #if_has_data{has_data = false}},
        khepri_condition:is_met(
          khepri_condition:compile(#if_has_data{has_data = false}),
-         foo, #node{payload = {data, foo}})),
+         foo, #node{payload = #kpayload_data{data = foo}})),
     ?assert(
        khepri_condition:is_met(
          khepri_condition:compile(#if_has_data{has_data = true}),
-         foo, #node{payload = {data, foo}})).
+         foo, #node{payload = #kpayload_data{data = foo}})).
 
 if_data_matches_matching_test() ->
     CompiledCond1 = khepri_condition:compile(
@@ -195,7 +195,7 @@ if_data_matches_matching_test() ->
          CompiledCond1, foo, #node{})),
     ?assert(
        khepri_condition:is_met(
-         CompiledCond1, foo, #node{payload = {data, {a, b}}})),
+         CompiledCond1, foo, #node{payload = #kpayload_data{data = {a, b}}})),
 
     CompiledCond2 = khepri_condition:compile(
                       #if_data_matches{pattern = {a, '_'}}),
@@ -213,18 +213,18 @@ if_data_matches_matching_test() ->
 
     ?assert(
        khepri_condition:is_met(
-         CompiledCond2, foo, #node{payload = {data, {a, b}}})),
+         CompiledCond2, foo, #node{payload = #kpayload_data{data = {a, b}}})),
     ?assert(
        khepri_condition:is_met(
-         CompiledCond2, foo, #node{payload = {data, {a, c}}})),
+         CompiledCond2, foo, #node{payload = #kpayload_data{data = {a, c}}})),
     ?assertEqual(
        {false, CompiledCond2},
        khepri_condition:is_met(
-         CompiledCond2, foo, #node{payload = {data, {b, c}}})),
+         CompiledCond2, foo, #node{payload = #kpayload_data{data = {b, c}}})),
     ?assertEqual(
        {false, CompiledCond2},
        khepri_condition:is_met(
-         CompiledCond2, foo, #node{payload = {data, other}})).
+         CompiledCond2, foo, #node{payload = #kpayload_data{data = other}})).
 
 if_payload_version_matching_test() ->
     ?assert(

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -112,7 +112,7 @@ get_store_info_with_keep_while_conds_test_() ->
      [?_assertEqual(
          {ok, #{[foo] => #{}}},
          khepri_machine:put(
-           ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value),
+           ?FUNCTION_NAME, [foo], #kpayload_data{data = foo_value},
            #{keep_while => KeepWhile})),
       ?_assertEqual(
          "\n"

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -37,7 +37,7 @@ delete_non_existing_node_under_non_existing_parent_test() ->
 
 delete_existing_node_with_data_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [foo]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -57,7 +57,7 @@ delete_existing_node_with_data_test() ->
 
 delete_existing_node_with_data_using_dot_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [foo, ?THIS_NODE]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -77,7 +77,7 @@ delete_existing_node_with_data_using_dot_test() ->
 
 delete_existing_node_with_child_nodes_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [foo]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -96,7 +96,7 @@ delete_existing_node_with_child_nodes_test() ->
 
 delete_a_node_deep_into_the_tree_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [foo, bar, baz]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -124,9 +124,9 @@ delete_a_node_deep_into_the_tree_test() ->
 
 delete_existing_node_with_condition_true_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [#if_data_matches{pattern = bar_value}]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -140,7 +140,7 @@ delete_existing_node_with_condition_true_test() ->
           child_nodes =
           #{foo =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, foo_value}}}},
+                  payload = #kpayload_data{data = foo_value}}}},
        Root),
     ?assertEqual({ok, #{[bar] => #{data => bar_value,
                                    payload_version => 1,
@@ -149,9 +149,9 @@ delete_existing_node_with_condition_true_test() ->
 
 delete_existing_node_with_condition_false_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [#if_data_matches{pattern = other_value}]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -165,18 +165,18 @@ delete_existing_node_with_condition_false_test() ->
           child_nodes =
           #{foo =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, foo_value}},
+                  payload = #kpayload_data{data = foo_value}},
             bar =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, bar_value}}}},
+                  payload = #kpayload_data{data = bar_value}}}},
        Root),
     ?assertEqual({ok, #{}}, Ret).
 
 delete_existing_node_with_condition_true_using_dot_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path =
                       [bar,
@@ -194,7 +194,7 @@ delete_existing_node_with_condition_true_using_dot_test() ->
           child_nodes =
           #{foo =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, foo_value}}}},
+                  payload = #kpayload_data{data = foo_value}}}},
        Root),
     ?assertEqual({ok, #{[bar] => #{data => bar_value,
                                    payload_version => 1,
@@ -203,9 +203,9 @@ delete_existing_node_with_condition_true_using_dot_test() ->
 
 delete_existing_node_with_condition_false_using_dot_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path =
                       [bar,
@@ -223,20 +223,20 @@ delete_existing_node_with_condition_false_using_dot_test() ->
           child_nodes =
           #{foo =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, foo_value}},
+                  payload = #kpayload_data{data = foo_value}},
             bar =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, bar_value}}}},
+                  payload = #kpayload_data{data = bar_value}}}},
        Root),
     ?assertEqual({ok, #{}}, Ret).
 
 delete_many_nodes_at_once_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)}],
+                     payload = #kpayload_data{data = baz_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [#if_name_matches{regex = "a"}]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -250,7 +250,7 @@ delete_many_nodes_at_once_test() ->
           child_nodes =
           #{foo =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, foo_value}}}},
+                  payload = #kpayload_data{data = foo_value}}}},
        Root),
     ?assertEqual({ok, #{[bar] => #{data => bar_value,
                                    payload_version => 1,

--- a/test/display_tree.erl
+++ b/test/display_tree.erl
@@ -18,13 +18,13 @@
 
 complex_flat_struct_to_tree_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
-                     payload = ?DATA_PAYLOAD(qux_value)},
+                     payload = #kpayload_data{data = qux_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(pouet_value)}],
+                     payload = #kpayload_data{data = pouet_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -357,7 +357,7 @@ flat_struct_with_children_before_parents_test() ->
 
 display_simple_tree_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -376,13 +376,14 @@ display_simple_tree_test() ->
 
 display_large_tree_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
-                     payload = ?DATA_PAYLOAD(qux_value)},
+                     payload = #kpayload_data{data = qux_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(
+                     payload = #kpayload_data{
+                                  data =
                                   [lorem, ipsum, dolor, sit, amet,
                                    consectetur, adipiscing, elit, sed, do,
                                    eiusmod, tempor, incididunt, ut, labore,
@@ -395,7 +396,7 @@ display_large_tree_test() ->
                                    nulla, pariatur, excepteur, sint, occaecat,
                                    cupidatat, non, proident, sunt, in, culpa,
                                    qui, officia, deserunt, mollit, anim, id,
-                                   est, laborum])}],
+                                   est, laborum]}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -432,13 +433,14 @@ display_large_tree_test() ->
 
 display_tree_with_plaintext_lines_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
-                     payload = ?DATA_PAYLOAD(qux_value)},
+                     payload = #kpayload_data{data = qux_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(
+                     payload = #kpayload_data{
+                                  data =
                                   [lorem, ipsum, dolor, sit, amet,
                                    consectetur, adipiscing, elit, sed, do,
                                    eiusmod, tempor, incididunt, ut, labore,
@@ -451,7 +453,7 @@ display_tree_with_plaintext_lines_test() ->
                                    nulla, pariatur, excepteur, sint, occaecat,
                                    cupidatat, non, proident, sunt, in, culpa,
                                    qui, officia, deserunt, mollit, anim, id,
-                                   est, laborum])}],
+                                   est, laborum]}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -488,13 +490,14 @@ display_tree_with_plaintext_lines_test() ->
 
 display_tree_without_colors_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
-                     payload = ?DATA_PAYLOAD(qux_value)},
+                     payload = #kpayload_data{data = qux_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(
+                     payload = #kpayload_data{
+                                  data =
                                   [lorem, ipsum, dolor, sit, amet,
                                    consectetur, adipiscing, elit, sed, do,
                                    eiusmod, tempor, incididunt, ut, labore,
@@ -507,7 +510,7 @@ display_tree_without_colors_test() ->
                                    nulla, pariatur, excepteur, sint, occaecat,
                                    cupidatat, non, proident, sunt, in, culpa,
                                    qui, officia, deserunt, mollit, anim, id,
-                                   est, laborum])}],
+                                   est, laborum]}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -544,13 +547,14 @@ display_tree_without_colors_test() ->
 
 display_tree_with_plaintext_lines_and_without_colors_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
-                     payload = ?DATA_PAYLOAD(qux_value)},
+                     payload = #kpayload_data{data = qux_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(
+                     payload = #kpayload_data{
+                                  data =
                                   [lorem, ipsum, dolor, sit, amet,
                                    consectetur, adipiscing, elit, sed, do,
                                    eiusmod, tempor, incididunt, ut, labore,
@@ -563,7 +567,7 @@ display_tree_with_plaintext_lines_and_without_colors_test() ->
                                    nulla, pariatur, excepteur, sint, occaecat,
                                    cupidatat, non, proident, sunt, in, culpa,
                                    qui, officia, deserunt, mollit, anim, id,
-                                   est, laborum])}],
+                                   est, laborum]}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -601,9 +605,9 @@ display_tree_with_plaintext_lines_and_without_colors_test() ->
 
 display_tree_with_binary_key_test() ->
     Commands = [#put{path = [<<"foo">>],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -625,9 +629,9 @@ display_tree_with_binary_key_test() ->
 
 display_tree_with_similar_atom_and_binary_keys_test() ->
     Commands = [#put{path = [<<"foo">>],
-                     payload = ?DATA_PAYLOAD(foo_binary)},
+                     payload = #kpayload_data{data = foo_binary}},
                 #put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_atom)}],
+                     payload = #kpayload_data{data = foo_atom}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -23,7 +23,7 @@
 
 are_keep_while_conditions_met_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
 
@@ -60,12 +60,12 @@ are_keep_while_conditions_met_test() ->
 
 insert_when_keep_while_true_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     KeepWhile = #{[foo] => #if_node_exists{exists = true}},
     Command = #put{path = [baz],
-                   payload = ?DATA_PAYLOAD(baz_value),
+                   payload = #kpayload_data{data = baz_value},
                    extra = #{keep_while => KeepWhile}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -81,11 +81,11 @@ insert_when_keep_while_true_test() ->
           #{foo =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, foo_value}},
+               payload = #kpayload_data{data = foo_value}},
             baz =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, baz_value}}}},
+               payload = #kpayload_data{data = baz_value}}}},
        Root),
     ?assertEqual(
        #{[baz] => KeepWhile},
@@ -97,13 +97,13 @@ insert_when_keep_while_true_test() ->
 
 insert_when_keep_while_false_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     %% The targeted keep_while node does not exist.
     KeepWhile1 = #{[foo, bar] => #if_node_exists{exists = true}},
     Command1 = #put{path = [baz],
-                    payload = ?DATA_PAYLOAD(baz_value),
+                    payload = #kpayload_data{data = baz_value},
                     extra = #{keep_while => KeepWhile1}},
     {S1, Ret1} = khepri_machine:apply(?META, Command1, S0),
 
@@ -120,7 +120,7 @@ insert_when_keep_while_false_test() ->
     %% The targeted keep_while node exists but the condition is not verified.
     KeepWhile2 = #{[foo] => #if_child_list_length{count = 10}},
     Command2 = #put{path = [baz],
-                    payload = ?DATA_PAYLOAD(baz_value),
+                    payload = #kpayload_data{data = baz_value},
                     extra =
                     #{keep_while => KeepWhile2}},
     {S2, Ret2} = khepri_machine:apply(?META, Command2, S0),
@@ -139,7 +139,7 @@ insert_when_keep_while_true_on_self_test() ->
     S0 = khepri_machine:init(#{}),
     KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = 0}},
     Command = #put{path = [foo],
-                   payload = ?DATA_PAYLOAD(foo_value),
+                   payload = #kpayload_data{data = foo_value},
                    extra = #{keep_while => KeepWhile}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -153,7 +153,7 @@ insert_when_keep_while_true_on_self_test() ->
           #{foo =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, foo_value}}}},
+               payload = #kpayload_data{data = foo_value}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{}}}, Ret).
 
@@ -161,7 +161,7 @@ insert_when_keep_while_false_on_self_test() ->
     S0 = khepri_machine:init(#{}),
     KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = 1}},
     Command = #put{path = [foo],
-                   payload = ?DATA_PAYLOAD(foo_value),
+                   payload = #kpayload_data{data = foo_value},
                    extra = #{keep_while => KeepWhile}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -175,21 +175,21 @@ insert_when_keep_while_false_on_self_test() ->
           #{foo =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, foo_value}}}},
+               payload = #kpayload_data{data = foo_value}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{}}}, Ret).
 
 keep_while_still_true_after_command_test() ->
     KeepWhile = #{[foo] => #if_child_list_length{count = 0}},
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value),
+                     payload = #kpayload_data{data = baz_value},
                      extra = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [foo],
-                   payload = ?DATA_PAYLOAD(new_foo_value)},
+                   payload = #kpayload_data{data = new_foo_value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -203,11 +203,11 @@ keep_while_still_true_after_command_test() ->
             #node{
                stat = #{payload_version => 2,
                         child_list_version => 1},
-               payload = {data, new_foo_value}},
+               payload = #kpayload_data{data = new_foo_value}},
             baz =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, baz_value}}}},
+               payload = #kpayload_data{data = baz_value}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{data => foo_value,
                                    payload_version => 1,
@@ -217,14 +217,14 @@ keep_while_still_true_after_command_test() ->
 keep_while_now_false_after_command_test() ->
     KeepWhile = #{[foo] => #if_child_list_length{count = 0}},
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value),
+                     payload = #kpayload_data{data = baz_value},
                      extra = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [foo, bar],
-                   payload = ?DATA_PAYLOAD(bar_value)},
+                   payload = #kpayload_data{data = bar_value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -238,24 +238,24 @@ keep_while_now_false_after_command_test() ->
             #node{
                stat = #{payload_version => 1,
                         child_list_version => 2},
-               payload = {data, foo_value},
+               payload = #kpayload_data{data = foo_value},
                child_nodes =
                #{bar =>
                  #node{stat = ?INIT_NODE_STAT,
-                       payload = {data, bar_value}}}}}},
+                       payload = #kpayload_data{data = bar_value}}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{}}}, Ret).
 
 recursive_automatic_cleanup_test() ->
     KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = {gt, 0}}},
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value),
+                     payload = #kpayload_data{data = foo_value},
                      extra = #{keep_while => KeepWhile}},
                 #put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value),
+                     payload = #kpayload_data{data = bar_value},
                      extra = #{keep_while => KeepWhile}},
                 #put{path = [foo, bar, baz],
-                     payload = ?DATA_PAYLOAD(baz_value)}],
+                     payload = #kpayload_data{data = baz_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #delete{path = [foo, bar, baz]},

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -24,7 +24,7 @@ insert_a_node_test_() ->
      [?_assertEqual(
          {ok, #{[foo] => #{}}},
          khepri_machine:put(
-           ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value)))]}.
+           ?FUNCTION_NAME, [foo], #kpayload_data{data = foo_value}))]}.
 
 query_a_node_test_() ->
     {setup,
@@ -37,7 +37,7 @@ query_a_node_test_() ->
                            child_list_length => 0}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = foo_value}),
              khepri_machine:get(?FUNCTION_NAME, [foo])
          end)]}.
 
@@ -54,7 +54,8 @@ delete_a_node_test_() ->
                               child_list_length => 0}}},
             begin
                 _ = khepri_machine:put(
-                      ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value)),
+                      ?FUNCTION_NAME, [foo],
+                      #kpayload_data{data = foo_value}),
                 khepri_machine:delete(?FUNCTION_NAME, [foo])
             end)},
         {"Checking the deleted key is gone",
@@ -75,7 +76,7 @@ query_keep_while_conds_state_test_() ->
              _ = khepri_machine:put(
                    ?FUNCTION_NAME,
                    [foo],
-                   ?DATA_PAYLOAD(foo_value),
+                   #kpayload_data{data = foo_value},
                    #{keep_while => KeepWhile}),
              khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME)
          end)]}.
@@ -89,13 +90,13 @@ use_an_invalid_path_test_() ->
          khepri_machine:put(
            ?FUNCTION_NAME,
            not_a_list,
-           ?NO_PAYLOAD)),
+           none)),
       ?_assertThrow(
          {invalid_path, "not_a_component"},
          khepri_machine:put(
            ?FUNCTION_NAME,
            ["not_a_component"],
-           ?NO_PAYLOAD))]}.
+           none))]}.
 
 use_an_invalid_payload_test_() ->
     {setup,

--- a/test/prop_state_machine.erl
+++ b/test/prop_state_machine.erl
@@ -110,19 +110,19 @@ add_entry(Entries, Path, Payload) ->
                             {Entry0, true}
                     end,
     Entry2 = case Payload of
-                 ?DATA_PAYLOAD(Data) -> Entry1#{data => Data};
-                 ?NO_PAYLOAD         -> maps:remove(data, Entry1)
+                 #kpayload_data{data = Data} -> Entry1#{data => Data};
+                 none                        -> maps:remove(data, Entry1)
              end,
     Entries1 = Entries#{Path => Entry2},
     add_entry1(Entries1, tl(lists:reverse(Path)), New).
 
-set_node_payload(#{data := Data} = Entry, ?DATA_PAYLOAD(Data)) ->
+set_node_payload(#{data := Data} = Entry, #kpayload_data{data = Data}) ->
     Entry;
-set_node_payload(Entry, ?NO_PAYLOAD) when not is_map_key(data, Entry) ->
+set_node_payload(Entry, none) when not is_map_key(data, Entry) ->
     Entry;
-set_node_payload(Entry, ?DATA_PAYLOAD(Data)) ->
+set_node_payload(Entry, #kpayload_data{data = Data}) ->
     Entry#{data => Data};
-set_node_payload(Entry, ?NO_PAYLOAD) ->
+set_node_payload(Entry, none) ->
     maps:remove(data, Entry).
 
 add_entry1(Entries, ReversedPath, New) ->
@@ -226,9 +226,9 @@ payload() ->
               data_payload()]).
 
 no_payload() ->
-    ?NO_PAYLOAD.
+    none.
 
 data_payload() ->
     ?LET(Data,
          binary(),
-         ?DATA_PAYLOAD(Data)).
+         #kpayload_data{data = Data}).

--- a/test/put_command.erl
+++ b/test/put_command.erl
@@ -19,9 +19,9 @@
 
 initialize_machine_with_genesis_data_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(foobar_value)},
+                     payload = #kpayload_data{data = foobar_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)}],
+                     payload = #kpayload_data{data = baz_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
 
@@ -38,18 +38,18 @@ initialize_machine_with_genesis_data_test() ->
                #{bar =>
                  #node{
                     stat = ?INIT_NODE_STAT,
-                    payload = {data, foobar_value}}}},
+                    payload = #kpayload_data{data = foobar_value}}}},
             baz =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, baz_value}}
+               payload = #kpayload_data{data = baz_value}}
            }},
        Root).
 
 insert_a_node_at_the_root_of_an_empty_db_test() ->
     S0 = khepri_machine:init(#{}),
     Command = #put{path = [foo],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -62,7 +62,7 @@ insert_a_node_at_the_root_of_an_empty_db_test() ->
           #{foo =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, value}}}},
+               payload = #kpayload_data{data = value}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{}}}, Ret).
 
@@ -74,7 +74,7 @@ insert_a_node_at_the_root_of_an_empty_db_with_conditions_test() ->
                                             [#if_node_exists{exists = false},
                                              #if_payload_version{version = 1}
                                             ]}]}],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -87,17 +87,17 @@ insert_a_node_at_the_root_of_an_empty_db_with_conditions_test() ->
           #{foo =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, value}}}},
+               payload = #kpayload_data{data = value}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{}}}, Ret).
 
 overwrite_an_existing_node_data_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [foo],
-                   payload = ?DATA_PAYLOAD(value2)},
+                   payload = #kpayload_data{data = value2}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -111,7 +111,7 @@ overwrite_an_existing_node_data_test() ->
             #node{
                stat = #{payload_version => 2,
                         child_list_version => 1},
-               payload = {data, value2}}}},
+               payload = #kpayload_data{data = value2}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{data => value1,
                                    payload_version => 1,
@@ -121,7 +121,7 @@ overwrite_an_existing_node_data_test() ->
 insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
     S0 = khepri_machine:init(#{}),
     Command = #put{path = [foo, ?PARENT_NODE, foo, bar, ?THIS_NODE],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -138,14 +138,14 @@ insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
                #{bar =>
                  #node{
                     stat = ?INIT_NODE_STAT,
-                    payload = {data, value}}}}}},
+                    payload = #kpayload_data{data = value}}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{}}}, Ret).
 
 insert_a_node_under_an_nonexisting_parents_test() ->
     S0 = khepri_machine:init(#{}),
     Command = #put{path = [foo, bar, baz, qux],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -170,19 +170,19 @@ insert_a_node_under_an_nonexisting_parents_test() ->
                          #{qux =>
                            #node{
                               stat = ?INIT_NODE_STAT,
-                              payload = {data, value}}}}}}}}}},
+                              payload = #kpayload_data{data = value}}}}}}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar, baz, qux] => #{}}}, Ret).
 
 insert_a_node_with_condition_true_on_self_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [#if_all{conditions =
                                    [foo,
                                     #if_data_matches{pattern = value1}]}],
-                   payload = ?DATA_PAYLOAD(value2)},
+                   payload = #kpayload_data{data = value2}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -195,7 +195,7 @@ insert_a_node_with_condition_true_on_self_test() ->
             #node{
                stat = #{payload_version => 2,
                         child_list_version => 1},
-               payload = {data, value2}}}},
+               payload = #kpayload_data{data = value2}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{data => value1,
                                    payload_version => 1,
@@ -204,14 +204,14 @@ insert_a_node_with_condition_true_on_self_test() ->
 
 insert_a_node_with_condition_false_on_self_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     %% We compile the condition beforehand because we need the compiled
     %% version to make an exact match on the returned error later.
     Compiled = khepri_condition:compile(#if_data_matches{pattern = value2}),
     Command = #put{path = [#if_all{conditions = [foo, Compiled]}],
-                   payload = ?DATA_PAYLOAD(value3)},
+                   payload = #kpayload_data{data = value3}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(S0#khepri_machine.root, S1#khepri_machine.root),
@@ -229,14 +229,14 @@ insert_a_node_with_condition_false_on_self_test() ->
 
 insert_a_node_with_condition_true_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [foo,
                            #if_all{conditions =
                                    [?THIS_NODE,
                                     #if_data_matches{pattern = value1}]}],
-                   payload = ?DATA_PAYLOAD(value2)},
+                   payload = #kpayload_data{data = value2}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -249,7 +249,7 @@ insert_a_node_with_condition_true_on_self_using_dot_test() ->
             #node{
                stat = #{payload_version => 2,
                         child_list_version => 1},
-               payload = {data, value2}}}},
+               payload = #kpayload_data{data = value2}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{data => value1,
                                    payload_version => 1,
@@ -258,7 +258,7 @@ insert_a_node_with_condition_true_on_self_using_dot_test() ->
 
 insert_a_node_with_condition_false_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     %% We compile the condition beforehand because we need the compiled
@@ -266,7 +266,7 @@ insert_a_node_with_condition_false_on_self_using_dot_test() ->
     Compiled = khepri_condition:compile(#if_data_matches{pattern = value2}),
     Command = #put{path = [foo,
                            #if_all{conditions = [?THIS_NODE, Compiled]}],
-                   payload = ?DATA_PAYLOAD(value3)},
+                   payload = #kpayload_data{data = value3}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(S0#khepri_machine.root, S1#khepri_machine.root),
@@ -284,14 +284,14 @@ insert_a_node_with_condition_false_on_self_using_dot_test() ->
 
 insert_a_node_with_condition_true_on_parent_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [#if_all{conditions =
                                    [foo,
                                     #if_data_matches{pattern = value1}]},
                            bar],
-                   payload = ?DATA_PAYLOAD(bar_value)},
+                   payload = #kpayload_data{data = bar_value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -304,18 +304,18 @@ insert_a_node_with_condition_true_on_parent_test() ->
             #node{
                stat = #{payload_version => 1,
                         child_list_version => 2},
-               payload = {data, value1},
+               payload = #kpayload_data{data = value1},
                child_nodes =
                #{bar =>
                  #node{
                     stat = ?INIT_NODE_STAT,
-                    payload = {data, bar_value}}}}}},
+                    payload = #kpayload_data{data = bar_value}}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{}}}, Ret).
 
 insert_a_node_with_condition_false_on_parent_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     %% We compile the condition beforehand because we need the compiled
@@ -323,7 +323,7 @@ insert_a_node_with_condition_false_on_parent_test() ->
     Compiled = khepri_condition:compile(#if_data_matches{pattern = value2}),
     Command = #put{path = [#if_all{conditions = [foo, Compiled]},
                            bar],
-                   payload = ?DATA_PAYLOAD(bar_value)},
+                   payload = #kpayload_data{data = bar_value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(S0#khepri_machine.root, S1#khepri_machine.root),
@@ -345,13 +345,13 @@ insert_a_node_with_condition_false_on_parent_test() ->
 
 insert_a_node_with_if_node_exists_true_on_self_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
                                      #if_node_exists{exists = true}]}],
-                    payload = ?DATA_PAYLOAD(value2)},
+                    payload = #kpayload_data{data = value2}},
     {S1, Ret1} = khepri_machine:apply(?META, Command1, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -365,7 +365,7 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
             #node{
                stat = #{payload_version => 2,
                         child_list_version => 1},
-               payload = {data, value2}}}},
+               payload = #kpayload_data{data = value2}}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{data => value1,
                                    payload_version => 1,
@@ -377,7 +377,7 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
                          [baz,
                           #if_node_exists{exists = true}]}),
     Command2 = #put{path = [Compiled],
-                    payload = ?DATA_PAYLOAD(value2)},
+                    payload = #kpayload_data{data = value2}},
     {S2, Ret2} = khepri_machine:apply(?META, Command2, S0),
 
     ?assertEqual(S0#khepri_machine.root, S2#khepri_machine.root),
@@ -391,13 +391,13 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
 
 insert_a_node_with_if_node_exists_false_on_self_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
                                      #if_node_exists{exists = false}]}],
-                    payload = ?DATA_PAYLOAD(value2)},
+                    payload = #kpayload_data{data = value2}},
     {S1, Ret1} = khepri_machine:apply(?META, Command1, S0),
 
     ?assertEqual(S0#khepri_machine.root, S1#khepri_machine.root),
@@ -416,7 +416,7 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
     Command2 = #put{path = [#if_all{conditions =
                                     [baz,
                                      #if_node_exists{exists = false}]}],
-                    payload = ?DATA_PAYLOAD(value2)},
+                    payload = #kpayload_data{data = value2}},
     {S2, Ret2} = khepri_machine:apply(?META, Command2, S0),
     Root = khepri_machine:get_root(S2),
 
@@ -429,24 +429,24 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
           #{foo =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, value1}},
+               payload = #kpayload_data{data = value1}},
             baz =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, value2}}}},
+               payload = #kpayload_data{data = value2}}}},
        Root),
     ?assertEqual({ok, #{[baz] => #{}}}, Ret2).
 
 insert_a_node_with_if_node_exists_true_on_parent_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
                                      #if_node_exists{exists = true}]},
                             bar],
-                    payload = ?DATA_PAYLOAD(bar_value)},
+                    payload = #kpayload_data{data = bar_value}},
     {S1, Ret1} = khepri_machine:apply(?META, Command1, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -459,12 +459,12 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
             #node{
                stat = #{payload_version => 1,
                         child_list_version => 2},
-               payload = {data, value1},
+               payload = #kpayload_data{data = value1},
                child_nodes =
                #{bar =>
                  #node{
                     stat = ?INIT_NODE_STAT,
-                    payload = {data, bar_value}}}}}},
+                    payload = #kpayload_data{data = bar_value}}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{}}}, Ret1),
 
@@ -474,7 +474,7 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
                           #if_node_exists{exists = true}]}),
     Command2 = #put{path = [Compiled,
                             bar],
-                    payload = ?DATA_PAYLOAD(bar_value)},
+                    payload = #kpayload_data{data = bar_value}},
     {S2, Ret2} = khepri_machine:apply(?META, Command2, S0),
 
     ?assertEqual(S0#khepri_machine.root, S2#khepri_machine.root),
@@ -488,14 +488,14 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
 
 insert_a_node_with_if_node_exists_false_on_parent_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value1)}],
+                     payload = #kpayload_data{data = value1}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
                                      #if_node_exists{exists = false}]},
                             bar],
-                    payload = ?DATA_PAYLOAD(value2)},
+                    payload = #kpayload_data{data = value2}},
     {S1, Ret1} = khepri_machine:apply(?META, Command1, S0),
 
     ?assertEqual(S0#khepri_machine.root, S1#khepri_machine.root),
@@ -506,16 +506,16 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
                      node_path => [foo],
                      node_is_target => false,
                      node_props => #{data => value1,
-                                         payload_version => 1,
-                                         child_list_version => 1,
-                                         child_list_length => 0},
+                                     payload_version => 1,
+                                     child_list_version => 1,
+                                     child_list_length => 0},
                      condition => #if_node_exists{exists = false}}}}, Ret1),
 
     Command2 = #put{path = [#if_all{conditions =
                                     [baz,
                                      #if_node_exists{exists = false}]},
                             bar],
-                    payload = ?DATA_PAYLOAD(bar_value)},
+                    payload = #kpayload_data{data = bar_value}},
     {S2, Ret2} = khepri_machine:apply(?META, Command2, S0),
     Root = khepri_machine:get_root(S2),
 
@@ -528,7 +528,7 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
           #{foo =>
             #node{
                stat = ?INIT_NODE_STAT,
-               payload = {data, value1}},
+               payload = #kpayload_data{data = value1}},
             baz =>
             #node{
                stat = ?INIT_NODE_STAT,
@@ -536,19 +536,19 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
                #{bar =>
                  #node{
                     stat = ?INIT_NODE_STAT,
-                    payload = {data, bar_value}}}}}},
+                    payload = #kpayload_data{data = bar_value}}}}}},
        Root),
     ?assertEqual({ok, #{[baz, bar] => #{}}}, Ret2).
 
 insert_with_a_path_matching_many_nodes_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)},
+                     payload = #kpayload_data{data = foo_value}},
                 #put{path = [bar],
-                     payload = ?DATA_PAYLOAD(bar_value)}],
+                     payload = #kpayload_data{data = bar_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [#if_name_matches{regex = any}],
-                   payload = ?DATA_PAYLOAD(new_value)},
+                   payload = #kpayload_data{data = new_value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(S0#khepri_machine.root, S1#khepri_machine.root),
@@ -557,11 +557,11 @@ insert_with_a_path_matching_many_nodes_test() ->
 
 clear_payload_in_an_existing_node_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
 
     Command = #put{path = [foo],
-                   payload = ?NO_PAYLOAD},
+                   payload = none},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -584,26 +584,26 @@ clear_payload_in_an_existing_node_test() ->
 
 put_command_bumps_applied_command_count_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{snapshot_interval => 3,
                                commands => Commands}),
 
     ?assertEqual(#{}, S0#khepri_machine.metrics),
 
     Command1 = #put{path = [bar],
-                    payload = ?NO_PAYLOAD},
+                    payload = none},
     {S1, _} = khepri_machine:apply(?META, Command1, S0),
 
     ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
 
     Command2 = #put{path = [baz],
-                    payload = ?NO_PAYLOAD},
+                    payload = none},
     {S2, _} = khepri_machine:apply(?META, Command2, S1),
 
     ?assertEqual(#{applied_command_count => 2}, S2#khepri_machine.metrics),
 
     Command3 = #put{path = [qux],
-                    payload = ?NO_PAYLOAD},
+                    payload = none},
     Meta = ?META,
     {S3, _, Effects} = khepri_machine:apply(Meta, Command3, S2),
 

--- a/test/queries.erl
+++ b/test/queries.erl
@@ -27,7 +27,7 @@ query_a_non_existing_node_test() ->
 
 query_an_existing_node_with_no_value_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo], #{}),
@@ -40,7 +40,7 @@ query_an_existing_node_with_no_value_test() ->
 
 query_an_existing_node_with_value_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo, bar], #{}),
@@ -54,7 +54,7 @@ query_an_existing_node_with_value_test() ->
 
 query_a_node_with_matching_condition_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -72,7 +72,7 @@ query_a_node_with_matching_condition_test() ->
 
 query_a_node_with_non_matching_condition_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -87,9 +87,9 @@ query_a_node_with_non_matching_condition_test() ->
 
 query_child_nodes_of_a_specific_node_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)}],
+                     payload = #kpayload_data{data = baz_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -112,9 +112,9 @@ query_child_nodes_of_a_specific_node_test() ->
 
 query_child_nodes_of_a_specific_node_with_condition_on_leaf_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)}],
+                     payload = #kpayload_data{data = baz_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -131,13 +131,13 @@ query_child_nodes_of_a_specific_node_with_condition_on_leaf_test() ->
 
 query_many_nodes_with_condition_on_parent_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(pouet_value)}],
+                     payload = #kpayload_data{data = pouet_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -159,13 +159,13 @@ query_many_nodes_with_condition_on_parent_test() ->
 
 query_many_nodes_recursively_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(pouet_value)}],
+                     payload = #kpayload_data{data = pouet_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret1 = khepri_machine:find_matching_nodes(
@@ -206,13 +206,13 @@ query_many_nodes_recursively_test() ->
 
 query_many_nodes_recursively_using_regex_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(pouet_value)}],
+                     payload = #kpayload_data{data = pouet_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -236,13 +236,13 @@ query_many_nodes_recursively_using_regex_test() ->
 
 query_many_nodes_recursively_with_condition_on_leaf_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(pouet_value)}],
+                     payload = #kpayload_data{data = pouet_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -263,13 +263,13 @@ query_many_nodes_recursively_with_condition_on_leaf_test() ->
 
 query_many_nodes_recursively_with_condition_on_self_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(pouet_value)}],
+                     payload = #kpayload_data{data = pouet_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -299,13 +299,13 @@ query_many_nodes_recursively_with_condition_on_self_test() ->
 
 query_many_nodes_recursively_with_several_star_star_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
-                     payload = ?DATA_PAYLOAD(qux_value)},
+                     payload = #kpayload_data{data = qux_value}},
                 #put{path = [foo, youpi],
-                     payload = ?DATA_PAYLOAD(youpi_value)},
+                     payload = #kpayload_data{data = youpi_value}},
                 #put{path = [baz],
-                     payload = ?DATA_PAYLOAD(baz_value)},
+                     payload = #kpayload_data{data = baz_value}},
                 #put{path = [baz, pouet],
-                     payload = ?DATA_PAYLOAD(pouet_value)}],
+                     payload = #kpayload_data{data = pouet_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -324,7 +324,7 @@ query_many_nodes_recursively_with_several_star_star_test() ->
 
 query_a_node_using_relative_path_components_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -339,9 +339,9 @@ query_a_node_using_relative_path_components_test() ->
 
 include_child_names_in_query_response_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [foo, quux],
-                     payload = ?DATA_PAYLOAD(quux_value)}],
+                     payload = #kpayload_data{data = quux_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(

--- a/test/root_node.erl
+++ b/test/root_node.erl
@@ -51,7 +51,7 @@ query_root_node_using_dot_test() ->
 
 query_above_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Root = khepri_machine:get_root(S0),
 
@@ -109,7 +109,7 @@ query_root_node_with_conditions_false_test() ->
 store_data_in_root_node_using_empty_path_test() ->
     S0 = khepri_machine:init(#{}),
     Command = #put{path = [],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -118,7 +118,7 @@ store_data_in_root_node_using_empty_path_test() ->
           stat =
           #{payload_version => 2,
             child_list_version => 1},
-          payload = {data, value}},
+          payload = #kpayload_data{data = value}},
        Root),
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
@@ -127,7 +127,7 @@ store_data_in_root_node_using_empty_path_test() ->
 store_data_in_root_node_using_root_test() ->
     S0 = khepri_machine:init(#{}),
     Command = #put{path = [?ROOT_NODE],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -136,7 +136,7 @@ store_data_in_root_node_using_root_test() ->
           stat =
           #{payload_version => 2,
             child_list_version => 1},
-          payload = {data, value}},
+          payload = #kpayload_data{data = value}},
        Root),
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
@@ -145,7 +145,7 @@ store_data_in_root_node_using_root_test() ->
 store_data_in_root_node_using_dot_test() ->
     S0 = khepri_machine:init(#{}),
     Command = #put{path = [?THIS_NODE],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -154,7 +154,7 @@ store_data_in_root_node_using_dot_test() ->
           stat =
           #{payload_version => 2,
             child_list_version => 1},
-          payload = {data, value}},
+          payload = #kpayload_data{data = value}},
        Root),
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
@@ -163,7 +163,7 @@ store_data_in_root_node_using_dot_test() ->
 store_data_in_root_node_using_dot_dot_test() ->
     S0 = khepri_machine:init(#{}),
     Command = #put{path = [?PARENT_NODE],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -172,7 +172,7 @@ store_data_in_root_node_using_dot_dot_test() ->
           stat =
           #{payload_version => 2,
             child_list_version => 1},
-          payload = {data, value}},
+          payload = #kpayload_data{data = value}},
        Root),
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
@@ -182,7 +182,7 @@ store_data_in_root_node_with_condition_true_test() ->
     S0 = khepri_machine:init(#{}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #put{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -191,7 +191,7 @@ store_data_in_root_node_with_condition_true_test() ->
           stat =
           #{payload_version => 2,
             child_list_version => 1},
-          payload = {data, value}},
+          payload = #kpayload_data{data = value}},
        Root),
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
@@ -201,7 +201,7 @@ store_data_in_root_node_with_condition_true_using_dot_test() ->
     S0 = khepri_machine:init(#{}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #put{path = [#if_all{conditions = [?THIS_NODE, Compiled]}],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -210,7 +210,7 @@ store_data_in_root_node_with_condition_true_using_dot_test() ->
           stat =
           #{payload_version => 2,
             child_list_version => 1},
-          payload = {data, value}},
+          payload = #kpayload_data{data = value}},
        Root),
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
@@ -220,7 +220,7 @@ store_data_in_root_node_with_condition_false_test() ->
     S0 = khepri_machine:init(#{}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #put{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
-                   payload = ?DATA_PAYLOAD(value)},
+                   payload = #kpayload_data{data = value}},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -258,7 +258,7 @@ delete_empty_root_node_test() ->
 
 delete_root_node_using_empty_path_test() ->
     Commands = [#put{path = [],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = []},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -277,7 +277,7 @@ delete_root_node_using_empty_path_test() ->
 
 delete_root_node_using_root_test() ->
     Commands = [#put{path = [],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [?ROOT_NODE]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -296,7 +296,7 @@ delete_root_node_using_root_test() ->
 
 delete_root_node_using_dot_test() ->
     Commands = [#put{path = [],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [?THIS_NODE]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -315,7 +315,7 @@ delete_root_node_using_dot_test() ->
 
 delete_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [],
-                     payload = ?DATA_PAYLOAD(value)}],
+                     payload = #kpayload_data{data = value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = [?PARENT_NODE]},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -334,9 +334,9 @@ delete_root_node_using_dot_dot_test() ->
 
 delete_root_node_with_child_nodes_test() ->
     Commands = [#put{path = [foo, bar],
-                     payload = ?DATA_PAYLOAD(bar_value)},
+                     payload = #kpayload_data{data = bar_value}},
                 #put{path = [baz, qux],
-                     payload = ?DATA_PAYLOAD(qux_value)}],
+                     payload = #kpayload_data{data = qux_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Command = #delete{path = []},
     {S1, Ret} = khepri_machine:apply(?META, Command, S0),
@@ -354,7 +354,7 @@ delete_root_node_with_child_nodes_test() ->
 
 delete_root_node_with_condition_true_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},
@@ -373,7 +373,7 @@ delete_root_node_with_condition_true_test() ->
 
 delete_root_node_with_condition_true_using_dot_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #delete{path = [#if_all{conditions = [?THIS_NODE, Compiled]}]},
@@ -392,7 +392,7 @@ delete_root_node_with_condition_true_using_dot_test() ->
 
 delete_root_node_with_condition_false_test() ->
     Commands = [#put{path = [foo],
-                     payload = ?DATA_PAYLOAD(foo_value)}],
+                     payload = #kpayload_data{data = foo_value}}],
     S0 = khepri_machine:init(#{commands => Commands}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},
@@ -407,6 +407,6 @@ delete_root_node_with_condition_false_test() ->
           child_nodes =
           #{foo =>
             #node{stat = ?INIT_NODE_STAT,
-                  payload = {data, foo_value}}}},
+                  payload = #kpayload_data{data = foo_value}}}},
        Root),
     ?assertEqual({ok, #{}}, Ret).

--- a/test/transactions.erl
+++ b/test/transactions.erl
@@ -133,7 +133,7 @@ get_in_ro_transaction_test_() ->
                             child_list_length => 0}}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Fun = fun() ->
                            khepri_tx:get([foo])
@@ -153,7 +153,7 @@ get_in_rw_transaction_test_() ->
                             child_list_length => 0}}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Fun = fun() ->
                            khepri_tx:get([foo])
@@ -169,13 +169,14 @@ put_in_ro_transaction_test_() ->
          {aborted, store_update_denied},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Fun = fun() ->
                            Path = [foo],
                            case khepri_tx:get(Path) of
                                {ok, #{Path := #{data := value1}}} ->
-                                   khepri_tx:put(Path, ?DATA_PAYLOAD(value2));
+                                   khepri_tx:put(
+                                     Path, #kpayload_data{data = value2});
                                Other ->
                                    Other
                            end
@@ -195,13 +196,14 @@ put_in_rw_transaction_test_() ->
                             child_list_length => 0}}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Fun = fun() ->
                            Path = [foo],
                            case khepri_tx:get(Path) of
                                {ok, #{Path := #{data := value1}}} ->
-                                   khepri_tx:put(Path, ?DATA_PAYLOAD(value2));
+                                   khepri_tx:put(
+                                     Path, #kpayload_data{data = value2});
                                Other ->
                                    Other
                            end
@@ -217,7 +219,7 @@ delete_in_ro_transaction_test_() ->
          {aborted, store_update_denied},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Fun = fun() ->
                            Path = [foo],
@@ -243,7 +245,7 @@ delete_in_rw_transaction_test_() ->
                             child_list_length => 0}}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Fun = fun() ->
                            Path = [foo],
@@ -266,7 +268,8 @@ exists_api_test_() ->
           {false, true, false}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo, bar], ?DATA_PAYLOAD(bar_value)),
+                   ?FUNCTION_NAME, [foo, bar],
+                   #kpayload_data{data = bar_value}),
 
              Fun = fun() ->
                            {khepri_tx:has_data([foo]),
@@ -285,7 +288,7 @@ has_data_api_test_() ->
           {true, false}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = foo_value}),
 
              Fun = fun() ->
                            {khepri_tx:exists([foo]),
@@ -306,7 +309,7 @@ find_api_test_() ->
                             child_list_length => 0}}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = foo_value}),
 
              Fun = fun() ->
                            khepri_tx:find([], #if_data_matches{pattern = '_'})
@@ -329,13 +332,14 @@ simple_api_test_() ->
                             child_list_length => 0}}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Fun = fun() ->
                            Path = [foo],
                            case khepri_tx:get(Path) of
                                {ok, #{Path := #{data := value1}}} ->
-                                   khepri_tx:put(Path, ?DATA_PAYLOAD(value2));
+                                   khepri_tx:put(
+                                     Path, #kpayload_data{data = value2});
                                Other ->
                                    Other
                            end
@@ -352,9 +356,9 @@ list_comprehension_test_() ->
          {atomic, [bar_value, foo_value]},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(foo_value)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = foo_value}),
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [bar], ?DATA_PAYLOAD(bar_value)),
+                   ?FUNCTION_NAME, [bar], #kpayload_data{data = bar_value}),
 
              Fun = fun() ->
                            {ok, Nodes} = khepri_tx:list([?ROOT_NODE]),
@@ -678,7 +682,7 @@ use_an_invalid_path_in_tx_test_() ->
          {aborted, {invalid_path, not_a_list}},
          begin
              Fun = fun() ->
-                           khepri_tx:put(not_a_list, ?NO_PAYLOAD)
+                           khepri_tx:put(not_a_list, none)
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun)
          end),
@@ -686,7 +690,7 @@ use_an_invalid_path_in_tx_test_() ->
          {aborted, {invalid_path, "not_a_component"}},
          begin
              Fun = fun() ->
-                           khepri_tx:put(["not_a_component"], ?NO_PAYLOAD)
+                           khepri_tx:put(["not_a_component"], none)
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun)
          end)]}.
@@ -743,7 +747,7 @@ tx_from_the_shell_test_() ->
                             child_list_length => 0}}}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              Bindings = erl_eval:new_bindings(),
              {ok, Tokens, _EndLocation} = erl_scan:string(?TX_CODE),
@@ -770,7 +774,7 @@ tx_using_erl_eval_test_() ->
          {invalid_tx_fun, {call_denied, _}},
          begin
              _ = khepri_machine:put(
-                   ?FUNCTION_NAME, [foo], ?DATA_PAYLOAD(value1)),
+                   ?FUNCTION_NAME, [foo], #kpayload_data{data = value1}),
 
              khepri_machine:transaction(
                ?FUNCTION_NAME,

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -35,8 +35,8 @@ noop_ok_test() ->
 allowed_khepri_tx_api_test() ->
     ?assertStandaloneFun(
        begin
-           _ = khepri_tx:put([foo], ?DATA_PAYLOAD(value)),
-           _ = khepri_tx:put([foo], ?DATA_PAYLOAD(value), #{}),
+           _ = khepri_tx:put([foo], #kpayload_data{data = value}),
+           _ = khepri_tx:put([foo], #kpayload_data{data = value}, #{}),
            _ = khepri_tx:get([foo]),
            _ = khepri_tx:get([foo], #{}),
            _ = khepri_tx:exists([foo]),
@@ -484,7 +484,7 @@ when_readwrite_mode_is_true_test() ->
     ?assert(
        is_record(khepri_tx:to_standalone_fun(
                    fun() ->
-                           khepri_tx:put([foo], ?DATA_PAYLOAD(value))
+                           khepri_tx:put([foo], #kpayload_data{data = value})
                    end,
                    rw),
                  standalone_fun)),
@@ -500,7 +500,7 @@ when_readwrite_mode_is_true_test() ->
        {invalid_tx_fun, {call_denied, {self, 0}}},
        khepri_tx:to_standalone_fun(
          fun() ->
-                 _ = khepri_tx:put([foo], ?DATA_PAYLOAD(value)),
+                 _ = khepri_tx:put([foo], #kpayload_data{data = value}),
                  self() ! message
          end,
          rw)),
@@ -535,7 +535,8 @@ when_readwrite_mode_is_false_test() ->
     ?assert(
        is_function(khepri_tx:to_standalone_fun(
                      fun() ->
-                             khepri_tx:put([foo], ?DATA_PAYLOAD(value))
+                             khepri_tx:put(
+                               [foo], #kpayload_data{data = value})
                      end,
                      ro),
                    0)),
@@ -552,7 +553,8 @@ when_readwrite_mode_is_false_test() ->
     ?assert(
        is_function(khepri_tx:to_standalone_fun(
                      fun() ->
-                             _ = khepri_tx:put([foo], ?DATA_PAYLOAD(value)),
+                             _ = khepri_tx:put(
+                                   [foo], #kpayload_data{data = value}),
                              self() ! message
                      end,
                      ro),
@@ -586,7 +588,7 @@ when_readwrite_mode_is_auto_test() ->
     ?assert(
        is_record(khepri_tx:to_standalone_fun(
                    fun() ->
-                           khepri_tx:put([foo], ?DATA_PAYLOAD(value))
+                           khepri_tx:put([foo], #kpayload_data{data = value})
                    end,
                    auto),
                  standalone_fun)),
@@ -602,7 +604,7 @@ when_readwrite_mode_is_auto_test() ->
        {invalid_tx_fun, {call_denied, {self, 0}}},
        khepri_tx:to_standalone_fun(
          fun() ->
-                 _ = khepri_tx:put([foo], ?DATA_PAYLOAD(value)),
+                 _ = khepri_tx:put([foo], #kpayload_data{data = value}),
                  self() ! message
          end,
          auto)),


### PR DESCRIPTION
The `?NO_PAYLOAD` macro becomes simply the `none` atom.

The `?DATA_PAYLOAD(Data)` one becomes the `#kpayload_data{data = Data}` record.

This allows some compile time verification and adds the ability to specify the payload types (for Dialyzer).