### PR TITLE
khepri_fun: Add `select_tuple_arity` type annotation

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -883,6 +883,15 @@ pass1_process_instructions(
     Comment = {'%', VarInfo},
     pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
 pass1_process_instructions(
+  [{select_tuple_arity, Src, _, _} = Instruction | Rest],
+  State,
+  Result) ->
+    State1 = ensure_instruction_is_permitted(Instruction, State),
+    Type = {t_tuple, 0, false, #{}},
+    VarInfo = {var_info, Src, [{type, Type}]},
+    Comment = {'%', VarInfo},
+    pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
+pass1_process_instructions(
   [{get_map_elements, _Fail, Src, {list, _}} = Instruction | Rest],
   State,
   Result) ->

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -305,6 +305,28 @@ allowed_bs_match_accepts_match_context_test() ->
            <<"5">> = trim_leading_dash3([], "-5")
        end).
 
+make_tuple([A]) ->
+    {a, A};
+make_tuple([A, B]) ->
+    {b, A, B};
+make_tuple([_, B, C]) ->
+    {c, B, C}.
+
+handle_tuple(Tuple) when is_tuple(Tuple) ->
+    case Tuple of
+        {a, _}    -> true;
+        {b, _, _} -> false;
+        {c, _, _} -> false
+    end.
+
+select_tuple_arity_var_info_test() ->
+    Nodes = nodes(),
+    ?assertStandaloneFun(
+       begin
+           Tuple = make_tuple(Nodes),
+           handle_tuple(Tuple)
+       end).
+
 denied_receive_block_test() ->
     ?assertToFunThrow(
        {invalid_tx_fun, receiving_message_denied},


### PR DESCRIPTION
The `select_tuple_arity` is used in the following code for instance:

```erlang
case Tuple of
    {ok, _, _}   -> true;
    {error, _}   -> false;
    {timeout, _} -> false
end
```

In other words, the VM can simply verify the arity of the tuple to decide between `true` and `false` if the atom in the first position was implicitly verified earlier in the code.

`beam_validator` expects the annotation to specify a tuple without any specific arity.