### PR TITLE
khepri_fun: Fix extraction of Elixir anonymous functions

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -569,7 +569,9 @@ lookup_function1(
       BeamFileRecord :: #beam_file{}.
 %% @private
 
-erl_eval_fun_to_asm(Module, Name, Arity, [{[], _, _, Clauses}]) ->
+erl_eval_fun_to_asm(Module, Name, Arity, [{Bindings, _, _, Clauses}])
+  when Bindings =:= [] orelse %% Erlang is using a list for bindings,
+       Bindings =:= #{} ->    %% but Elixir is using a map.
     %% We construct an abstract form based on the `env' of the lambda loaded
     %% by `erl_eval'.
     Anno = erl_anno:from_term(1),


### PR DESCRIPTION
... written in the Elixir shell (`erl_eval` anonymous functions).

In the `erl_eval` anonymous function's env, the first element in the tuple represents the function bindings. Erlang is using a list, but Elixir is using a map.

`erl_eval_fun_to_asm()`, which does pattern matching to ensure there is no bindings, expected an empty list. Now it accepts an empty map as well to support the Elixir case.

Note that bindings are still unsupported.

Reported by @mkuratczyk.
Paired with @mkuratczyk.