### PR TITLE
Support Erlang/OTP 25

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,8 +12,7 @@
             warnings_as_errors]}.
 
 {dialyzer, [{plt_extra_apps, [edoc, eunit, inets, mnesia, proper, ssl, xmerl]},
-            {warnings, [race_conditions,
-                        underspecs,
+            {warnings, [underspecs,
                         unknown,
                         unmatched_returns]}]}.
 

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1335,9 +1335,18 @@ find_function(
       BeamFileRecord :: #beam_file_ext{}.
 %% @private
 
+erl_eval_fun_to_asm(Module, Name, Arity, [{_, Bindings, _, _, _, Clauses}])
+  when Bindings =:= [] orelse %% Erlang is using a list for bindings,
+       Bindings =:= #{} ->    %% but Elixir is using a map.
+    %% Erlang starting from 25.
+    erl_eval_fun_to_asm1(Module, Name, Arity, Clauses);
 erl_eval_fun_to_asm(Module, Name, Arity, [{Bindings, _, _, Clauses}])
   when Bindings =:= [] orelse %% Erlang is using a list for bindings,
        Bindings =:= #{} ->    %% but Elixir is using a map.
+    %% Erlang up to 24.
+    erl_eval_fun_to_asm1(Module, Name, Arity, Clauses).
+
+erl_eval_fun_to_asm1(Module, Name, Arity, Clauses) ->
     %% We construct an abstract form based on the `env' of the lambda loaded
     %% by `erl_eval'.
     Anno = erl_anno:from_term(1),

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -472,6 +472,8 @@ ensure_instruction_is_permitted({bs_add, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({bs_append, _, _, _, _, _, _, _, _}) ->
     ok;
+ensure_instruction_is_permitted({bs_create_bin, _, _, _, _, _, _}) ->
+    ok;
 ensure_instruction_is_permitted({bs_init2, _, _, _, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({bs_init_bits, _, _, _, _, _, _}) ->


### PR DESCRIPTION
This includes at least the support of the new `bs_create_bin` instruction.