### PR TITLE
Add documentation provider

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -45,3 +45,5 @@
 {profiles,
  [{test,
    [{deps, [{proper, "1.4.0"}]}]}]}.
+
+{hex, [{doc, edoc}]}.


### PR DESCRIPTION
For case when last version(`7.0.1`) of project plugin `rebar3_hex` is used for publication of documentation to `hex.pm`, can be received second warning:
```sh
$ rebar3 hex publish docs
...
===> Verifying dependencies...
===> docs argument given, will not publish package
===> No documentation provider was configured, docs will not be generated
```
For this case was added provider as suggested in `rebar3_hex` documentation.