### PR TITLE
Add Elixir sigils for `khepri_path:path/0`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,12 +6,18 @@ on:
 
 jobs:
   Test:
-    name: Test on Erlang/OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
+    name: Test on Erlang/OTP ${{ matrix.beam_versions.otp }}, Elixir ${{ matrix.beam_versions.elixir }} and ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        otp_version: [23, 24, '25.0-rc3']
+        beam_versions:
+          - otp: 23
+            elixir: '1.11.4'
+          - otp: 24
+            elixir: '1.13.4'
+          # - otp: '25.0-rc3'
+          #   elixir: '1.13.4'
         os: [ubuntu-latest, windows-latest]
 
     env:
@@ -22,12 +28,13 @@ jobs:
       - uses: erlef/setup-beam@v1
         id: install-erlang
         with:
-          otp-version: ${{matrix.otp_version}}
+          otp-version: ${{ matrix.beam_versions.otp }}
+          elixir-version: ${{ matrix.beam_versions.elixir }}
           rebar3-version: '3.18.0'
 
       - name: Restore Dialyzer PLT files from cache
         uses: actions/cache@v2
-        if: ${{ matrix.otp_version == env.RUN_DIALYZER_ON_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.beam_versions.otp == env.RUN_DIALYZER_ON_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
         with:
           path: _build/*/rebar3_*_plt
           key: dialyzer-plt-cache-${{ steps.install-erlang.outputs.otp-version }}-${{ runner.os }}-${{ hashFiles('rebar.config*') }}-v1
@@ -44,12 +51,17 @@ jobs:
       - name: Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Erlang/OTP ${{ matrix.otp_version }} on ${{ matrix.os }}
+          COVERALLS_FLAG_NAME: Erlang/OTP ${{ matrix.beam_versions.otp }} on ${{ matrix.os }}
         run: rebar3 as test coveralls send
 
       - name: Dialyzer
-        if: ${{ matrix.otp_version == env.RUN_DIALYZER_ON_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.beam_versions.otp == env.RUN_DIALYZER_ON_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
         run: rebar3 clean && rebar3 as test dialyzer
+
+      - name: Get Elixir dependencies
+        run: mix deps.get
+      - name: ExUnit
+        run: mix test
 
   Finish:
     name: Finishing

--- a/lib/khepri.ex
+++ b/lib/khepri.ex
@@ -1,0 +1,31 @@
+defmodule Khepri do
+  @moduledoc """
+  Elixir bindings for Khepri
+  """
+
+  @doc """
+  Creates a native path or pattern from a unix string
+
+  ## Examples
+
+      iex> ~p"/stock/wood/:oak"
+      ["stock", "wood", :oak]
+  """
+  def sigil_p(path, _opts) do
+    :khepri_path.from_string(path)
+  end
+
+  @doc """
+  Creates a native path or pattern at compile-time
+
+  ## Examples
+
+      iex> ~P"/stock/wood/:oak"
+      ["stock", "wood", :oak]
+  """
+  defmacro sigil_P({:<<>>, _meta, [path]}, _opts) do
+    path
+    |> :khepri_path.from_string()
+    |> Macro.escape()
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule Khepri.MixProject do
   defp deps() do
     [
       # Dependency pinning must be updated in rebar.config too.
-      {:ra, "2.0.4"}
+      {:ra, "2.0.9"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,10 @@ defmodule Khepri.MixProject do
     ]
   end
 
+  def application do
+    [extra_applications: [:elixir]]
+  end
+
   defp deps() do
     [
       # Dependency pinning must be updated in rebar.config too.

--- a/test/khepri_test.exs
+++ b/test/khepri_test.exs
@@ -1,0 +1,5 @@
+defmodule KhepriTest do
+  use ExUnit.Case, async: true
+  import Khepri
+  doctest Khepri
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
Similar to #98 and based on discussion in the [ErlangForums thread](https://erlangforums.com/t/khepri-a-tree-like-replicated-on-disk-database-library-for-erlang-and-elixir-introduction-feedbacks/438/44?u=the-mikedavis), this PR explores using Elixir macros in an Erlang dependency.

To be clear: I don't think this PR should be merged. As it turns out, it's pretty simple to do this in pure Erlang since sigils are either regular functions or Elixir macros:

```erl
sigil_p(Path, _Opts) ->
    from_string(Path).

sigil_P(Path, _Opts) ->
	from_string(Path).
```

```elixir
iex> import :khepri_path
iex> ~p"/stock/wood/:oak"
["stock", "wood", :oak]
iex> ~P"/stock/wood/:oak"
["stock", "wood", :oak]
```

(8e9483a has notes on the difference between lowercase and uppercase.) I'll follow up with a PR to add those two functions if you'd like 🙂

But this was a fun exploration into including Elixir files in Erlang dependencies without requiring that Erlang users install Elixir/Mix. The main pitfall I ran into is that documentation isn't combined for the Erlang API and the Elixir API: you would have to generate Erlang documentation separately from Elixir documentation. This could be an interesting issue to bring up in ex_doc.

Overall, I don't think Elixir-specific bindings are necessary to include in Khepri, but this could be a cool approach for an Erlang library that has an API based on parse-transforms: the corresponding Elixir modules could use Elixir macros instead.