### PR TITLE
Use an LRU cache for standalone funs

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -220,7 +220,7 @@ fun((#{calls := #{Call :: mfa() => true},
                      should_process_function_fun(),
                      is_standalone_fun_still_needed =>
                      is_standalone_fun_still_needed_fun(),
-                     function_cache => module()}.
+                     standalone_fun_cache => module()}.
 %% Options to tune the extraction of an anonymous function.
 %%
 %% <ul>
@@ -456,7 +456,7 @@ get_cached_standalone_fun(
   #state{fun_info = #{module := Module}, options = Options} = State)
   when Module =/= erl_eval ->
     Key = standalone_fun_cache_key(State),
-    FunctionCache = maps:get(function_cache, Options, khepri_fun_cache),
+    FunctionCache = maps:get(standalone_fun_cache, Options, khepri_fun_cache),
     case FunctionCache:get(Key, undefined) of
         #{standalone_fun := StandaloneFunWithoutEnv,
           checksums := Checksums,
@@ -533,7 +533,7 @@ cache_standalone_fun(
     %% currently.
     Counters = counters:new(1, [write_concurrency]),
 
-    FunctionCache = maps:get(function_cache, Options, khepri_fun_cache),
+    FunctionCache = maps:get(standalone_fun_cache, Options, khepri_fun_cache),
 
     case StandaloneFun of
         #standalone_fun{} ->

--- a/src/khepri_fun_cache.erl
+++ b/src/khepri_fun_cache.erl
@@ -1,0 +1,18 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% @doc A cache interface for transaction functions
+
+-module(khepri_fun_cache).
+
+-export([get/2, put/2]).
+
+-callback get(Key :: term(), Default :: term()) -> term().
+-callback put(Key :: term(), Fun :: term()) -> ok.
+
+get(Key, Default) -> persistent_term:get(Key, Default).
+put(Key, Fun) -> persistent_term:put(Key, Fun).

--- a/src/khepri_fun_cache.erl
+++ b/src/khepri_fun_cache.erl
@@ -6,13 +6,106 @@
 %%
 
 %% @doc A cache interface for transaction functions
+%%
+%% The default cache implementation is an `ets'-based LRU cache.
+%% The capacity of the cache can be configured by setting
+%% `application:set_env(khepri, fun_cache_capacity, Capacity)'.
+%% By default, the capacity is `10_000' elements.
 
 -module(khepri_fun_cache).
 
 -export([get/2, put/2]).
 
+%% Exported for testing
+-export([clear/0]).
+
+-define(CACHE, '$__ETS_LRU_CACHE__').
+-define(RANKS, '$__ETS_LRU_RANKS__').
+
+-ifdef(TEST).
+-define(CAPACITY, 3).
+-else.
+-define(CAPACITY, 10_000).
+-endif.
+
 -callback get(Key :: term(), Default :: term()) -> term().
 -callback put(Key :: term(), Fun :: term()) -> ok.
 
-get(Key, Default) -> persistent_term:get(Key, Default).
-put(Key, Fun) -> persistent_term:put(Key, Fun).
+get(Key, Default) ->
+    case ets:whereis(?CACHE) of
+        undefined ->
+            setup_tables(),
+            Default;
+        _Tid ->
+            get1(Key, Default)
+    end.
+
+get1(Key, Default) ->
+    case ets:lookup(?CACHE, Key) of
+        [{Key, Rank, Value}] ->
+            update_rank(Rank, Key),
+            Value;
+        [] ->
+            Default
+    end.
+
+put(Key, Value) ->
+    case ets:whereis(?CACHE) of
+        undefined ->
+            setup_tables(),
+            insert_key(Key, Value),
+            ok;
+        _Tid ->
+            put1(Key, Value)
+    end.
+
+put1(Key, Value) ->
+    case ets:lookup(?CACHE, Key) of
+        [{Key, _Rank, Value}] ->
+            ok;
+        [{Key, Rank, _OtherValue}] ->
+            update_rank(Rank, Key),
+            ets:update_element(?CACHE, Key, {3, Value}),
+            ok;
+        [] ->
+            insert_key(Key, Value),
+            ok
+    end.
+
+clear() ->
+    ets:delete(?CACHE),
+    ets:delete(?RANKS),
+    ok.
+
+setup_tables() ->
+    _ = ets:new(?CACHE, [public, named_table, set]),
+    _ = ets:new(?RANKS, [public, named_table, ordered_set]),
+    ok.
+
+update_rank(Rank, Key) ->
+    NextRank = next_rank(),
+    ets:delete(?RANKS, Rank),
+    ets:insert(?RANKS, {NextRank, Key}),
+    ets:update_element(?CACHE, Key, {2, NextRank}),
+    ok.
+
+insert_key(Key, Value) ->
+    case ets:info(?CACHE, size) >= capacity() of
+        true ->
+            %% The cache is full so we discard the least-recently used item.
+            OldestRank = ets:first(?RANKS),
+            [{OldestRank, OldestKey}] = ets:take(?RANKS, OldestRank),
+            ets:delete(?CACHE, OldestKey);
+        _ ->
+            ok
+    end,
+    NextRank = next_rank(),
+    ets:insert(?CACHE, {Key, NextRank, Value}),
+    ets:insert(?RANKS, {NextRank, Key}),
+    ok.
+
+capacity() ->
+    application:get_env(khepri, fun_cache_capacity, ?CAPACITY).
+
+next_rank() ->
+    erlang:unique_integer([monotonic]).

--- a/src/khepri_fun_cache.erl
+++ b/src/khepri_fun_cache.erl
@@ -19,8 +19,8 @@
 %% Exported for testing
 -export([clear/0]).
 
--define(CACHE, '$__ETS_LRU_CACHE__').
--define(RANKS, '$__ETS_LRU_RANKS__').
+-define(CACHE, '$__KHEPRI_FUN_CACHE__').
+-define(RANKS, '$__KHEPRI_FUN_RANKS__').
 
 -ifdef(TEST).
 -define(CAPACITY, 3).


### PR DESCRIPTION
I tried out micro-benchmarking some LRU styles: [the-mikedavis/lru_bench](https://github.com/the-mikedavis/lru_bench/tree/7c65a323d253b66a157ac3a720bfbc8fde431205) and I found one that I think works pretty well, especially for concurrent read/write throughput. I need to plug this in to khepri-benchmark to see how it fares with concurrency but the micro-benchmarks say that this cache is ~1.4x slower for `get/2`s and ~1.8x slower for `put/2`s compared to `persistent_term` which I think is not too bad.

Mostly I had fun beating [lru](https://hex.pm/packages/lru) which is linear runtime (this implementation is logarithmic) on the cache capacity for both `put/2` and `get/2`. Look how it crawls in that XX-Large case! 😄

I'd like to improve the documentation and maybe rename some variables but I thought I'd open this up to discussion earlier rather than later. Plus I have some questions:

* Does this match expectations for interfaces/behaviours? I based it on [`rabbit_auth_cache`](https://github.com/rabbitmq/rabbitmq-server/blob/7abf749a60458aba9d6c9e6bdec1d3b0b2254007/deps/rabbitmq_auth_backend_cache/src/rabbit_auth_cache.erl)
* Should I be tuning any of the read/write concurrency settings in `ets`?

And mostly: is the lack of atomicity in `put/2` and `get/2` ok? A tla+ checker might point out some nasty scenarios from concurrent `put/2`s and `get/2`s, but given that this cache is purely for speed, I think the fidelity of the data doesn't matter much: if keys are dropped or something lives in the cache for longer than expected, it's no big deal. What do you think?

connects #75 