### PR TITLE
deny apply/1 and apply_last/2 instructions

### DIFF
--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -198,6 +198,10 @@ ensure_instruction_is_permitted({allocate_zero, _, _}) ->
     ok;
 ensure_instruction_is_permitted({allocate_heap, _, _, _}) ->
     ok;
+ensure_instruction_is_permitted({apply, _}) ->
+    throw(dynamic_apply_denied);
+ensure_instruction_is_permitted({apply_last, _, _}) ->
+    throw(dynamic_apply_denied);
 ensure_instruction_is_permitted({badmatch, _}) ->
     ok;
 ensure_instruction_is_permitted({bif, Bif, _, Args, _}) ->

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -465,6 +465,21 @@ denied_erlang_send_3_test() ->
        {invalid_tx_fun, {call_denied, {erlang, send, 3}}},
        _ = erlang:send(list_to_pid("<0.0.0>"), msg, [nosuspend])).
 
+%% `apply_last' instruction is used when the apply is the last call
+%% in the function.
+denied_apply_last_test() ->
+    self() ! erlang,
+    Module = receive Msg -> Msg end,
+    ?assertToFunThrow(
+       {invalid_tx_fun, dynamic_apply_denied},
+       _ = Module:now()).
+denied_apply_test() ->
+    self() ! erlang,
+    Module = receive Msg -> Msg end,
+    ?assertToFunThrow(
+       {invalid_tx_fun, dynamic_apply_denied},
+       c = hd(Module:tl([[a, b], c]))).
+
 allowed_dict_api_test() ->
     ?assertStandaloneFun(
        begin


### PR DESCRIPTION
These instructions can be used to smuggle impure function calls past the linter like so:

```erl
Module = erlang,
Module:send(Pid, msg).
```

It's notable that this can make usage in Elixir less convenient because the map syntax can be interpreted as apply:

```elixir
defmodule Foo do
  def foo(map_or_module), do: map_or_module.utc_now
end

iex> Foo.foo(%{utc_now: 0})
0
iex> Foo.foo(DateTime)
~U[2022-02-09 15:09:30.338756Z]
```

So elixir map access instead needs to use `Map.get/3`/`Map.fetch/2`/etc.