### PR TITLE
infer type annotation for `test_arity` test instruction

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1006,6 +1006,15 @@ pass1_process_instructions(
     VarInfo = {var_info, Var, [accepts_match_context]},
     Comment = {'%', VarInfo},
     pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
+pass1_process_instructions(
+  [{test, test_arity, _Fail, [Var, Arity]} = Instruction | Rest],
+  State,
+  Result) ->
+    State1 = ensure_instruction_is_permitted(Instruction, State),
+    Type = {t_tuple, Arity, false, #{}},
+    VarInfo = {var_info, Var, [{type, Type}]},
+    Comment = {'%', VarInfo},
+    pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
 
 pass1_process_instructions(
   [Instruction | Rest],

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1621,6 +1621,9 @@ pass2_process_instruction(
             Instruction
     end;
 pass2_process_instruction(
+  {bif, _, _, _, _} = Instruction, State) ->
+    replace_label(Instruction, 3, State);
+pass2_process_instruction(
   {bs_add, _, _, _} = Instruction, State) ->
     replace_label(Instruction, 2, State);
 pass2_process_instruction(


### PR DESCRIPTION
It looks like this `{test, test_arity, _, _}` instruction needs the `t_tuple` type inference similar to `get_tuple_element/3` and `select_tuple_arity/3`. The instruction seems to show up when the compiler knows ahead of time that the input will be a tuple but isn't sure of the arity and needs to branch on the arity.