### PR TITLE
Decode "Line" chunk and expand `line` instructions

### DIFF
--- a/test/mod_used_for_transactions.erl
+++ b/test/mod_used_for_transactions.erl
@@ -11,6 +11,7 @@
          get_lambda/0,
          %% We export this one just to try to prevent inlining.
          hash_term/1,
+         crashing_fun/0,
          make_record/1,
          outer_function/2]).
 
@@ -24,6 +25,9 @@ get_lambda() ->
 
 hash_term(Term) ->
     erlang:phash2(Term).
+
+crashing_fun() ->
+    throw("Expected crash").
 
 -record(my_record, {function}).
 


### PR DESCRIPTION
Line information comes from the "Line" chunk in the beam module. This is not decoded by `beam_disasm` and the `line` instructions it produces only have the index inside that "Line" beam chunk.

So far, we needed to get rid of all those `line` instructions because they were invalid for the compiler. It meant that frames in stacktraces pointing to an extracted function had no location. This made any sort of debugging quite difficult.

Here is an example without this patch:

```
%% Based on the following function:
%%     crashing_fun() ->
%%         throw("Expected crash").

1> Fun = khepri_fun:to_standalone_fun(fun mod:crashing_fun/0, #{}).
2> khepri_fun:exec(Fun, []).
** exception throw: "Expected crash"
     in function  kfun__mod__crashing_fun__33048370:run/0
```

Now, we decode the "Line" beam chunk for each module we need to disassemble. We then use this decoded table to replace the incomplete `line` instructions by valid ones.

Thanks to that, we get stacktrace frames with correct locations, making debugging far easier. Here is the same example as above, but with this change in place:

```
1> Fun = khepri_fun:to_standalone_fun(fun mod:crashing_fun/0, #{}).
2> khepri_fun:exec(Fun, []).
** exception throw: "Expected crash"
     in function  kfun__mod__crashing_fun__33048370:run/0 (.../mod.erl, line 30)
```

Fixes #50.
