### PR TITLE
Let the caller choose between consistency and low latency for queries

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -469,7 +469,7 @@ get_store_ids() ->
 %% @private
 
 forget_store_ids() ->
-    _ = persistent_term:get(?PT_STORE_IDS),
+    _ = persistent_term:erase(?PT_STORE_IDS),
     ok.
 
 %% -------------------------------------------------------------------

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -127,6 +127,8 @@
 
          info/0,
          info/1]).
+%% For internal use only.
+-export([forget_store_ids/0]).
 
 -compile({no_auto_import, [get/2]}).
 
@@ -460,6 +462,15 @@ remember_store_id(ClusterName) ->
 
 get_store_ids() ->
     maps:keys(persistent_term:get(?PT_STORE_IDS, #{})).
+
+-spec forget_store_ids() -> ok.
+%% @doc Clears the remembered store IDs.
+%%
+%% @private
+
+forget_store_ids() ->
+    _ = persistent_term:get(?PT_STORE_IDS),
+    ok.
 
 %% -------------------------------------------------------------------
 %% Data manipulation.

--- a/src/khepri_app.erl
+++ b/src/khepri_app.erl
@@ -20,7 +20,7 @@ start(normal, []) ->
 stop(_) ->
     StoreIds = khepri:get_store_ids(),
     lists:foreach(
-      fun(StoreId) -> khepri_machine:clear_cached_leader(StoreId) end,
+      fun(StoreId) -> khepri_machine:clear_cache(StoreId) end,
       StoreIds),
     khepri:forget_store_ids(),
     ok.

--- a/src/khepri_app.erl
+++ b/src/khepri_app.erl
@@ -18,6 +18,11 @@ start(normal, []) ->
     khepri_sup:start_link().
 
 stop(_) ->
+    StoreIds = khepri:get_store_ids(),
+    lists:foreach(
+      fun(StoreId) -> khepri_machine:clear_cached_leader(StoreId) end,
+      StoreIds),
+    khepri:forget_store_ids(),
     ok.
 
 config_change(_Changed, _New, _Removed) ->

--- a/test/app.erl
+++ b/test/app.erl
@@ -9,11 +9,19 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-app_starts_workers_test() ->
-    ?assertMatch({ok, _}, application:ensure_all_started(khepri)),
-    ?assert(is_process_alive(whereis(khepri_event_handler))),
-    ?assertEqual(ok, application:stop(khepri)),
-    ?assertEqual(undefined, whereis(khepri_event_handler)).
+app_starts_workers_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertMatch({ok, _}, application:ensure_all_started(khepri)),
+        ?_assert(is_process_alive(whereis(khepri_event_handler))),
+        ?_assertEqual([?FUNCTION_NAME], khepri:get_store_ids()),
+        ?_assertEqual(ok, application:stop(khepri)),
+        ?_assertEqual(undefined, whereis(khepri_event_handler)),
+        ?_assertEqual([], khepri:get_store_ids()),
+        ?_assertEqual([], [PT || {Key, _} = PT <- persistent_term:get(),
+                                 element(1, Key) =:= khepri])]}]}.
 
 event_handler_gen_server_callbacks_test() ->
     %% This testcase is mostly to improve code coverage. We don't really care

