### PR TITLE
Let the caller select between sync and async commands (put, delete or read-write transaction)

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -754,7 +754,7 @@ get(Path) ->
       Result :: khepri_machine:result();
 (PathPattern, Options) -> Result when
       PathPattern :: khepri_path:pattern() | string(),
-      Options :: khepri_machine:operation_options(),
+      Options :: khepri_machine:query_options(),
       Result :: khepri_machine:result().
 %% @doc Returns all tree nodes matching the path pattern.
 %%
@@ -776,7 +776,7 @@ get(Path, Options) when is_map(Options) ->
 -spec get(StoreId, PathPattern, Options) -> Result when
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern() | string(),
-      Options :: khepri_machine:operation_options(),
+      Options :: khepri_machine:query_options(),
       Result :: khepri_machine:result().
 %% @doc Returns all tree nodes matching the path pattern.
 %%

--- a/test/async_option.erl
+++ b/test/async_option.erl
@@ -1,0 +1,461 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(async_option).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/internal.hrl").
+-include("test/helpers.hrl").
+
+async_unset_in_put_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(?FUNCTION_NAME, [foo], none)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_false_in_put_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(
+                  ?FUNCTION_NAME, [foo], none, #{async => false})),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_true_in_put_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                ok,
+                khepri_machine:put(
+                  ?FUNCTION_NAME, [foo], none, #{async => true})),
+             lists:foldl(
+               fun
+                   (_, {ok, Result}) when Result =:= #{} ->
+                       timer:sleep(500),
+                       khepri_machine:get(?FUNCTION_NAME, [foo]);
+                   (_, Ret) ->
+                       Ret
+               end, {ok, #{}}, lists:seq(1, 60)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_correlation_in_put_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Correlation = 1,
+             ?assertEqual(
+                ok,
+                khepri_machine:put(
+                  ?FUNCTION_NAME, [foo], none, #{async => Correlation})),
+             Ret = receive
+                       {ra_event, _, {applied, [{Correlation, Reply}]}} ->
+                           Reply
+                   end,
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                Ret),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_priority_in_put_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                ok,
+                khepri_machine:put(
+                  ?FUNCTION_NAME, [foo], none, #{async => low})),
+             lists:foldl(
+               fun
+                   (_, {ok, Result}) when Result =:= #{} ->
+                       timer:sleep(500),
+                       khepri_machine:get(?FUNCTION_NAME, [foo]);
+                   (_, Ret) ->
+                       Ret
+               end, {ok, #{}}, lists:seq(1, 60)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_correlation_and_priority_in_put_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Correlation = 1,
+             ?assertEqual(
+                ok,
+                khepri_machine:put(
+                  ?FUNCTION_NAME, [foo], none,
+                  #{async => {Correlation, low}})),
+             Ret = receive
+                       {ra_event, _, {applied, [{Correlation, Reply}]}} ->
+                           Reply
+                   end,
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                Ret),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_unset_in_delete_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(?FUNCTION_NAME, [foo], none)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:delete(?FUNCTION_NAME, [foo])),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_false_in_delete_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(?FUNCTION_NAME, [foo], none)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:delete(
+                  ?FUNCTION_NAME, [foo], #{async => false})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_true_in_delete_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(?FUNCTION_NAME, [foo], none)),
+             ?assertEqual(
+                ok,
+                khepri_machine:delete(
+                  ?FUNCTION_NAME, [foo], #{async => true})),
+             lists:foldl(
+               fun
+                   (_, {ok, Result}) when Result =/= #{} ->
+                       timer:sleep(500),
+                       khepri_machine:get(?FUNCTION_NAME, [foo]);
+                   (_, Ret) ->
+                       Ret
+               end,
+               {ok, #{[foo] => #{payload_version => 1,
+                                 child_list_version => 1,
+                                 child_list_length => 0}}},
+               lists:seq(1, 60)),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_correlation_in_delete_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(?FUNCTION_NAME, [foo], none)),
+             Correlation = 1,
+             ?assertEqual(
+                ok,
+                khepri_machine:delete(
+                  ?FUNCTION_NAME, [foo], #{async => Correlation})),
+             Ret = receive
+                       {ra_event, _, {applied, [{Correlation, Reply}]}} ->
+                           Reply
+                   end,
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                Ret),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_priority_in_delete_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(?FUNCTION_NAME, [foo], none)),
+             ?assertEqual(
+                ok,
+                khepri_machine:delete(
+                  ?FUNCTION_NAME, [foo], #{async => low})),
+             lists:foldl(
+               fun
+                   (_, {ok, Result}) when Result =/= #{} ->
+                       timer:sleep(500),
+                       khepri_machine:get(?FUNCTION_NAME, [foo]);
+                   (_, Ret) ->
+                       Ret
+               end,
+               {ok, #{[foo] => #{payload_version => 1,
+                                 child_list_version => 1,
+                                 child_list_length => 0}}},
+               lists:seq(1, 60)),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_correlation_and_priority_in_delete_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                khepri_machine:put(?FUNCTION_NAME, [foo], none)),
+             Correlation = 1,
+             ?assertEqual(
+                ok,
+                khepri_machine:delete(
+                  ?FUNCTION_NAME, [foo], #{async => {Correlation, low}})),
+             Ret = receive
+                       {ra_event, _, {applied, [{Correlation, Reply}]}} ->
+                           Reply
+                   end,
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                Ret),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_unset_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:put([foo], none) end,
+             ?assertEqual(
+                {atomic, {ok, #{[foo] => #{}}}},
+                khepri_machine:transaction(?FUNCTION_NAME, Fun)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_false_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:put([foo], none) end,
+             ?assertEqual(
+                {atomic, {ok, #{[foo] => #{}}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{async => false})),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_true_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:put([foo], none) end,
+             ?assertEqual(
+                ok,
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{async => true})),
+             lists:foldl(
+               fun
+                   (_, {ok, Result}) when Result =:= #{} ->
+                       timer:sleep(500),
+                       khepri_machine:get(?FUNCTION_NAME, [foo]);
+                   (_, Ret) ->
+                       Ret
+               end, {ok, #{}}, lists:seq(1, 60)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_correlation_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:put([foo], none) end,
+             Correlation = 1,
+             ?assertEqual(
+                ok,
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{async => Correlation})),
+             Ret = receive
+                       {ra_event, _, {applied, [{Correlation, Reply}]}} ->
+                           Reply
+                   end,
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                Ret),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_priority_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:put([foo], none) end,
+             ?assertEqual(
+                ok,
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{async => low})),
+             lists:foldl(
+               fun
+                   (_, {ok, Result}) when Result =:= #{} ->
+                       timer:sleep(500),
+                       khepri_machine:get(?FUNCTION_NAME, [foo]);
+                   (_, Ret) ->
+                       Ret
+               end, {ok, #{}}, lists:seq(1, 60)),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.
+
+async_with_correlation_and_priority_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:put([foo], none) end,
+             Correlation = 1,
+             ?assertEqual(
+                ok,
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun,
+                  #{async => {Correlation, low}})),
+             Ret = receive
+                       {ra_event, _, {applied, [{Correlation, Reply}]}} ->
+                           Reply
+                   end,
+             ?assertEqual(
+                {ok, #{[foo] => #{}}},
+                Ret),
+             ?assertEqual(
+                {ok, #{[foo] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 0}}},
+                khepri_machine:get(?FUNCTION_NAME, [foo]))
+         end)
+     ]}.

--- a/test/favor_option.erl
+++ b/test/favor_option.erl
@@ -13,147 +13,298 @@
 -include("src/internal.hrl").
 -include("test/helpers.hrl").
 
-favor_compromise_in_query_test_() ->
+favor_compromise_in_get_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_test(
          begin
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_last_consistent_call_atomics(
-                      ?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
 
-                 ?assertEqual(
-                    {ok, #{}},
-                    khepri_machine:get(
-                      ?FUNCTION_NAME, [foo], #{favor => compromise})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(
+                  ?FUNCTION_NAME, [foo], #{favor => compromise})),
 
-                 ?assertEqual(
-                    {?FUNCTION_NAME, node()},
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 Ref = khepri_machine:get_last_consistent_call_atomics(
-                         ?FUNCTION_NAME),
-                 TS1 = atomics:get(Ref, 1),
-                 ?assertNotEqual(0, TS1),
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             Ref = khepri_machine:get_last_consistent_call_atomics(
+                     ?FUNCTION_NAME),
+             TS1 = atomics:get(Ref, 1),
+             ?assertNotEqual(0, TS1),
 
-                 timer:sleep(1000),
+             timer:sleep(1000),
 
-                 ?assertEqual(
-                    {ok, #{}},
-                    khepri_machine:get(
-                      ?FUNCTION_NAME, [foo], #{favor => compromise})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(
+                  ?FUNCTION_NAME, [foo], #{favor => compromise})),
 
-                 ?assertEqual(
-                    {?FUNCTION_NAME, node()},
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 TS2 = atomics:get(Ref, 1),
-                 ?assertEqual(TS1, TS2),
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             TS2 = atomics:get(Ref, 1),
+             ?assertEqual(TS1, TS2),
 
-                 timer:sleep(2000),
+             timer:sleep(2000),
 
-                 ?assertEqual(
-                    {ok, #{}},
-                    khepri_machine:get(
-                      ?FUNCTION_NAME, [foo], #{favor => compromise})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(
+                  ?FUNCTION_NAME, [foo], #{favor => compromise})),
 
-                 ?assertEqual(
-                    {?FUNCTION_NAME, node()},
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 TS3 = atomics:get(Ref, 1),
-                 ?assertNotEqual(TS1, TS3),
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             TS3 = atomics:get(Ref, 1),
+             ?assertNotEqual(TS1, TS3),
 
-                 ok
+             ok
          end)
      ]}.
 
-favor_consistency_in_query_test_() ->
+favor_consistency_in_get_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_test(
          begin
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_last_consistent_call_atomics(
-                      ?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
 
-                 ?assertEqual(
-                    {ok, #{}},
-                    khepri_machine:get(
-                      ?FUNCTION_NAME, [foo], #{favor => consistency})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(
+                  ?FUNCTION_NAME, [foo], #{favor => consistency})),
 
-                 ?assertEqual(
-                    {?FUNCTION_NAME, node()},
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 Ref = khepri_machine:get_last_consistent_call_atomics(
-                         ?FUNCTION_NAME),
-                 TS1 = atomics:get(Ref, 1),
-                 ?assertNotEqual(0, TS1),
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             Ref = khepri_machine:get_last_consistent_call_atomics(
+                     ?FUNCTION_NAME),
+             TS1 = atomics:get(Ref, 1),
+             ?assertNotEqual(0, TS1),
 
-                 timer:sleep(1000),
+             timer:sleep(1000),
 
-                 ?assertEqual(
-                    {ok, #{}},
-                    khepri_machine:get(
-                      ?FUNCTION_NAME, [foo], #{favor => consistency})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(
+                  ?FUNCTION_NAME, [foo], #{favor => consistency})),
 
-                 ?assertEqual(
-                    {?FUNCTION_NAME, node()},
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 TS2 = atomics:get(Ref, 1),
-                 ?assertNotEqual(TS1, TS2),
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             TS2 = atomics:get(Ref, 1),
+             ?assertNotEqual(TS1, TS2),
 
-                 ok
+             ok
          end)
      ]}.
 
-favor_low_latency_in_query_test_() ->
+favor_low_latency_in_get_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_test(
          begin
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_last_consistent_call_atomics(
-                      ?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
 
-                 ?assertEqual(
-                    {ok, #{}},
-                    khepri_machine:get(
-                      ?FUNCTION_NAME, [foo], #{favor => low_latency})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(
+                  ?FUNCTION_NAME, [foo], #{favor => low_latency})),
 
-                 ?assertEqual(
-                    {?FUNCTION_NAME, node()},
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_last_consistent_call_atomics(
-                      ?FUNCTION_NAME)),
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
 
-                 ?assertEqual(
-                    {ok, #{}},
-                    khepri_machine:get(
-                      ?FUNCTION_NAME, [foo], #{favor => low_latency})),
+             ?assertEqual(
+                {ok, #{}},
+                khepri_machine:get(
+                  ?FUNCTION_NAME, [foo], #{favor => low_latency})),
 
-                 ?assertEqual(
-                    {?FUNCTION_NAME, node()},
-                    khepri_machine:get_cached_leader(?FUNCTION_NAME)),
-                 ?assertEqual(
-                    undefined,
-                    khepri_machine:get_last_consistent_call_atomics(
-                      ?FUNCTION_NAME)),
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
 
-                 ok
+             ok
+         end)
+     ]}.
+
+favor_compromise_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:get([foo]) end,
+
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
+
+             ?assertEqual(
+                {atomic, {ok, #{}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{favor => compromise})),
+
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             Ref = khepri_machine:get_last_consistent_call_atomics(
+                     ?FUNCTION_NAME),
+             TS1 = atomics:get(Ref, 1),
+             ?assertNotEqual(0, TS1),
+
+             timer:sleep(1000),
+
+             ?assertEqual(
+                {atomic, {ok, #{}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{favor => compromise})),
+
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             TS2 = atomics:get(Ref, 1),
+             ?assertEqual(TS1, TS2),
+
+             timer:sleep(2000),
+
+             ?assertEqual(
+                {atomic, {ok, #{}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{favor => compromise})),
+
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             TS3 = atomics:get(Ref, 1),
+             ?assertNotEqual(TS1, TS3),
+
+             ok
+         end)
+     ]}.
+
+favor_consistency_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:get([foo]) end,
+
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
+
+             ?assertEqual(
+                {atomic, {ok, #{}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{favor => consistency})),
+
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             Ref = khepri_machine:get_last_consistent_call_atomics(
+                     ?FUNCTION_NAME),
+             TS1 = atomics:get(Ref, 1),
+             ?assertNotEqual(0, TS1),
+
+             timer:sleep(1000),
+
+             ?assertEqual(
+                {atomic, {ok, #{}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{favor => consistency})),
+
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             TS2 = atomics:get(Ref, 1),
+             ?assertNotEqual(TS1, TS2),
+
+             ok
+         end)
+     ]}.
+
+favor_low_latency_in_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_test(
+         begin
+             Fun = fun() -> khepri_tx:get([foo]) end,
+
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
+
+             ?assertEqual(
+                {atomic, {ok, #{}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{favor => low_latency})),
+
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
+
+             ?assertEqual(
+                {atomic, {ok, #{}}},
+                khepri_machine:transaction(
+                  ?FUNCTION_NAME, Fun, #{favor => low_latency})),
+
+             ?assertEqual(
+                {?FUNCTION_NAME, node()},
+                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+             ?assertEqual(
+                undefined,
+                khepri_machine:get_last_consistent_call_atomics(
+                  ?FUNCTION_NAME)),
+
+             ok
          end)
      ]}.

--- a/test/test_ra_server_helpers.erl
+++ b/test/test_ra_server_helpers.erl
@@ -46,11 +46,11 @@ cleanup(#{ra_system := RaSystem,
           store_dir := StoreDir,
           store_id := StoreId}) ->
     ServerIds = khepri:members(StoreId),
+    _ = application:stop(khepri),
     _ = ra:delete_cluster(ServerIds),
     _ = supervisor:terminate_child(ra_systems_sup, RaSystem),
     _ = supervisor:delete_child(ra_systems_sup, RaSystem),
     _ = remove_store_dir(StoreDir),
-    ok = khepri_machine:clear_cache(StoreId),
     ok.
 
 store_dir_name(RaSystem) ->


### PR DESCRIPTION
`khepri_machine:put/5`, `khepri_machine:delete/3` and `khepri_machine:transaction/4` now accept an options map with a single option called `async`.

`async` indicates if the caller wants a synchronous or an asynchronous command. Accepted values are:
* `true' to perform an asynchronous low-priority command without a correlation ID.
* `false' to perform a synchronous command.
* A correlation ID to perform an asynchronous low-priority command with that correlation ID.
* A priority to perform an asynchronous command with the specified priority but without a correlation ID.
* A combination of a correlation ID and a priority to perform an asynchronous command with the specified parameters.

The default is currently set to `false` (i.e. all commands are synchronous).

Note that to clarify options, the `operation_options()` type was renamed to `query_options()`. The new option described above is part of a new type called `command_options()`.
