### PR TITLE
Remove hack to run dialyzer on testsuites

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/cache@v2
         if: ${{ matrix.otp_version == env.LATEST_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
         with:
-          path: _build/default/rebar3_*_plt
+          path: _build/*/rebar3_*_plt
           key: dialyzer-plt-cache-${{ steps.install-erlang.outputs.otp-version }}-${{ runner.os }}-${{ hashFiles('rebar.config*') }}-v1
 
       - name: Compile
@@ -49,7 +49,7 @@ jobs:
 
       - name: Dialyzer
         if: ${{ matrix.otp_version == env.LATEST_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
-        run: rebar3 clean && rebar3 dialyzer
+        run: rebar3 clean && rebar3 as test dialyzer
 
   Finish:
     name: Finishing

--- a/rebar.config
+++ b/rebar.config
@@ -2,14 +2,7 @@
 {minimum_otp_vsn, "23.0"}.
 
 %% Dependency pinning must be updated in mix.exs too.
-{deps, [{ra, "2.0.2"},
-        %% PropEr isn't really a dependency. However, in order to be able to
-        %% run Dialyzer on the testsuites, the `prop_*` modules must compile
-        %% successfully first. Unfortunately there is no profiles dedicated to
-        %% Dialyzer.
-        %%
-        %% This application is neither added to mix.exs nor to khepri.app.src.
-        {proper, "1.4.0"}]}.
+{deps, [{ra, "2.0.2"}]}.
 
 {project_plugins, [rebar3_proper]}.
 
@@ -21,17 +14,6 @@
                         underspecs,
                         unknown,
                         unmatched_returns]}]}.
-
-%% In order to run Dialyzer on testsuites, we have to add `test` to the source
-%% directories, even though this is semantically incorrect.
-%%
-%% The downside is that PropEr becomes a regular dependency (even when this
-%% library is used as a dependency and never tested) and test modules are
-%% compiled by default...
-%%
-%% Once and if Rebar grows support for Dialyzer on tests, we can get rid of all
-%% this.
-{extra_src_dirs, ["test"]}.
 
 {xref_checks, [undefined_function_calls,
                undefined_functions,
@@ -57,5 +39,13 @@
                   {eunit, "-c"},
                   {proper, "-c"},
                   {cover, "-v --min_coverage=75"},
+                  %% FIXME: Dialyzer is only executed on the library by
+                  %% default, not its testsuite. To run Dialyzer on the
+                  %% testsuites as well, the following command must be used:
+                  %%   rebar as test dialyzer
                   dialyzer,
                   edoc]}]}.
+
+{profiles,
+ [{test,
+   [{deps, [{proper, "1.4.0"}]}]}]}.


### PR DESCRIPTION
In order to run Dialyzer on testsuites, I changed `extra_src_dirs` to include the test directory as well. Unfortunately, after adding the property-based testcases, I had to add PropEr to the dependencies...

The other solution is to explicitly run Dialyzer under the `test` Rebar profile. I don't know any way to tell Rebar to use that profile by default with Dialyzer, so one has to remember to use it on the command line.

The `check` alias does not set any specific profile, so Dialyzer is executed on the library only or the user must specify the `test` profile on the command line. The problem with the latter is that it will affect other commands such as `xref`.