### PR TITLE
Configure project to include "mix.exs" when published via "rebar3 hex publish"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 erl_crash.dump
 .sw?
 .*.sw?
+/deps
 /_build
 /doc/*
 !/doc/overview.edoc

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 %% Dependency pinning must be updated in mix.exs too.
 {deps, [{ra, "2.0.2"}]}.
 
-{project_plugins, [rebar3_proper]}.
+{project_plugins, [rebar3_proper, rebar3_hex]}.
 
 {erl_opts, [debug_info,
             warnings_as_errors]}.

--- a/src/khepri.app.src
+++ b/src/khepri.app.src
@@ -15,8 +15,10 @@
     ra
    ]},
   {env,[]},
+  {files, [
+    "README.md", "LICENSE", "mix.exs",
+    "rebar.config", "rebar.lock", "src", "include"]},
   {modules, []},
-
   {licenses, ["Apache 2.0"]},
   {links, [{"GitHub", "https://github.com/rabbitmq/khepri"}]},
   {build_tools, ["rebar3", "mix"]},


### PR DESCRIPTION
Fixes #26

Explicitly list files and directories to include to ensure `rebar3 hex publish` includes the `mix.exs` file.

https://hex.pm/docs/rebar3_publish#adding-metadata-to-code-classinlinesrcltmyappgtappsrccode

@dumbbell I'm not sure how you're publishing this project to `hex.pm`. We should discuss.