### PR TITLE
Accept Unix-like paths in `keep_while` conditions

### DIFF
--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -44,7 +44,7 @@
 -record(put, {path :: khepri_path:native_pattern(),
               payload = ?NO_PAYLOAD :: khepri_payload:payload(),
               extra = #{} :: #{keep_while =>
-                               khepri:keep_while_conds_map()}}).
+                               khepri_condition:native_keep_while()}}).
 
 -record(delete, {path :: khepri_path:native_pattern()}).
 

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -192,28 +192,6 @@
                   khepri:error().
 %% Return value of a query or synchronous command.
 
--type keep_while_conds_map() :: #{khepri_path:path() =>
-                                  khepri_condition:keep_while()}.
-%% Per-node `keep_while' conditions.
-%%
-%% When a node is put with `keep_while' conditions, this node will be kept in
-%% the database while each condition remains true for their associated path.
-%%
-%% Example:
-%% ```
-%% khepri:put(
-%%   StoreId,
-%%   [foo],
-%%   Payload,
-%%   #{keep_while => #{
-%%     %% The node `[foo]' will be removed as soon as `[bar]' is removed
-%%     %% because the condition associated with `[bar]' will not be true
-%%     %% anymore.
-%%     [bar] => #if_node_exists{exists = true}
-%%   }}
-%% ).
-%% '''
-
 -type trigger_id() :: atom().
 %% An ID to identify a registered trigger.
 
@@ -301,7 +279,6 @@
               node_props/0,
               node_props_map/0,
               result/0,
-              keep_while_conds_map/0,
               trigger_id/0,
 
               async_option/0,
@@ -419,7 +396,7 @@ put(StoreId, PathPattern, Data) ->
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -439,7 +416,7 @@ put(StoreId, PathPattern, Data, Options) ->
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -494,7 +471,7 @@ put(StoreId, PathPattern, Data, Options) ->
 %% <ul>
 %% <li>`keep_while': `keep_while' conditions to tie the life of the inserted
 %% node to conditions on other nodes; see {@link
-%% keep_while_conds_map()}.</li>
+%% khepri_condition:keep_while()}.</li>
 %% </ul>
 %%
 %% The `Options' map may specify command-level options; see {@link
@@ -563,7 +540,7 @@ create(StoreId, PathPattern, Data) ->
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -584,7 +561,7 @@ create(StoreId, PathPattern, Data, Options) ->
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -651,7 +628,7 @@ update(StoreId, PathPattern, Data) ->
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -672,7 +649,7 @@ update(StoreId, PathPattern, Data, Options) ->
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -744,7 +721,7 @@ compare_and_swap(StoreId, PathPattern, DataPattern, Data) ->
       PathPattern :: khepri_path:pattern(),
       DataPattern :: ets:match_pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -770,7 +747,7 @@ compare_and_swap(StoreId, PathPattern, DataPattern, Data, Options) ->
       PathPattern :: khepri_path:pattern(),
       DataPattern :: ets:match_pattern(),
       Data :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -806,7 +783,7 @@ compare_and_swap(StoreId, PathPattern, DataPattern, Data, Extra, Options) ->
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Payload :: khepri_payload:payload() | data() | fun(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -848,7 +825,7 @@ clear_payload(StoreId, PathPattern) ->
 -spec clear_payload(StoreId, PathPattern, Extra | Options) -> Result when
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -867,7 +844,7 @@ clear_payload(StoreId, PathPattern, Options) ->
 -spec clear_payload(StoreId, PathPattern, Extra, Options) -> Result when
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
-      Extra :: #{keep_while => keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: command_options(),
       Result :: result() | NoRetIfAsync,
       NoRetIfAsync :: ok.

--- a/src/khepri_condition.erl
+++ b/src/khepri_condition.erl
@@ -229,6 +229,36 @@
 %% An association between a path and a condition. As long as the condition
 %% evaluates to true, the tree node is kept. Once the condition evaluates to
 %% false, the tree node is deleted.
+%%
+%% If the `keep_while' conditions are false at the time of the insert, the
+%% insert fails. The only exception to that is if the `keep_while' condition
+%% is on the inserted node itself.
+%%
+%% Paths in the map can be native paths or Unix-like paths. However, having
+%% two entries that resolve to the same node (one native path entry and one
+%% Unix-like path entry for instance) is undefined behavior: one of them will
+%% overwrite the other.
+%%
+%% Example:
+%% ```
+%% khepri:put(
+%%   StoreId,
+%%   [foo],
+%%   Payload,
+%%   #{keep_while => #{
+%%     %% The node `[foo]' will be removed as soon as `[bar]' is removed
+%%     %% because the condition associated with `[bar]' will not be true
+%%     %% anymore.
+%%     [bar] => #if_node_exists{exists = true}
+%%   }}
+%% ).
+%% '''
+
+-type native_keep_while() :: #{khepri_path:native_path() => condition()}.
+%% An association between a native path and a condition.
+%%
+%% This is the same as {@link keep_while()} but the paths in the map keys were
+%% converted to native paths if necessary.
 
 -export([ensure_native_keep_while/1,
          compile/1,
@@ -243,7 +273,12 @@
 
 -export_type([condition/0,
               comparison_op/1,
-              keep_while/0]).
+              keep_while/0,
+              native_keep_while/0]).
+
+-spec ensure_native_keep_while(KeepWhile) -> NativeKeepWhile when
+      KeepWhile :: keep_while(),
+      NativeKeepWhile :: native_keep_while().
 
 ensure_native_keep_while(KeepWhile) ->
     maps:fold(

--- a/src/khepri_condition.erl
+++ b/src/khepri_condition.erl
@@ -230,7 +230,8 @@
 %% evaluates to true, the tree node is kept. Once the condition evaluates to
 %% false, the tree node is deleted.
 
--export([compile/1,
+-export([ensure_native_keep_while/1,
+         compile/1,
          applies_to_grandchildren/1,
          is_met/3,
          is_valid/1]).
@@ -243,6 +244,18 @@
 -export_type([condition/0,
               comparison_op/1,
               keep_while/0]).
+
+ensure_native_keep_while(KeepWhile) ->
+    maps:fold(
+      fun(Path, Condition, Acc) ->
+              Path1 = khepri_path:from_string(Path),
+              %% TODO: Handle situations where the parsed path yields a native
+              %% path already present in the resulting map.
+              %%
+              %% Should we merge conditions in a `#if_all{}' condition? Return
+              %% an error?
+              Acc#{Path1 => Condition}
+      end, #{}, KeepWhile).
 
 -spec compile(Condition) -> Condition when
       Condition :: khepri_path:pattern_component().

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -164,9 +164,17 @@ put(StoreId, PathPattern, Payload, Extra, Options)
     PathPattern1 = khepri_path:from_string(PathPattern),
     khepri_path:ensure_is_valid(PathPattern1),
     Payload1 = khepri_payload:prepare(Payload),
+    Extra1 = case Extra of
+                 #{keep_while := KeepWhile} ->
+                     KeepWhile1 = khepri_condition:ensure_native_keep_while(
+                                    KeepWhile),
+                     Extra#{keep_while => KeepWhile1};
+                 _ ->
+                     Extra
+             end,
     Command = #put{path = PathPattern1,
                    payload = Payload1,
-                   extra = Extra},
+                   extra = Extra1},
     process_command(StoreId, Command, Options);
 put(_StoreId, PathPattern, Payload, _Extra, _Options) ->
     throw({invalid_payload, PathPattern, Payload}).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -81,6 +81,10 @@
 -type machine_config() :: #config{}.
 %% Configuration record, holding read-only or rarely changing fields.
 
