### PR TITLE
Accept string-based paths in `khepri_machine` and `khepri_tx`

### DIFF
--- a/src/khepri_condition.erl
+++ b/src/khepri_condition.erl
@@ -551,8 +551,6 @@ compare_numerical_values(_, _)                 -> false.
 
 is_valid(Component) when ?IS_PATH_COMPONENT(Component) ->
     true;
-is_valid(?THIS_NODE) ->
-    true;
 is_valid(#if_node_exists{exists = Exists}) ->
     is_boolean(Exists);
 is_valid(#if_name_matches{}) ->

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -435,9 +435,10 @@ put(StoreId, PathPattern, Payload, Options) ->
 
 put(StoreId, PathPattern, Payload, Extra, Options)
   when ?IS_KHEPRI_PAYLOAD(Payload) ->
-    khepri_path:ensure_is_valid(PathPattern),
+    PathPattern1 = khepri_path:from_string(PathPattern),
+    khepri_path:ensure_is_valid(PathPattern1),
     Payload1 = prepare_payload(Payload),
-    Command = #put{path = PathPattern,
+    Command = #put{path = PathPattern1,
                    payload = Payload1,
                    extra = Extra},
     process_command(StoreId, Command, Options);
@@ -500,9 +501,10 @@ get(StoreId, PathPattern) ->
 %% "error" tuple.
 
 get(StoreId, PathPattern, Options) ->
-    khepri_path:ensure_is_valid(PathPattern),
+    PathPattern1 = khepri_path:from_string(PathPattern),
+    khepri_path:ensure_is_valid(PathPattern1),
     Query = fun(#?MODULE{root = Root}) ->
-                    find_matching_nodes(Root, PathPattern, Options)
+                    find_matching_nodes(Root, PathPattern1, Options)
             end,
     process_query(StoreId, Query, Options).
 
@@ -555,8 +557,9 @@ delete(StoreId, PathPattern) ->
 %% message if a correlation ID was specified).
 
 delete(StoreId, PathPattern, Options) ->
-    khepri_path:ensure_is_valid(PathPattern),
-    Command = #delete{path = PathPattern},
+    PathPattern1 = khepri_path:from_string(PathPattern),
+    khepri_path:ensure_is_valid(PathPattern1),
+    Command = #delete{path = PathPattern1},
     process_command(StoreId, Command, Options).
 
 -spec transaction(StoreId, Fun) -> Ret when

--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -43,14 +43,14 @@
 
 -module(khepri_path).
 
+-include_lib("stdlib/include/assert.hrl").
+
 -include("include/khepri.hrl").
 
 -export([compile/1,
          from_string/1,
-         component_from_string/1,
          maybe_from_string/1,
          to_string/1,
-         component_to_string/1,
          combine_with_conditions/2,
          targets_specific_node/1,
          component_targets_specific_node/1,
@@ -59,6 +59,10 @@
          abspath/2,
          realpath/1,
          pattern_includes_root_node/1]).
+
+-ifdef(TEST).
+-export([component_to_string/1]).
+-endif.
 
 -type node_id() :: atom() | binary().
 %% A node name.
@@ -87,75 +91,120 @@
 compile(PathPattern) ->
     lists:map(fun khepri_condition:compile/1, PathPattern).
 
--spec from_string(string()) -> pattern().
+-spec from_string(MaybeString) -> PathPattern when
+      MaybeString :: string() | pattern(),
+      PathPattern :: pattern().
 
-from_string("") ->
-    [];
-from_string("/" ++ PathString) ->
-    from_string(PathString, []);
-from_string("./" ++ PathString) ->
-    from_string(PathString, [?THIS_NODE]);
-from_string(".") ->
-    [?THIS_NODE];
-from_string("../" ++ PathString) ->
-    from_string(PathString, [?PARENT_NODE]);
-from_string("..") ->
-    [?PARENT_NODE];
-from_string(PathString) ->
-    from_string(PathString, [?THIS_NODE]).
+from_string("/" ++ MaybeString) ->
+    from_string(MaybeString, [?ROOT_NODE]);
+from_string(MaybeString) when is_list(MaybeString) ->
+    from_string(MaybeString, []);
+from_string(NotPath) ->
+    throw({invalid_path, #{path => NotPath}}).
 
-from_string(PathString, ParentPath) ->
-    ReOpts = [{capture, all_but_first, list}, dotall],
-    case re:run(PathString, "^((?U)<<.*>>)(?:/(.*)|$)", ReOpts) of
-        {match, [ComponentString, Rest]} ->
-            Component = component_from_string(ComponentString),
-            from_string(Rest, [Component | ParentPath]);
-        {match, [ComponentString]} ->
-            Component = component_from_string(ComponentString),
-            lists:reverse([Component | ParentPath]);
-        nomatch ->
-            case re:run(PathString, "^([^/]*)(?:/(.*)|$)", ReOpts) of
-                {match, ["", Rest]} ->
-                    from_string(Rest, ParentPath);
-                {match, [ComponentString, Rest]} ->
-                    Component = component_from_string(ComponentString),
-                    from_string(Rest, [Component | ParentPath]);
-                {match, [""]} ->
-                    lists:reverse(ParentPath);
-                {match, [ComponentString]} ->
-                    Component = component_from_string(ComponentString),
-                    lists:reverse([Component | ParentPath])
+from_string([Component | _] = Rest, ReversedPath)
+  when ?IS_NODE_ID(Component) orelse
+       ?IS_CONDITION(Component) ->
+    finalize_path(Rest, ReversedPath);
+from_string([Char, Component | _] = Rest, ReversedPath)
+  when ?IS_SPECIAL_PATH_COMPONENT(Char) andalso
+       (?IS_NODE_ID(Component) orelse
+        ?IS_CONDITION(Component)) ->
+    finalize_path(Rest, ReversedPath);
+from_string([Char] = Rest, [] = ReversedPath)
+  when ?IS_SPECIAL_PATH_COMPONENT(Char) ->
+    finalize_path(Rest, ReversedPath);
+
+from_string([$/ | Rest], ReversedPath) ->
+    from_string(Rest, ReversedPath);
+
+from_string([$<, $< | Rest], ReversedPath) ->
+    ?assertNotEqual("", Rest),
+    parse_binary_from_string(Rest, ReversedPath);
+
+from_string([Char | _] = Rest, ReversedPath) when is_integer(Char) ->
+    parse_atom_from_string(Rest, ReversedPath);
+
+from_string([], ReversedPath) ->
+    finalize_path([], ReversedPath);
+
+from_string(Rest, ReversedPath) ->
+    NotPath = lists:reverse(ReversedPath) ++ Rest,
+    throw({invalid_path, #{path => NotPath,
+                           tail => Rest}}).
+
+parse_atom_from_string(Rest, ReversedPath) ->
+    parse_atom_from_string(Rest, "", ReversedPath).
+
+parse_atom_from_string([$/ | _] = Rest, Acc, ReversedPath) ->
+    Component = finalize_atom_component(Acc),
+    ReversedPath1 = prepend_component(Component, ReversedPath),
+    from_string(Rest, ReversedPath1);
+parse_atom_from_string([Char | Rest], Acc, ReversedPath)
+  when is_integer(Char) ->
+    Acc1 = [Char | Acc],
+    parse_atom_from_string(Rest, Acc1, ReversedPath);
+parse_atom_from_string([] = Rest, Acc, ReversedPath) ->
+    Component = finalize_atom_component(Acc),
+    ReversedPath1 = prepend_component(Component, ReversedPath),
+    from_string(Rest, ReversedPath1).
+
+finalize_atom_component(Acc) ->
+    Acc1 = lists:reverse(Acc),
+    case Acc1 of
+        "." ->
+            ?THIS_NODE;
+        ".." ->
+            ?PARENT_NODE;
+        "*" ->
+            ?STAR;
+        "**" ->
+            ?STAR_STAR;
+        _ ->
+            case re:run(Acc1, "\\*", [{capture, none}]) of
+                match ->
+                    ReOpts = [global, {return, list}],
+                    Regex = re:replace(Acc1, "\\*", ".*", ReOpts),
+                    #if_name_matches{regex = "^" ++ Regex ++ "$"};
+                nomatch ->
+                    erlang:list_to_atom(Acc1)
             end
     end.
 
--spec component_from_string(string()) -> pattern_component().
+parse_binary_from_string(Rest, ReversedPath) ->
+    parse_binary_from_string(Rest, "", ReversedPath).
 
-component_from_string("/") ->
-    ?ROOT_NODE;
-component_from_string(".") ->
-    ?THIS_NODE;
-component_from_string("..") ->
-    ?PARENT_NODE;
-component_from_string("*") ->
-    ?STAR;
-component_from_string("**") ->
-    ?STAR_STAR;
-component_from_string(Component) ->
-    ReOpts1 = [{capture, all_but_first, list}, dotall],
-    Component1 = case re:run(Component, "^<<(.*)>>$", ReOpts1) of
-                     {match, [C]} -> C;
-                     nomatch      -> Component
-                 end,
-    ReOpts2 = [{capture, none}],
-    case re:run(Component1, "\\*", ReOpts2) of
-        match ->
-            ReOpts3 = [global, {return, list}],
-            Regex = re:replace(Component1, "\\*", ".*", ReOpts3),
-            #if_name_matches{regex = "^" ++ Regex ++ "$"};
-        nomatch when Component1 =:= Component ->
-            list_to_atom(Component);
-        nomatch ->
-            list_to_binary(Component1)
+%% If a binary contains ">>" before its, we consider them to be part of the
+%% binary's content, not the end marker.
+parse_binary_from_string([$>, $> | Rest], Acc, ReversedPath)
+  when Rest =:= "" orelse hd(Rest) =:= $/ ->
+    Component = finalize_binary_componenent(Acc),
+    ReversedPath1 = prepend_component(Component, ReversedPath),
+    from_string(Rest, ReversedPath1);
+parse_binary_from_string([Char | Rest], Acc, ReversedPath)
+  when is_integer(Char) ->
+    Acc1 = [Char | Acc],
+    parse_binary_from_string(Rest, Acc1, ReversedPath);
+parse_binary_from_string([], Acc, ReversedPath) ->
+    %% This "binary" has no end marker. We consider it an atom then.
+    parse_atom_from_string([], Acc ++ "<<", ReversedPath).
+
+finalize_binary_componenent(Acc) ->
+    Acc1 = lists:reverse(Acc),
+    erlang:list_to_binary(Acc1).
+
+prepend_component(Component, []) when ?IS_NODE_ID(Component) ->
+    %% This is a relative path.
+    [Component, ?THIS_NODE];
+prepend_component(Component, ReversedPath) ->
+    [Component | ReversedPath].
+
+finalize_path(Rest, []) ->
+    Rest;
+finalize_path(Rest, ReversedPath) ->
+    case lists:reverse(ReversedPath) ++ Rest of
+        [?ROOT_NODE | Path] -> Path;
+        Path                -> Path
     end.
 
 -spec maybe_from_string(pattern() | string()) -> pattern().
@@ -309,8 +358,9 @@ is_valid(NotPathPattern) ->
 
 ensure_is_valid(PathPattern) ->
     case is_valid(PathPattern) of
-        true          -> ok;
-        {false, Path} -> throw({invalid_path, Path})
+        true               -> ok;
+        {false, Component} -> throw({invalid_path, #{path => PathPattern,
+                                                     component => Component}})
     end.
 
 -spec abspath(pattern(), pattern()) -> pattern().

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -86,13 +86,14 @@ use_an_invalid_path_test_() ->
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertThrow(
-         {invalid_path, not_a_list},
+         {invalid_path, #{path := not_a_list}},
          khepri_machine:put(
            ?FUNCTION_NAME,
            not_a_list,
            none)),
       ?_assertThrow(
-         {invalid_path, "not_a_component"},
+         {invalid_path, #{path := ["not_a_component"],
+                          tail := ["not_a_component"]}},
          khepri_machine:put(
            ?FUNCTION_NAME,
            ["not_a_component"],

--- a/test/path_operations.erl
+++ b/test/path_operations.erl
@@ -12,45 +12,6 @@
 -include("include/khepri.hrl").
 
 %% -------------------------------------------------------------------
-%% Path component parsing.
-%% -------------------------------------------------------------------
-
-atom_component_from_string_test() ->
-    ?assertEqual(foo, khepri_path:component_from_string("foo")),
-    ?assertEqual('<foo>', khepri_path:component_from_string("<foo>")),
-    ?assertEqual('<<foo', khepri_path:component_from_string("<<foo")).
-
-binary_component_from_string_test() ->
-    ?assertEqual(<<"foo">>, khepri_path:component_from_string("<<foo>>")),
-    ?assertEqual(<<"<foo>">>, khepri_path:component_from_string("<<<foo>>>")).
-
-root_component_from_string_test() ->
-    ?assertEqual(?ROOT_NODE, khepri_path:component_from_string("/")).
-
-dot_component_from_string_test() ->
-    ?assertEqual(?THIS_NODE, khepri_path:component_from_string(".")).
-
-dot_dot_component_from_string_test() ->
-    ?assertEqual(?PARENT_NODE, khepri_path:component_from_string("..")).
-
-star_component_from_string_test() ->
-    ?assertEqual(?STAR, khepri_path:component_from_string("*")).
-
-star_star_component_from_string_test() ->
-    ?assertEqual(?STAR_STAR, khepri_path:component_from_string("**")).
-
-glob_pattern_component_from_string_test() ->
-    ?assertEqual(
-       #if_name_matches{regex = "^foo.*$"},
-       khepri_path:component_from_string("foo*")),
-    ?assertEqual(
-       #if_name_matches{regex = "^.*foo.*$"},
-       khepri_path:component_from_string("*foo*")),
-    ?assertEqual(
-       #if_name_matches{regex = "^.*foo.*bar.*$"},
-       khepri_path:component_from_string("*foo*bar*")).
-
-%% -------------------------------------------------------------------
 %% Entire path parsing.
 %% -------------------------------------------------------------------
 
@@ -87,6 +48,9 @@ relative_path_prefixed_with_dot_dot_from_string_test() ->
 path_with_star_from_string_test() ->
     ?assertEqual(
        [foo, ?STAR],
+       khepri_path:from_string([?ROOT_NODE, foo, ?STAR])),
+    ?assertEqual(
+       [foo, ?STAR],
        khepri_path:from_string("/foo/*")).
 
 path_with_star_star_from_string_test() ->
@@ -96,8 +60,17 @@ path_with_star_star_from_string_test() ->
 
 path_with_binary_from_string_test() ->
     ?assertEqual(
+       ['<atom>'],
+       khepri_path:from_string("/<atom>")),
+    ?assertEqual(
        [<<"binary">>],
        khepri_path:from_string("/<<binary>>")),
+    ?assertEqual(
+       [<<"<binary>">>],
+       khepri_path:from_string("/<<<binary>>>")),
+    ?assertEqual(
+       ['<<atom'],
+       khepri_path:from_string("/<<atom")),
     ?assertEqual(
        [<<"bin/ary">>],
        khepri_path:from_string("/<<bin/ary>>")),
@@ -123,45 +96,56 @@ path_with_whitespaces_from_string_test() ->
        ['foo  ', '  bar'],
        khepri_path:from_string("/foo  /  bar")).
 
-maybe_from_string_on_path_test() ->
+from_string_on_path_test() ->
     ?assertEqual(
        [foo, bar],
-       khepri_path:maybe_from_string([foo, bar])),
+       khepri_path:from_string([foo, bar])),
     ?assertEqual(
        [?THIS_NODE, foo, bar],
-       khepri_path:maybe_from_string([?THIS_NODE, foo, bar])).
+       khepri_path:from_string([?THIS_NODE, foo, bar])).
 
