### PR TITLE
rewrite case labels in select_tuple_arity instruction

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1111,9 +1111,10 @@ pass2_process_instruction(
   {loop_rec, _, _} = Instruction, State) ->
     replace_label(Instruction, 2, State);
 pass2_process_instruction(
-  {select_val, _, _, {list, Cases}} = Instruction,
+  {Select, _, _, {list, Cases}} = Instruction,
   #state{mfa_in_progress = {Module, _, _},
-         label_map = LabelMap} = State) ->
+         label_map = LabelMap} = State)
+  when Select =:= select_val orelse Select =:= select_tuple_arity ->
     Cases1 = [case Case of
                   {f, OldLabel} ->
                       NewLabel = maps:get({Module, OldLabel}, LabelMap),

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -126,6 +126,16 @@ allowed_case_block_test() ->
            end
        end).
 
+allowed_case_block_with_different_tuple_arities_test() ->
+    ?assertStandaloneFun(
+       begin
+           case {a, b, c} of
+               {_, _, _} -> three;
+               {_, _} ->    two;
+               {_} ->       one
+           end
+       end).
+
 allowed_binary_handling_test() ->
     ?assertStandaloneFun(
        begin

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -19,7 +19,8 @@
            {no_missing_calls,
             [extracting_unexported_external_function_test/0]},
            {no_match,
-            [matches_type/2]}]).
+            [matches_type/2,
+             allowed_case_block_with_different_tuple_arities_test/0]}]).
 
 -define(make_standalone_fun(Expression),
         begin


### PR DESCRIPTION
:wave: hello!

The disasm scanning to lint transaction functions is super cool!

I noticed the select_tuple_arity instruction doesn't get its cases' labels rewritten, so code that has a case statement branching on the arities of tuples will make the `compile:forms/2` call error out with a message talking about undefined labels. That instruction has the same shape as select_val, so I have it re-using that function clause to rewrite the labels.

What do you think?