### PR TITLE
khepri_conditions: Allow to specify conditions in `#if_data_matches{}`

### DIFF
--- a/include/khepri.hrl
+++ b/include/khepri.hrl
@@ -56,6 +56,7 @@
 
 -record(if_data_matches,
         {pattern = '_' :: ets:match_pattern(),
+         conditions = [] :: [any()],
          compiled = undefined :: ets:comp_match_spec() | undefined}).
 
 -record(if_node_exists,

--- a/test/conditions.erl
+++ b/test/conditions.erl
@@ -224,7 +224,32 @@ if_data_matches_matching_test() ->
     ?assertEqual(
        {false, CompiledCond2},
        khepri_condition:is_met(
-         CompiledCond2, foo, #node{payload = khepri_payload:data(other)})).
+         CompiledCond2, foo, #node{payload = khepri_payload:data(other)})),
+
+    CompiledCond3 = khepri_condition:compile(
+                      #if_data_matches{pattern = {a, '$1'},
+                                       conditions = [{is_integer, '$1'},
+                                                     {'>=', '$1', 10}]}),
+    ?assert(
+       khepri_condition:is_met(
+         CompiledCond3, foo, #{data => {a, 10}})),
+    ?assertEqual(
+       {false, CompiledCond3},
+       khepri_condition:is_met(
+         CompiledCond3, foo, #{})),
+    ?assertEqual(
+       {false, CompiledCond3},
+       khepri_condition:is_met(
+         CompiledCond3, foo, #{data => {a, 9}})),
+    ?assertEqual(
+       {false, CompiledCond3},
+       khepri_condition:is_met(
+         CompiledCond3, foo, #{data => {a, not_integer}})),
+    ?assertEqual(
+       {false, CompiledCond3},
+       khepri_condition:is_met(
+         CompiledCond3, foo, #{data => other})),
+    ok.
 
 if_payload_version_matching_test() ->
     ?assert(


### PR DESCRIPTION
In other words, the new `conditions` field of the `#if_data_matches{}` record can be used to set the `MatchCondition` field of the `{MatchHead, MatchCondition, MatchBody}` pattern matching structure.

Here is an example of a conditional pattern match:

```erlang
%% The data must be of the form `{age, Age}' and `Age' must be an
%% integer greater than or equal to 18.
#if_data_matches{pattern = {age, '$1'},
                 conditions = [{is_integer, '$1'},
                               {'>=', '$1', 18}]}.
```

Fixes #85.