### PR TITLE
khepri_fun: Extract literal funs in `move` instructions

### DIFF
--- a/src/khepri_fun.hrl
+++ b/src/khepri_fun.hrl
@@ -10,4 +10,5 @@
 -record(standalone_fun, {module :: module(),
                          beam :: binary(),
                          arity :: arity(),
+                         literal_funs :: [khepri_fun:standalone_fun()],
                          env :: list()}).

--- a/test/mod_used_for_transactions.erl
+++ b/test/mod_used_for_transactions.erl
@@ -13,7 +13,8 @@
          hash_term/1,
          crashing_fun/0,
          make_record/1,
-         outer_function/2]).
+         outer_function/2,
+         min/2]).
 
 exported() -> unexported().
 unexported() -> ok.
@@ -45,3 +46,6 @@ inner_function(#my_record{function = hash_term = Function}, Term) ->
     true;
 inner_function(_, _) ->
     false.
+
+min(A, B) ->
+    erlang:min(A, B).

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -497,7 +497,7 @@ apply_fun_to_args(Fun, Arg1, Arg2) ->
 allowed_higher_order_external_call_test() ->
     StandaloneFun = ?make_standalone_fun(
                         begin
-                            Fun = fun erlang:min/2,
+                            Fun = fun mod_used_for_transactions:min/2,
                             apply_fun_to_args(Fun, 1, 2)
                         end),
     ?assertMatch(#standalone_fun{}, StandaloneFun),


### PR DESCRIPTION
As part of the `call_fun2` instruction introduced in Erlang/OTP 25, it is apparently possible that the assembly references an anonymous function directly, instead of an MFA. Therefore, we need to follow and extract it like any anonymous functions in the environment.

The extraction is performed when we find such a `move` instruction. The instruction is then updated with a reference to the extracted standalone function. At the time we prepare the reference, that's ok if the module is unavailable in the code server.

When the standalone function is executed later, we simply load all modules stored in the new `literal_funs` list in the `#standalone_fun{}` record. At runtime, the references to those literal funs will be resolved successfully.

The `allowed_higher_order_external_call_test` testcase is modified to reference a function which should be extracted, unlike `erlang:min/2`.

References #19, #86.