--- a/test/favor_option.erl
+++ b/test/favor_option.erl
@@ -1,0 +1,159 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(favor_option).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/internal.hrl").
+-include("test/helpers.hrl").
+
+favor_compromise_in_query_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_last_consistent_call_atomics(
+                      ?FUNCTION_NAME)),
+
+                 ?assertEqual(
+                    {ok, #{}},
+                    khepri_machine:get(
+                      ?FUNCTION_NAME, [foo], #{favor => compromise})),
+
+                 ?assertEqual(
+                    {?FUNCTION_NAME, node()},
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 Ref = khepri_machine:get_last_consistent_call_atomics(
+                         ?FUNCTION_NAME),
+                 TS1 = atomics:get(Ref, 1),
+                 ?assertNotEqual(0, TS1),
+
+                 timer:sleep(1000),
+
+                 ?assertEqual(
+                    {ok, #{}},
+                    khepri_machine:get(
+                      ?FUNCTION_NAME, [foo], #{favor => compromise})),
+
+                 ?assertEqual(
+                    {?FUNCTION_NAME, node()},
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 TS2 = atomics:get(Ref, 1),
+                 ?assertEqual(TS1, TS2),
+
+                 timer:sleep(2000),
+
+                 ?assertEqual(
+                    {ok, #{}},
+                    khepri_machine:get(
+                      ?FUNCTION_NAME, [foo], #{favor => compromise})),
+
+                 ?assertEqual(
+                    {?FUNCTION_NAME, node()},
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 TS3 = atomics:get(Ref, 1),
+                 ?assertNotEqual(TS1, TS3),
+
+                 ok
+         end)
+     ]}.
+
+favor_consistency_in_query_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_last_consistent_call_atomics(
+                      ?FUNCTION_NAME)),
+
+                 ?assertEqual(
+                    {ok, #{}},
+                    khepri_machine:get(
+                      ?FUNCTION_NAME, [foo], #{favor => consistency})),
+
+                 ?assertEqual(
+                    {?FUNCTION_NAME, node()},
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 Ref = khepri_machine:get_last_consistent_call_atomics(
+                         ?FUNCTION_NAME),
+                 TS1 = atomics:get(Ref, 1),
+                 ?assertNotEqual(0, TS1),
+
+                 timer:sleep(1000),
+
+                 ?assertEqual(
+                    {ok, #{}},
+                    khepri_machine:get(
+                      ?FUNCTION_NAME, [foo], #{favor => consistency})),
+
+                 ?assertEqual(
+                    {?FUNCTION_NAME, node()},
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 TS2 = atomics:get(Ref, 1),
+                 ?assertNotEqual(TS1, TS2),
+
+                 ok
+         end)
+     ]}.
+
+favor_low_latency_in_query_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_last_consistent_call_atomics(
+                      ?FUNCTION_NAME)),
+
+                 ?assertEqual(
+                    {ok, #{}},
+                    khepri_machine:get(
+                      ?FUNCTION_NAME, [foo], #{favor => low_latency})),
+
+                 ?assertEqual(
+                    {?FUNCTION_NAME, node()},
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_last_consistent_call_atomics(
+                      ?FUNCTION_NAME)),
+
+                 ?assertEqual(
+                    {ok, #{}},
+                    khepri_machine:get(
+                      ?FUNCTION_NAME, [foo], #{favor => low_latency})),
+
+                 ?assertEqual(
+                    {?FUNCTION_NAME, node()},
+                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                 ?assertEqual(
+                    undefined,
+                    khepri_machine:get_last_consistent_call_atomics(
+                      ?FUNCTION_NAME)),
+
+                 ok
+         end)
+     ]}.

--- a/test/test_ra_server_helpers.erl
+++ b/test/test_ra_server_helpers.erl
@@ -11,10 +11,16 @@
          cleanup/1]).
 
 setup(Testcase) ->
-    {ok, _} = application:ensure_all_started(ra),
+    _ = logger:set_primary_config(level, warning),
+    {ok, _} = application:ensure_all_started(khepri),
+    ok = application:set_env(
+           khepri,
+           consistent_query_interval_in_compromise,
+           2),
+
     RaSystem = Testcase,
     StoreDir = store_dir_name(RaSystem),
-    remove_store_dir(StoreDir),
+    _ = remove_store_dir(StoreDir),
     Default = ra_system:default_config(),
     RaSystemConfig = Default#{name => RaSystem,
                               data_dir => StoreDir,
@@ -27,6 +33,7 @@ setup(Testcase) ->
                               RaSystem,
                               Testcase,
                               atom_to_list(Testcase)),
+            ok = khepri_machine:clear_cache(StoreId),
             #{ra_system => RaSystem,
               ra_system_pid => RaSystemPid,
               store_dir => StoreDir,
@@ -43,6 +50,7 @@ cleanup(#{ra_system := RaSystem,
     _ = supervisor:terminate_child(ra_systems_sup, RaSystem),
     _ = supervisor:delete_child(ra_systems_sup, RaSystem),
     _ = remove_store_dir(StoreDir),
+    ok = khepri_machine:clear_cache(StoreId),
     ok.
 
 store_dir_name(RaSystem) ->


### PR DESCRIPTION
`khepri_machine:get/3` and `khepri_machine:transaction/4` now accept a new option in the options map: `favor`.

`favor` indicates what the caller prefers between freshness of the data and low latency of the query. Accepted values are:

* `consistency`: it means that a "consistent query" will be used in Ra. It will return the most up-to-date piece of data the cluster agreed on. Note that it could block and time out if there is no quorum in the Ra cluster.
* `compromise`: it performs "leader queries" most of the time to reduce latency (though latency will still be higher than "local queries"; see below), but uses "consistent queries" every 10 seconds to verify that the cluster is healthy. It should be faster but may block and time out like `consistency` and still return slightly out-of-date data.
* `low_latency`: it means that "local queries" are used exclusively. They are the fastest and have the lowest latency. However, the returned data is whatever the local Ra server has. It could be out-of-date if it has troubles keeping up with the Ra cluster. The chance of blocking and timing out is very small.

The default is currently set to `compromise`.

The 10-second interval between "consistent queries" in the `compromise` strategy is configurable using the `consistent_query_interval_in_compromise` application environment variable. This variable accepts an interval in seconds.

Before this patch, queries were based entirely on "leader queries", thus something close to the new `compromise` strategy in terms of performance.

Here is a quick benchmark on my laptop:

![Screenshot 2022-03-21 at 10-53-11 Khepri benchmark](https://user-images.githubusercontent.com/159804/159238459-db24026e-fa50-4f9e-8ece-711d606ba95f.png)

Configuration:
* CPU: Intel Core i7-9850H CPU @ 2.60GHz, 12 cores
* RAM: 32 GiB
* OS: FreeBSD 14-CURRENT
* Erlang: 24.2.2

The benchmark was running while my browser was also running with many tabs opened.