### PR TITLE
khepri: Add `get_data_or/{2,3,4}`

### DIFF
--- a/test/simple_get.erl
+++ b/test/simple_get.erl
@@ -215,6 +215,55 @@ get_data_on_many_nodes_test_() ->
            ?FUNCTION_NAME,
            [?THIS_NODE, #if_name_matches{regex = any}]))]}.
 
+get_data_or_default_on_non_existing_node_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         default,
+         khepri:get_data_or(?FUNCTION_NAME, [foo], default))]}.
+
+get_data_or_default_on_existing_node_with_data_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, #{[foo] => #{}}},
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertEqual(
+         foo_value,
+         khepri:get_data_or(?FUNCTION_NAME, [foo], default))]}.
+
+get_data_or_default_on_existing_node_without_data_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, #{[foo] => #{}}},
+         khepri:create(?FUNCTION_NAME, [foo], khepri_payload:none())),
+      ?_assertEqual(
+         default,
+         khepri:get_data_or(?FUNCTION_NAME, [foo], default))]}.
+
+get_data_or_default_on_many_nodes_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, #{[foo, bar] => #{}}},
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         {ok, #{[baz] => #{}}},
+         khepri:create(?FUNCTION_NAME, [baz], baz_value)),
+      ?_assertThrow(
+         {error,
+          {possibly_matching_many_nodes_denied,
+           #if_name_matches{regex = any}}},
+         khepri:get_data_or(
+           ?FUNCTION_NAME,
+           [?THIS_NODE, #if_name_matches{regex = any}],
+           default))]}.
+
 list_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,

--- a/test/transactions.erl
+++ b/test/transactions.erl
@@ -283,6 +283,105 @@ get_data_in_rw_transaction_test_() ->
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
+get_data_on_many_nodes_in_ro_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {aborted,
+          {error,
+           {possibly_matching_many_nodes_denied,
+            #if_name_matches{regex = any}}}},
+         begin
+             _ = khepri:put(
+                   ?FUNCTION_NAME, [foo], khepri_payload:none()),
+
+             Fun = fun() ->
+                           khepri_tx:get_data([?STAR])
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end)]}.
+
+get_data_or_default_on_non_existing_node_in_ro_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {atomic, default},
+         begin
+             Fun = fun() ->
+                           khepri_tx:get_data_or([foo], default)
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end)]}.
+
+get_data_or_default_on_existing_node_with_data_in_ro_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {atomic, value1},
+         begin
+             _ = khepri:put(
+                   ?FUNCTION_NAME, [foo], khepri_payload:data(value1)),
+
+             Fun = fun() ->
+                           khepri_tx:get_data_or([foo], default)
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end)]}.
+
+get_data_or_default_on_many_nodes_in_ro_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {aborted,
+          {error,
+           {possibly_matching_many_nodes_denied,
+            #if_name_matches{regex = any}}}},
+         begin
+             _ = khepri:put(
+                   ?FUNCTION_NAME, [foo], khepri_payload:none()),
+
+             Fun = fun() ->
+                           khepri_tx:get_data_or([?STAR], default)
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end)]}.
+
+get_data_or_default_on_existing_node_without_data_in_ro_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {atomic, default},
+         begin
+             _ = khepri:put(
+                   ?FUNCTION_NAME, [foo], khepri_payload:none()),
+
+             Fun = fun() ->
+                           khepri_tx:get_data_or([foo], default)
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end)]}.
+
+get_data_or_default_in_rw_transaction_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {atomic, value1},
+         begin
+             _ = khepri:put(
+                   ?FUNCTION_NAME, [foo], khepri_payload:data(value1)),
+
+             Fun = fun() ->
+                           khepri_tx:get_data_or([foo], default)
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
 put_in_ro_transaction_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,


### PR DESCRIPTION
This is the same as `get_data/{1,2,3}` except that it takes a default value as argument to return if the tree node does not exist, has no data or holds a stored procedure.