-maybe_from_string_on_string_test() ->
+from_string_on_string_test() ->
     ?assertEqual(
        [foo, bar],
-       khepri_path:maybe_from_string("/foo/bar")).
+       khepri_path:from_string("/foo/bar")).
 
-maybe_from_string_on_relative_string_test() ->
+from_string_on_relative_string_test() ->
     ?assertEqual(
        [?THIS_NODE, foo, bar],
-       khepri_path:maybe_from_string("foo/bar")),
+       khepri_path:from_string("foo/bar")),
     ?assertEqual(
        [?THIS_NODE, foo, bar],
-       khepri_path:maybe_from_string("./foo/bar")).
+       khepri_path:from_string("./foo/bar")).
 
-maybe_from_string_on_empty_string_test() ->
+from_string_on_empty_string_test() ->
     ?assertEqual(
        [],
-       khepri_path:maybe_from_string("")).
+       khepri_path:from_string("")).
 
-maybe_special_chars_from_string_test() ->
+special_chars_from_string_test() ->
     ?assertEqual(
        [],
-       khepri_path:maybe_from_string("/")),
+       khepri_path:from_string("/")),
     ?assertEqual(
        [?THIS_NODE],
-       khepri_path:maybe_from_string(".")),
+       khepri_path:from_string(".")),
     ?assertEqual(
        [?PARENT_NODE],
-       khepri_path:maybe_from_string("^")),
+       khepri_path:from_string("^")),
     ?assertEqual(
        [?PARENT_NODE],
-       khepri_path:maybe_from_string("..")).
+       khepri_path:from_string("..")).
+
+glob_pattern_from_string_test() ->
+    ?assertEqual(
+       [#if_name_matches{regex = "^foo.*$"}],
+       khepri_path:from_string("/foo*")),
+    ?assertEqual(
+       [#if_name_matches{regex = "^.*foo.*$"}],
+       khepri_path:from_string("/*foo*")),
+    ?assertEqual(
+       [#if_name_matches{regex = "^.*foo.*bar.*$"}],
+       khepri_path:from_string("/*foo*bar*")).
 
 %% -------------------------------------------------------------------
 %% Path component serializing.

--- a/test/transactions.erl
+++ b/test/transactions.erl
@@ -699,7 +699,7 @@ use_an_invalid_path_in_tx_test_() ->
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertEqual(
-         {aborted, {invalid_path, not_a_list}},
+         {aborted, {invalid_path, #{path => not_a_list}}},
          begin
              Fun = fun() ->
                            khepri_tx:put(not_a_list, none)
@@ -707,7 +707,8 @@ use_an_invalid_path_in_tx_test_() ->
              khepri:transaction(?FUNCTION_NAME, Fun)
          end),
       ?_assertEqual(
-         {aborted, {invalid_path, "not_a_component"}},
+         {aborted, {invalid_path, #{path => ["not_a_component"],
+                                    tail => ["not_a_component"]}}},
          begin
              Fun = fun() ->
                            khepri_tx:put(["not_a_component"], none)


### PR DESCRIPTION
This was the case for the "simple API" in `khepri` only so far. But this is convenient to be able to use string-based paths anywhere. It also improves the consistency of the API.

As a consequence, `khepri_path:from_string/1` accepts both string-based and regular paths and returns a regular path. Now unnecessary, `khepri_path:maybe_from_string/1` and `khepri_path:component_from_string/1` were removed.

`khepri_path:component_to_string/1` is still there but made internal. It's not public anymore.