### PR TITLE
add translation for 'raise' BIF

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -613,6 +613,14 @@ pass1_process_instructions(
     Instruction = {test, bs_match_string,
                    Fail, [Ctx, Stride, {string, String}]},
     pass1_process_instructions([Instruction | Rest], State, Result);
+pass1_process_instructions(
+  [{raise, Fail, Args, Dst} | Rest],
+  State,
+  Result) ->
+    %% `beam_disasm` did not decode this instruction correctly. `raise'
+    %% should be translated into a `bif'.
+    Instruction = {bif, raise, Fail, Args, Dst},
+    pass1_process_instructions([Instruction | Rest], State, Result);
 
 %% Second group.
 

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -300,6 +300,12 @@ ensure_instruction_is_permitted({test_heap, _, _}) ->
     ok;
 ensure_instruction_is_permitted({trim, _, _}) ->
     ok;
+ensure_instruction_is_permitted({'try', _, _}) ->
+    ok;
+ensure_instruction_is_permitted({try_end, _}) ->
+    ok;
+ensure_instruction_is_permitted({try_case, _}) ->
+    ok;
 ensure_instruction_is_permitted(Unknown) ->
     throw({unknown_instruction, Unknown}).
 

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -276,6 +276,8 @@ ensure_instruction_is_permitted({put_map_assoc, _, _, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({put_tuple2, _, _}) ->
     ok;
+ensure_instruction_is_permitted(raw_raise) ->
+    ok;
 ensure_instruction_is_permitted(remove_message) ->
     throw(receiving_message_denied);
 ensure_instruction_is_permitted(return) ->

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -202,6 +202,26 @@ allowed_try_catch_block_test() ->
            end
        end).
 
+call_that_will_raise(A) ->
+    try
+       1 + A
+    catch
+       error:_:Stacktrace ->
+           erlang:raise(error, "Oh no!", Stacktrace)
+    end.
+
+allowed_call_to_try_catch_function_test() ->
+    self() ! a,
+    A = receive Msg -> Msg end,
+    ?assertStandaloneFun(
+       begin
+           try
+               call_that_will_raise(A)
+           after
+               ok
+           end
+       end).
+
 allowed_catch_test() ->
     ?assertStandaloneFun(
        begin


### PR DESCRIPTION
See [this](https://github.com/erlang/otp/blob/df48c260e74c3e9058ff8681ce9f554e6fa0fe34/lib/compiler/src/beam_asm.erl#L360-L361) line in beam_asm.

The `raise` instruction needs to be translated to a `bif`. Luckily
the arguments line up very well so it's an easy translation. It was
a bit tough writing a test case that the compiler wouldn't optimize
the raise/try out of, I ended up using the send+receive technique from
a few test cases down.