### PR TITLE
khepri_fun: propagate argument annotations to callee in bs_no_start_match2 validation failures

### DIFF
--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -276,6 +276,33 @@ allowed_bs_match_digit_parser_test() ->
            {[1, 2, 3, 4, 5], <<>>} = parse_float(<<".", 1, 2, 3, 4, 5>>)
        end).
 
+%% This set of parse_float, parse_digits, etc. is the same as the above
+%% functions and test case, except that the intermediary function
+%% `parse_digits/2' introduces new bindings that change the arity, to
+%% ensure we are not hard-coding an arity.
+parse_float2(<<".", Rest/binary>>) ->
+    parse_digits2([], Rest);
+parse_float2(Bin) -> {[], Bin}.
+
+parse_digits2(Foo, Bin) ->
+    parse_digits2(Foo, [], Bin).
+
+parse_digits2(Foo, Bar, Bin) ->
+    parse_digits2(Foo, Bar, Bin, []).
+
+parse_digits2(
+  Foo, Bar, <<Digit/integer, Rest/binary>>, Acc)
+  when is_integer(Digit) andalso Digit >= 48 andalso Digit =< 57 ->
+    parse_digits2(Foo, Bar, Rest, [Digit | Acc]);
+parse_digits2(_Foo, _Bar, Rest, Acc) ->
+    {lists:reverse(Acc), Rest}.
+
+allowed_bs_match_digit_parser2_test() ->
+    ?assertStandaloneFun(
+       begin
+           {[1, 2, 3, 4, 5], <<>>} = parse_float2(<<".", 1, 2, 3, 4, 5>>)
+       end).
+
 %% The compiler determines that this clause will always match because this
 %% function is not exported and is only called with a compile-time binary
 %% matching the pattern. As a result, the instruction for this match is


### PR DESCRIPTION
This is a follow up for removing the hard-coded register `FIXME` (https://github.com/rabbitmq/khepri/pull/49#issuecomment-1039196029). Sorry the title is so long and jargon-y 😅

A simplification of the problem is that function `A` calls function `B` calls function `C`. `A` passes an argument to `B` that `accepts_match_context`, but `B` doesn't have any annotations for its parameters, so the `beam_validator` emits an error on the call instruction saying: `no_bs_start_match2`.

<details><summary>I got a bit derailed looking into this by function <code>C</code>...</summary><br>

In the test case fixtures, `C` has a parameter that `accepts_match_context`, so I thought that in order to fix this, we would need to determine the types of each function in the call graph (which naively seems easy based on [`beam_validator:build_function_table/2`](https://github.com/erlang/otp/blob/59aa9c55b3c7eb7e646c98b8888af43b135e7664/lib/compiler/src/beam_validator.erl#L238-L264)). It turns out though that this is not the case (see the commit message for edf1e98 for some more details on this).

<hr></details>

In order to handle this particular `beam_validator` failure, we detect the annotations within the branch of the failed call instruction and add those annotions to the callee right after its entrypoint.