### PR TITLE
GitHub Actions: Trigger benchmark run after a commit is pushed to the `main` branch

### DIFF
--- a/.github/workflows/trigger-benchmark.yaml
+++ b/.github/workflows/trigger-benchmark.yaml
@@ -1,0 +1,20 @@
+name: Trigger benchmark
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  Trigger:
+    name: Trigger benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.KHEPRI_BENCHMARK_REPO_ACCESS_TOKEN }}
+          repository: rabbitmq/khepri-benchmark
+          event-type: push-in-khepri
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
The benchmark is managed in a separate repository:
https://github.com/rabbitmq/khepri-benchmark

Results should be publicly visible on the associated GitHub Page:
https://rabbitmq.github.io/khepri-benchmark/