### PR TITLE
mix.exs: Read application details from Rebar files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,19 +2,48 @@ defmodule Khepri.MixProject do
   use Mix.Project
 
   def project do
+    # To avoid duplication, we query the app file to learn the application
+    # name, description and version.
+    {:ok, [app]} = :file.consult("src/khepri.app.src")
+    {:application, app_name, props} = app
+
+    description = to_string(Keyword.get(props, :description))
+    version = to_string(Keyword.get(props, :vsn))
+
     [
-      app: :khepri,
-      description: "Tree-like replicated on-disk database library",
-      version: "0.3.0",
+      app: app_name,
+      description: description,
+      version: version,
       language: :erlang,
       deps: deps()
     ]
   end
 
   defp deps() do
-    [
-      # Dependency pinning must be updated in rebar.config too.
-      {:ra, "2.0.4"}
-    ]
+    # To avoid duplication, we query rebar.config to get the list of
+    # dependencies and their version pinning.
+    {:ok, terms} = :file.consult("rebar.config")
+    deps = Keyword.get(terms, :deps)
+
+    # The conversion to the mix.exs expected structure is basic, but that
+    # should do it for our needs.
+    for {app_name, version} <- deps do
+      case version do
+        _ when is_list(version) ->
+          {app_name, to_string(version)}
+
+        {:git, url} ->
+          {app_name, git: to_string(url)}
+
+        {:git, url, {:ref, ref}} ->
+          {app_name, git: to_string(url), ref: to_string(ref)}
+
+        {:git, url, {:branch, branch}} ->
+          {app_name, git: to_string(url), branch: to_string(branch)}
+
+        {:git, url, {:tag, tag}} ->
+          {app_name, git: to_string(url), tag: to_string(tag)}
+      end
+    end
   end
 end

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,6 @@
 %% vim:ft=erlang:
 {minimum_otp_vsn, "23.0"}.
 
-%% Dependency pinning must be updated in mix.exs too.
 {deps, [{ra, "2.0.9"}]}.
 
 {project_plugins, [rebar3_proper,

--- a/src/khepri.app.src
+++ b/src/khepri.app.src
@@ -3,7 +3,6 @@
  [{description, "Tree-like replicated on-disk database library"},
   %% In addition to below, the version needs to be updated in:
   %%   * README.md
-  %%   * mix.exs
   %%   * doc/overview.edoc
   %% Pay attention to links in particular.
   {vsn, "0.3.0"},


### PR DESCRIPTION
The information we need is:
* the application name
* its description
* its version
* its list of dependencies and their version pinning

Everything is available from `src/khepri.app.src` and `rebar.config`.

We do a very basic read of those files. In other words, we don't bother with Rebar profiles, `rebar.config.script` interpretation and so on. We expect a very straightforward list of dependencies, but that should be fine for our needs.

This should solve the problem of keeping `mix.exs` in sync. Indeed, this was triggered by the fact that Ra's version pinning in `mix.exs` was out-of-date for some time now.