+-type keep_while_conds_map() :: #{khepri_path:native_path() =>
+                                  khepri_condition:native_keep_while()}.
+%% Per-node `keep_while' conditions.
+
 -type keep_while_conds_revidx() :: #{khepri_path:native_path() =>
                                      #{khepri_path:native_path() => ok}}.
 %% Internal reverse index of the keep_while conditions. If node A depends on a
@@ -102,7 +106,7 @@
 -type walk_down_the_tree_extra() :: #{include_root_props =>
                                       boolean(),
                                       keep_while_conds =>
-                                      khepri:keep_while_conds_map(),
+                                      keep_while_conds_map(),
                                       keep_while_conds_revidx =>
                                       keep_while_conds_revidx(),
                                       keep_while_aftermath =>
@@ -126,6 +130,7 @@
               tree_node/0,
               stat/0,
               triggered/0,
+              keep_while_conds_map/0,
               keep_while_conds_revidx/0]).
 
 %% -------------------------------------------------------------------
@@ -139,7 +144,7 @@
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
       Payload :: khepri_payload:payload(),
-      Extra :: #{keep_while => khepri:keep_while_conds_map()},
+      Extra :: #{keep_while => khepri_condition:keep_while()},
       Options :: khepri:command_options(),
       Result :: khepri:result() | NoRetIfAsync,
       NoRetIfAsync :: ok.
@@ -404,7 +409,7 @@ ack_triggers_execution(StoreId, TriggeredStoredProcs) ->
 
 -spec get_keep_while_conds_state(StoreId) -> Ret when
       StoreId :: khepri:store_id(),
-      Ret :: {ok, khepri:keep_while_conds_map()} | khepri:error().
+      Ret :: {ok, keep_while_conds_map()} | khepri:error().
 %% @doc Returns the `keep_while' conditions internal state.
 %%
 %% The returned state consists of all the `keep_while' condition set so far.
@@ -995,7 +1000,7 @@ gather_node_props(#node{stat = #{payload_version := DVersion,
 
 -spec to_absolute_keep_while(BasePath, KeepWhile) -> KeepWhile when
       BasePath :: khepri_path:native_path(),
-      KeepWhile :: khepri_condition:keep_while().
+      KeepWhile :: khepri_condition:native_keep_while().
 %% @private
 
 to_absolute_keep_while(BasePath, KeepWhile) ->
@@ -1007,7 +1012,7 @@ to_absolute_keep_while(BasePath, KeepWhile) ->
 
 -spec are_keep_while_conditions_met(Node, KeepWhile) -> Ret when
       Node :: tree_node(),
-      KeepWhile :: khepri_condition:keep_while(),
+      KeepWhile :: khepri_condition:native_keep_while(),
       Ret :: true | {false, any()}.
 %% @private
 
@@ -1053,10 +1058,10 @@ is_keep_while_condition_met_on_self(_, _, _) ->
 -spec update_keep_while_conds_revidx(
         KeepWhileConds, KeepWhileCondsRevIdx, Watcher, KeepWhile) ->
     KeepWhileConds when
-      KeepWhileConds :: khepri:keep_while_conds_map(),
+      KeepWhileConds :: keep_while_conds_map(),
       KeepWhileCondsRevIdx :: keep_while_conds_revidx(),
       Watcher :: khepri_path:native_path(),
-      KeepWhile :: khepri_condition:keep_while().
+      KeepWhile :: khepri_condition:native_keep_while().
 
 update_keep_while_conds_revidx(
   KeepWhileConds, KeepWhileCondsRevIdx, Watcher, KeepWhile) ->
@@ -1121,7 +1126,7 @@ find_matching_nodes_cb(_, {interrupted, _, _}, _, Result) ->
       State :: state(),
       PathPattern :: khepri_path:native_pattern(),
       Payload :: khepri_payload:payload(),
-      Extra :: #{keep_while => khepri_condition:keep_while()},
+      Extra :: #{keep_while => khepri_condition:native_keep_while()},
       Ret :: {State, Result} | {State, Result, ra_machine:effects()},
       Result :: khepri:result().
 %% @private

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -15,7 +15,7 @@
 -record(khepri_machine,
         {config = #config{} :: khepri_machine:machine_config(),
          root = #node{stat = ?INIT_NODE_STAT} :: khepri_machine:tree_node(),
-         keep_while_conds = #{} :: khepri:keep_while_conds_map(),
+         keep_while_conds = #{} :: khepri_machine:keep_while_conds_map(),
          keep_while_conds_revidx = #{}
            :: khepri_machine:keep_while_conds_revidx(),
          triggers = #{} ::

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -124,9 +124,17 @@ put(PathPattern, Data, Extra) ->
     ensure_updates_are_allowed(),
     PathPattern1 = path_from_string(PathPattern),
     Payload1 = khepri_payload:wrap(Data),
+    Extra1 = case Extra of
+                 #{keep_while := KeepWhile} ->
+                     KeepWhile1 = khepri_condition:ensure_native_keep_while(
+                                    KeepWhile),
+                     Extra#{keep_while => KeepWhile1};
+                 _ ->
+                     Extra
+             end,
     {State, SideEffects} = get_tx_state(),
     Ret = khepri_machine:insert_or_update_node(
-            State, PathPattern1, Payload1, Extra),
+            State, PathPattern1, Payload1, Extra1),
     case Ret of
         {NewState, Result, NewSideEffects} ->
             set_tx_state(NewState, SideEffects ++ NewSideEffects);

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -69,17 +69,57 @@ query_keep_while_conds_state_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
-     [?_assertEqual(
-         {ok, #{[foo] =>
-                #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
-         begin
-             _ = khepri:put(
-                   ?FUNCTION_NAME,
-                   [foo],
-                   khepri_payload:data(foo_value),
-                   #{keep_while => KeepWhile}),
-             khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME)
-         end)]}.
+     [{inorder,
+       [?_assertEqual(
+           {ok, #{[foo] => #{}}},
+           khepri:put(
+             ?FUNCTION_NAME,
+             [foo],
+             khepri_payload:data(foo_value),
+             #{keep_while => KeepWhile})),
+        ?_assertEqual(
+           {ok, #{[foo] =>
+                  #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))
+       ]}]}.
+
+use_unix_string_path_in_keep_while_cond_test_() ->
+    KeepWhile = #{"." => #if_child_list_length{count = {gt, 0}}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertEqual(
+           {ok, #{[foo] => #{}}},
+           khepri:put(
+             ?FUNCTION_NAME,
+             [foo],
+             khepri_payload:data(foo_value),
+             #{keep_while => KeepWhile})),
+        ?_assertEqual(
+           {ok, #{[foo] =>
+                  #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))
+       ]}]}.
+
+use_unix_binary_path_in_keep_while_cond_test_() ->
+    KeepWhile = #{<<".">> => #if_child_list_length{count = {gt, 0}}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertEqual(
+           {ok, #{[foo] => #{}}},
+           khepri:put(
+             ?FUNCTION_NAME,
+             [foo],
+             khepri_payload:data(foo_value),
+             #{keep_while => KeepWhile})),
+        ?_assertEqual(
+           {ok, #{[foo] =>
+                  #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))
+       ]}]}.
 
 use_an_invalid_path_test_() ->
     {setup,

--- a/test/transactions.erl
+++ b/test/transactions.erl
@@ -432,6 +432,72 @@ put_in_rw_transaction_test_() ->
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
+put_with_native_keep_while_cond_test_() ->
+    KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = {gt, 0}}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertEqual(
+           {atomic,
+            {ok, #{[foo] => #{}}}},
+           begin
+               Fun = fun() ->
+                             khepri_tx:put(
+                               [foo], value,
+                               #{keep_while => KeepWhile})
+                     end,
+               khepri:transaction(?FUNCTION_NAME, Fun, rw)
+           end),
+        ?_assertEqual(
+           {ok, #{[foo] =>
+                  #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))]}]}.
+
+put_with_unix_string_keep_while_cond_test_() ->
+    KeepWhile = #{"." => #if_child_list_length{count = {gt, 0}}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertEqual(
+           {atomic,
+            {ok, #{[foo] => #{}}}},
+           begin
+               Fun = fun() ->
+                             khepri_tx:put(
+                               [foo], value,
+                               #{keep_while => KeepWhile})
+                     end,
+               khepri:transaction(?FUNCTION_NAME, Fun, rw)
+           end),
+        ?_assertEqual(
+           {ok, #{[foo] =>
+                  #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))]}]}.
+
+put_with_unix_binary_keep_while_cond_test_() ->
+    KeepWhile = #{<<".">> => #if_child_list_length{count = {gt, 0}}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertEqual(
+           {atomic,
+            {ok, #{[foo] => #{}}}},
+           begin
+               Fun = fun() ->
+                             khepri_tx:put(
+                               [foo], value,
+                               #{keep_while => KeepWhile})
+                     end,
+               khepri:transaction(?FUNCTION_NAME, Fun, rw)
+           end),
+        ?_assertEqual(
+           {ok, #{[foo] =>
+                  #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))]}]}.
+
 create_in_ro_transaction_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,


### PR DESCRIPTION
Now the following `keep_while` conditions are equivalent:

```erlang
%% Using a native path.
khepri:put(
  StoreId, Path, Value,
  #{keep_while => #{[?THIS_NODE] => Condition}}).
```
```erlang
%% Using a Unix-like string path.
khepri:put(
  StoreId, Path, Value,
  #{keep_while => #{"." => Condition}}).
```
```erlang
%% Using a Unix-like binary path.
khepri:put(
  StoreId, Path, Value,
  #{keep_while => #{<<".">> => Condition}}).
```

There is a second commit which fixes the definition of the `keep_while` option in the `put()` family of functions. It was set to an internal structure of the state machine instead of `khepri_condition:keep_while()`. That internal structure type is made private again as a consequence.