### PR TITLE
khepri_fun: Patch incorrectly decoded instructions

### DIFF
--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -209,9 +209,9 @@ ensure_instruction_is_permitted({bs_append, _, _, _, _, _, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({bs_init2, _, _, _, _, _, _}) ->
     ok;
-ensure_instruction_is_permitted({bs_put_binary, _, _, _, _, _}) ->
-    ok;
-ensure_instruction_is_permitted({bs_put_integer, _, _, _, _, _}) ->
+ensure_instruction_is_permitted({BsPutSomething, _, _, _, _, _})
+  when BsPutSomething =:= bs_put_binary orelse
+       BsPutSomething =:= bs_put_integer ->
     ok;
 ensure_instruction_is_permitted({bs_put_string, _, _}) ->
     ok;
@@ -283,6 +283,8 @@ ensure_instruction_is_permitted({swap, _, _}) ->
 ensure_instruction_is_permitted({test, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({test, _, _, _, _}) ->
+    ok;
+ensure_instruction_is_permitted({test, _, _, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({test_heap, _, _}) ->
     ok;

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -17,7 +17,9 @@
                         allowed_erlang_expressions_test/0,
                         allowed_erlang_module_api_test/0]},
            {no_missing_calls,
-            [extracting_unexported_external_function_test/0]}]).
+            [extracting_unexported_external_function_test/0]},
+           {no_match,
+            [matches_type/2]}]).
 
 -define(make_standalone_fun(Expression),
         begin
@@ -196,6 +198,19 @@ allowed_catch_test() ->
                {'EXIT', _Exit} -> true;
                _ -> false
            end
+       end).
+
+matches_type(exchange, <<"exchanges">>) -> true;
+matches_type(queue,    <<"queues">>)    -> true;
+matches_type(exchange, <<"all">>)       -> true;
+matches_type(queue,    <<"all">>)       -> true;
+matches_type(_,        _)               -> false.
+
+allowed_bs_match_test() ->
+    List = [{'apply-to', <<"queues">>}],
+    ?assertStandaloneFun(
+       begin
+           matches_type(queue, proplists:get_value('apply-to', List))
        end).
 
 denied_receive_block_test() ->


### PR DESCRIPTION
`beam_asm` decodes several bitstring matching instructions incorrectly. Sometimes, it's just the field flags which are not decoded. Unfortunately, sometimes, instruction arguments order is incorrect or the argument does not have the form expected by the compiler.

Now, `pass1_process_instructions/3` starts by patching those instructions before doing anything else with them. This way the rest of the code handles correct instructions (from the point of view of the compiler). A second benefit is that if `beam_disasm` is fixed, Khepri will continue to work.