### PR TITLE
patch more incorrectly decoded bitstring-matching instructions

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -597,7 +597,9 @@ pass1_process_instructions(
 pass1_process_instructions(
   [{BsGetSomething, Ctx, Dst, {u, Live}} | Rest],
   State,
-  Result) when BsGetSomething =:= bs_get_position orelse BsGetSomething =:= bs_get_tail ->
+  Result)
+  when BsGetSomething =:= bs_get_position orelse
+       BsGetSomething =:= bs_get_tail ->
     %% `beam_disasm' did not decode this instruction correctly. We need to
     %% patch it to store `Live' as an integer.
     Instruction = {BsGetSomething, Ctx, Dst, Live},

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -571,17 +571,36 @@ pass1_process_instructions(
     Instruction = {test, bs_start_match3, Fail, Live, [Bin], Dst},
     pass1_process_instructions([Instruction | Rest], State, Result);
 pass1_process_instructions(
-  [{test, bs_get_integer2,
+  [{bs_start_match4, Fail, {u, Live}, Src, Dst} | Rest],
+  State,
+  Result) ->
+    %% `beam_disasm' did not decode this instruction correctly. We need to
+    %% patch it to store `Live' as an integer.
+    Instruction = {bs_start_match4, Fail, Live, Src, Dst},
+    pass1_process_instructions([Instruction | Rest], State, Result);
+pass1_process_instructions(
+  [{test, BsGetSomething,
     Fail, [Ctx, Live, Size, Unit, {field_flags, FF} = FieldFlags0, Dst]}
    | Rest],
   State,
-  Result) when is_integer(FF) ->
+  Result)
+  when (BsGetSomething =:= bs_get_integer2 orelse
+        BsGetSomething =:= bs_get_binary2) andalso
+       is_integer(FF) ->
     %% `beam_disasm' did not decode this instruction correctly. We need to
     %% patch it to move `Live' before the list. We also need to decode field
     %% flags.
     FieldFlags = decode_field_flags(FieldFlags0),
-    Instruction = {test, bs_get_integer2,
+    Instruction = {test, BsGetSomething,
                    Fail, Live, [Ctx, Size, Unit, FieldFlags], Dst},
+    pass1_process_instructions([Instruction | Rest], State, Result);
+pass1_process_instructions(
+  [{BsGetSomething, Ctx, Dst, {u, Live}} | Rest],
+  State,
+  Result) when BsGetSomething =:= bs_get_position orelse BsGetSomething =:= bs_get_tail ->
+    %% `beam_disasm' did not decode this instruction correctly. We need to
+    %% patch it to store `Live' as an integer.
+    Instruction = {BsGetSomething, Ctx, Dst, Live},
     pass1_process_instructions([Instruction | Rest], State, Result);
 pass1_process_instructions(
   [{test, bs_match_string, Fail, [Ctx, Stride, String]} | Rest],

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -215,6 +215,14 @@ ensure_instruction_is_permitted({BsPutSomething, _, _, _, _, _})
     ok;
 ensure_instruction_is_permitted({bs_put_string, _, _}) ->
     ok;
+ensure_instruction_is_permitted({bs_get_position, _, _, _}) ->
+    ok;
+ensure_instruction_is_permitted({bs_set_position, _, _}) ->
+    ok;
+ensure_instruction_is_permitted({bs_get_tail, _, _, _}) ->
+    ok;
+ensure_instruction_is_permitted({bs_start_match4, _, _, _, _}) ->
+    ok;
 ensure_instruction_is_permitted({Call, _, _})
   when Call =:= call orelse Call =:= call_only orelse
        Call =:= call_ext orelse Call =:= call_ext_only ->

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -213,6 +213,15 @@ allowed_bs_match_test() ->
            matches_type(queue, proplists:get_value('apply-to', List))
        end).
 
+parse_date(<<Year:4/bytes, $-, Month:2/bytes, $-, Day:2/bytes, _Rest/binary>>) ->
+    {Year, Month, Day}.
+
+allowed_bs_match_date_parser_test() ->
+    ?assertStandaloneFun(
+       begin
+           {<<"2022">>, <<"02">>, <<"02">>} = parse_date(<<"2022-02-02">>)
+       end).
+
 denied_receive_block_test() ->
     ?assertToFunThrow(
        {invalid_tx_fun, receiving_message_denied},

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -213,7 +213,8 @@ allowed_bs_match_test() ->
            matches_type(queue, proplists:get_value('apply-to', List))
        end).
 
-parse_date(<<Year:4/bytes, $-, Month:2/bytes, $-, Day:2/bytes, _Rest/binary>>) ->
+parse_date(
+    <<Year:4/bytes, $-, Month:2/bytes, $-, Day:2/bytes, _Rest/binary>>) ->
     {Year, Month, Day}.
 
 allowed_bs_match_date_parser_test() ->


### PR DESCRIPTION
builds on #39 to decode more bitstring-matching instructions that are not decoded properly by beam_disasm