### PR TITLE
guess var_info for no_bs_start_match2 compilation errors

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -313,10 +313,10 @@ handle_validation_error(
 handle_validation_error(
   Asm,
   {FailingFun,
-   {{call_only, _Arity, {f, _EntryLabel}},
+   {{Call, _Arity, {f, _EntryLabel}},
     _,
     no_bs_start_match2}},
-  Error) ->
+  Error) when Call =:= call orelse Call =:= call_only ->
     %% The register and and type cannot be determined from just the error
     %% message, so we use `accepts_match_context' as a placeholder and
     %% determine the real comment in `add_comment_to_function/7'

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -15,12 +15,15 @@
 
 -dialyzer([{no_return, [allowed_khepri_tx_api_test/0,
                         allowed_erlang_expressions_test/0,
-                        allowed_erlang_module_api_test/0]},
+                        allowed_erlang_module_api_test/0,
+                        allowed_bs_match_accepts_match_context_test/0]},
            {no_missing_calls,
             [extracting_unexported_external_function_test/0]},
            {no_match,
             [matches_type/2,
-             allowed_case_block_with_different_tuple_arities_test/0]}]).
+             allowed_case_block_with_different_tuple_arities_test/0,
+             trim_leading_dash3/2,
+             allowed_bs_match_accepts_match_context_test/0]}]).
 
 -define(make_standalone_fun(Expression),
         begin
@@ -232,6 +235,35 @@ allowed_bs_match_date_parser_test() ->
     ?assertStandaloneFun(
        begin
            {<<"2022">>, <<"02">>, <<"02">>} = parse_date(<<"2022-02-02">>)
+       end).
+
+%% The compiler determines that this clause will always match because this
+%% function is not exported and is only called with a compile-time binary
+%% matching the pattern. As a result, the instruction for this match is
+%% `bs_start_match4'
+trim_leading_dash1(<<$-, Rest/binary>>) -> trim_leading_dash1(Rest);
+trim_leading_dash1(Binary)              -> Binary.
+
+%% This is the same function but we'll give it a non-binary argument in
+%% the test case to avoid the `bs_start_match4' optimization. Instead
+%% the compiler uses a `{test,bs_start_match3,..}` instruction.
+trim_leading_dash2(<<$-, Rest/binary>>) -> trim_leading_dash2(Rest);
+trim_leading_dash2(Binary)              -> Binary.
+
+%% Again, effectively the same function but to fix compilation for this
+%% case we need to determine the correct arity to mark as accepting
+%% a match context, so we should test a case where the binary match
+%% is done in another argument.
+trim_leading_dash3(Arg, <<$-, Rest/binary>>) -> trim_leading_dash3(Arg, Rest);
+trim_leading_dash3(_Arg, Binary)             -> Binary.
+
+allowed_bs_match_accepts_match_context_test() ->
+    ?assertStandaloneFun(
+       begin
+           <<"5">> = trim_leading_dash1(<<"-5">>),
+           <<"5">> = trim_leading_dash2(<<"-5">>),
+           <<"5">> = trim_leading_dash2("-5"),
+           <<"5">> = trim_leading_dash3([], "-5")
        end).
 
 denied_receive_block_test() ->


### PR DESCRIPTION
Given some code like the following:

    trim_leading_dash1(<<$-, Rest/binary>>) -> trim_leading_dash1(Rest);
    trim_leading_dash1(Binary)              -> Binary.

The compiler will add an annotation for the {x,0} register

    {'%',{var_info,{x,0},[accepts_match_context]}}.

This annotation is not available in the disasm, so when we recompile
this function, the compiler gives an error.

This change detects which x-register should accept the match context
by peeking the first instruction after the entrypoint label. This
instruction can either be a {test,bs_start_match3,..} instruction or
bs_start_match4 (if the compiler can determine that the function will
_always_ be passed a binary), both of which contain the register
which will be matched.

closes #44
see also #36