### PR TITLE
khepri_fun: Add guessed `var_info` annotations to assembly

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -193,8 +193,15 @@ to_standalone_fun2(
                        should_process_function(
                          Module, Name, Arity, Module, State);
                    external ->
-                       should_process_function(
-                         Module, Name, Arity, undefined, State)
+                       _ = code:ensure_loaded(Module),
+                       case erlang:function_exported(Module, Name, Arity) of
+                           true ->
+                               should_process_function(
+                                 Module, Name, Arity, undefined, State);
+                           false ->
+                               throw({call_to_unexported_function,
+                                      {Module, Name, Arity}})
+                       end
                end,
     case ShouldProcess of
         true ->

--- a/test/mod_used_for_transactions.erl
+++ b/test/mod_used_for_transactions.erl
@@ -10,7 +10,9 @@
 -export([exported/0,
          get_lambda/0,
          %% We export this one just to try to prevent inlining.
-         hash_term/1]).
+         hash_term/1,
+         make_record/1,
+         outer_function/2]).
 
 exported() -> unexported().
 unexported() -> ok.
@@ -22,3 +24,20 @@ get_lambda() ->
 
 hash_term(Term) ->
     erlang:phash2(Term).
+
+-record(my_record, {function}).
+
+make_record(Function) ->
+    #my_record{function = Function}.
+
+outer_function(#my_record{function = Value} = MyRecord, Term) ->
+    is_atom(Value) andalso
+    inner_function(MyRecord, Term);
+outer_function(_, _) ->
+    false.
+
+inner_function(#my_record{function = hash_term = Function}, Term) ->
+    _ = (?MODULE:Function(Term)),
+    true;
+inner_function(_, _) ->
+    false.


### PR DESCRIPTION
Let's take the following code:

```erlang
-export([outer_function/2]).

outer_function(#my_record{field = ...} = MyRecord, Term) ->
    (...),
    inner_function(MyRecord, Term);
outer_function(_, _) ->
    (...).

inner_function(#my_record{field = ...} = MyRecord, Term) ->
    (...);
inner_function(_, _) ->
    (...).
```

Both `outer_function/2` and `inner_function/2` take a tuple as their first argument and do a pattern matching with it. `outer_function/2` is exported and `inner_function/2` is only called by `outer_function/2`.

In this situation, the compiler may perform an optimization on `inner_function/2`: it is sure that the function will take a tuple of the expected form because it was already checked in `outer_function/2` and it is the only caller. Therefore, it will skip any verifications and will read the content of the tuple directly using the `get_tuple_element` instruction.

When compiled from source, the compiler adds annotations of the following form at the beginning of `inner_function/2` assembly:

```erlang
{'%', {var_info, {x,0}, [{type, {t_tuple, 2, true, #{...}}}]}}.
```

However, the assembly we recover from an already compiled module misses those annotations. And when we compile the same assembly without those annotations, the compilation fails with:

```erlang
{bad_type,
 {needed, {t_tuple, _Size, _, _Fields} = NeededType},
 {actual, any}}
```

This is caused by checks that we are only passing tuples to a `get_tuple_element` instruction for instance.

This patch handle this compilation failure by forging a `var_info` annotation based on the error message and adding it at the beginning of the failing function. The compilation is then retried.

The recreated annotation doesn't exactly match the original one. But it is sufficient to please the compiler. I make the assumption this is fine because the code we extract was already compiled successfully once. Therefore, there should be no situation where for example `get_tuple_element` would be called with something else than a tuple.

If the annotated code still fails to compile with a similar error for the same variable/register annotation, the extraction aborts. This is to prevent infinite retry loops because of an incorrectly forged `var_info`.

This added error handling matches specifically the situation described above for now. We may add more in the future based on real situations we encounter.