### PR TITLE
Revisit the clustering code

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,10 +37,12 @@ jobs:
 
       - name: Xref
         run: rebar3 xref
-      - name: EUnit
+      - name: EUnit (unit tests)
         run: rebar3 eunit --verbose --cover
-      - name: PropEr
+      - name: PropEr (property tests)
         run: rebar3 proper --verbose --cover
+      - name: Common test (integration tests)
+        run: rebar3 ct --verbose --cover --sname ct
 
       - name: Dialyzer
         if: ${{ matrix.otp_version == env.RUN_DIALYZER_ON_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,10 @@ jobs:
       matrix:
         otp_version: [23, 24, 25]
         os: [ubuntu-latest, windows-latest]
+        exclude:
+          # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.
+          - otp_version: 24
+            os: windows-latest
 
     env:
       RUN_DIALYZER_ON_OTP_RELEASE: 25

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ khepri:start().
 ```
 
 The default Khepri store uses the default Ra system. Data is stored in the
-configured default Ra system data directory, which defaults to the current
-working directory.
+configured default Ra system data directory, which is `khepri#$NODENAME` in
+the current working directory.
 
 It is fine to get started and play with Khepri. However, it is recommended to
 configure your own Ra system and Ra cluster to select the directory where data

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -189,7 +189,7 @@ the first insert though.
 A Khepri store corresponds to one Ra cluster. In fact, the name of the Ra
 cluster is the name of the Khepri store. It is possible to have multiple
 database instances running on the same Erlang node or cluster by starting
-multiple Ra clusters. Note that it is called a "Ra cluster" but it can have a
+multiple Ra clusters. Note that it is called a "cluster" but it can have a
 single member.
 
 You can start a Khepri store using {@link start/0} up to {@link start/3}. See

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -192,10 +192,11 @@ database instances running on the same Erlang node or cluster by starting
 multiple Ra clusters. Note that it is called a "Ra cluster" but it can have a
 single member.
 
-By default, {@link khepri:start/0} starts a default store called `khepri',
-based on Ra's default system. You can start a simple store using {@link
-khepri:start/1}. To configure a cluster, you need to use {@link
-khepri_cluster} to add or remove members.
+You can start a Khepri store using {@link start/0} up to {@link start/3}. See
+those functions to learn more about the configuration settings.
+
+To expand or shrink a cluster, {@link khepri_cluster:join/1} and {@link
+khepri_cluster:reset/0} allow a Khepri store node to join or leave a cluster.
 
 == Khepri API ==
 

--- a/rebar.config
+++ b/rebar.config
@@ -50,8 +50,15 @@
 
 {profiles,
  [{test,
-   [{deps, [{proper, "1.4.0"}]},
-    {dialyzer, [{plt_extra_apps, [edoc,
+   [{deps, [{proper, "1.4.0"},
+            %% FIXME: We need to add `cth_readable' as a dependency and an
+            %% extra app for Dialyzer. That's because Rebar is using that
+            %% application to override `ct:pal()' and Dialyzer complains it
+            %% doesn't know this application.
+            cth_readable]},
+    {dialyzer, [{plt_extra_apps, [common_test,
+                                  cth_readable, %% <-- See comment above.
+                                  edoc,
                                   eunit,
                                   inets,
                                   mnesia,

--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -5,8 +5,8 @@
 %% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
+-define(DEFAULT_RA_SYSTEM_NAME, khepri).
 -define(DEFAULT_RA_CLUSTER_NAME, khepri).
--define(DEFAULT_RA_FRIENDLY_NAME, "Khepri datastore").
 
 -define(INIT_DATA_VERSION, 1).
 -define(INIT_CHILD_LIST_VERSION, 1).
@@ -26,6 +26,11 @@
 
 -define(IS_TIMEOUT(Timeout), (Timeout =:= infinity orelse
                               (is_integer(Timeout) andalso Timeout >= 0))).
+-define(HAS_TIME_LEFT(Timeout), (Timeout =:= infinity orelse Timeout > 0)).
+
+%% timer:sleep/1 time used as a retry interval when the local Ra server is
+%% unaware of a leader exit.
+-define(NOPROC_RETRY_INTERVAL, 200).
 
 -record(evf_tree, {path :: khepri_path:native_pattern(),
                    props = #{} :: khepri_evf:tree_event_filter_props()}).

--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -24,6 +24,9 @@
                                      is_record(Payload, p_data) orelse
                                      is_record(Payload, p_sproc))).
 
+-define(IS_TIMEOUT(Timeout), (Timeout =:= infinity orelse
+                              (is_integer(Timeout) andalso Timeout >= 0))).
+
 -record(evf_tree, {path :: khepri_path:native_pattern(),
                    props = #{} :: khepri_evf:tree_event_filter_props()}).
 %-record(evf_process, {pid :: pid(),

--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -6,7 +6,8 @@
 %%
 
 -define(DEFAULT_RA_SYSTEM_NAME, khepri).
--define(DEFAULT_RA_CLUSTER_NAME, khepri).
+-define(DEFAULT_STORE_ID, khepri).
+-define(IS_STORE_ID(StoreId), is_atom(StoreId)).
 
 -define(INIT_DATA_VERSION, 1).
 -define(INIT_CHILD_LIST_VERSION, 1).

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -31,8 +31,8 @@
 %%
 %% When a store is started, a store ID {@link store_id/0} is returned. This
 %% store ID is then used by the rest of this module's API. The returned store
-%% ID currently corresponds exactly to the Ra cluster name. Currently, it must
-%% be an atom; other types are unsupported.
+%% ID currently corresponds exactly to the Ra cluster name. It must be an atom
+%% though; other types are unsupported.
 %%
 %% == Interacting with the Khepri store ==
 %%
@@ -133,10 +133,7 @@
                            transaction/2, transaction/3]}).
 -endif.
 
-%% FIXME: The code currently expects that the Ra cluster name is an atom.
-%% However, Ra accepts binaries and strings as well. We should probably fix
-%% that at some point.
--type store_id() :: atom(). % ra:cluster_name().
+-type store_id() :: atom().
 %% ID of a Khepri store.
 %%
 %% This is the same as the Ra cluster name hosting the Khepri store.
@@ -276,7 +273,7 @@
 
 -export_type([store_id/0,
               ok/1,
-              error/0,
+              error/0, error/1,
 
               data/0,
               payload_version/0,
@@ -318,10 +315,10 @@ start() ->
 start(RaSystemOrDataDir) ->
     khepri_cluster:start(RaSystemOrDataDir).
 
--spec start(RaSystem | DataDir, ClusterName | RaServerConfig) -> Ret when
+-spec start(RaSystem | DataDir, StoreId | RaServerConfig) -> Ret when
       RaSystem :: atom(),
       DataDir :: file:filename_all(),
-      ClusterName :: ra:cluster_name(),
+      StoreId :: store_id(),
       RaServerConfig :: khepri_cluster:incomplete_ra_server_config(),
       Ret :: khepri:ok(StoreId) | khepri:error(),
       StoreId :: khepri:store_id().
@@ -329,14 +326,14 @@ start(RaSystemOrDataDir) ->
 %%
 %% @see khepri_cluster:start/2.
 
-start(RaSystemOrDataDir, ClusterNameOrRaServerConfig) ->
-    khepri_cluster:start(RaSystemOrDataDir, ClusterNameOrRaServerConfig).
+start(RaSystemOrDataDir, StoreIdOrRaServerConfig) ->
+    khepri_cluster:start(RaSystemOrDataDir, StoreIdOrRaServerConfig).
 
--spec start(RaSystem | DataDir, ClusterName | RaServerConfig, Timeout) ->
+-spec start(RaSystem | DataDir, StoreId | RaServerConfig, Timeout) ->
     Ret when
       RaSystem :: atom(),
       DataDir :: file:filename_all(),
-      ClusterName :: ra:cluster_name(),
+      StoreId :: store_id(),
       RaServerConfig :: khepri_cluster:incomplete_ra_server_config(),
       Timeout :: timeout(),
       Ret :: khepri:ok(StoreId) | khepri:error(),
@@ -345,9 +342,9 @@ start(RaSystemOrDataDir, ClusterNameOrRaServerConfig) ->
 %%
 %% @see khepri_cluster:start/3.
 
-start(RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout) ->
+start(RaSystemOrDataDir, StoreIdOrRaServerConfig, Timeout) ->
     khepri_cluster:start(
-      RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout).
+      RaSystemOrDataDir, StoreIdOrRaServerConfig, Timeout).
 
 -spec reset() -> Ret when
       Ret :: ok | error().
@@ -424,7 +421,7 @@ get_store_ids() ->
 %% @see put/3.
 
 put(PathPattern, Data) ->
-    put(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Data).
+    put(?DEFAULT_STORE_ID, PathPattern, Data).
 
 -spec put(StoreId, PathPattern, Data) -> Result when
       StoreId :: store_id(),
@@ -529,7 +526,7 @@ put(StoreId, PathPattern, Data, Options) ->
 %% Example:
 %% ```
 %% %% Insert a node at `/:foo/:bar', overwriting the previous value.
-%% Result = khepri:put(ra_cluster_name, [foo, bar], new_value),
+%% Result = khepri:put(StoreId, [foo, bar], new_value),
 %%
 %% %% Here is the content of `Result'.
 %% {ok, #{[foo, bar] => #{data => old_value,
@@ -538,7 +535,7 @@ put(StoreId, PathPattern, Data, Options) ->
 %%                        child_list_length => 0}}} = Result.
 %% '''
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the node to create or
 %%        modify.
 %% @param Data the Erlang term or function to store, or a {@link
@@ -567,7 +564,7 @@ put(StoreId, PathPattern, Data, Extra, Options) ->
 %% @see create/3.
 
 create(PathPattern, Data) ->
-    create(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Data).
+    create(?DEFAULT_STORE_ID, PathPattern, Data).
 
 -spec create(StoreId, PathPattern, Data) -> Result when
       StoreId :: store_id(),
@@ -621,7 +618,7 @@ create(StoreId, PathPattern, Data, Options) ->
 %% `#if_node_exists{exists = false}' condition on its last component.
 %% Otherwise, the behavior is that of {@link put/5}.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the node to create or
 %%        modify.
 %% @param Data the Erlang term or function to store, or a {@link
@@ -655,7 +652,7 @@ create(StoreId, PathPattern, Data, Extra, Options) ->
 %% @see update/3.
 
 update(PathPattern, Data) ->
-    update(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Data).
+    update(?DEFAULT_STORE_ID, PathPattern, Data).
 
 -spec update(StoreId, PathPattern, Data) -> Result when
       StoreId :: store_id(),
@@ -709,7 +706,7 @@ update(StoreId, PathPattern, Data, Options) ->
 %% `#if_node_exists{exists = true}' condition on its last component.
 %% Otherwise, the behavior is that of {@link put/5}.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the node to create or
 %%        modify.
 %% @param Data the Erlang term or function to store, or a {@link
@@ -744,7 +741,7 @@ update(StoreId, PathPattern, Data, Extra, Options) ->
 %% @see compare_and_swap/4.
 
 compare_and_swap(PathPattern, DataPattern, Data) ->
-    compare_and_swap(?DEFAULT_RA_CLUSTER_NAME, PathPattern, DataPattern, Data).
+    compare_and_swap(?DEFAULT_STORE_ID, PathPattern, DataPattern, Data).
 
 -spec compare_and_swap(StoreId, PathPattern, DataPattern, Data) -> Result when
       StoreId :: store_id(),
@@ -807,7 +804,7 @@ compare_and_swap(StoreId, PathPattern, DataPattern, Data, Options) ->
 %% `#if_data_matches{pattern = DataPattern}' condition on its last component.
 %% Otherwise, the behavior is that of {@link put/5}.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the node to create or
 %%        modify.
 %% @param Data the Erlang term or function to store, or a {@link
@@ -855,7 +852,7 @@ do_put(StoreId, PathPattern, Payload, Extra, Options) ->
 %% @see clear_payload/2.
 
 clear_payload(PathPattern) ->
-    clear_payload(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    clear_payload(?DEFAULT_STORE_ID, PathPattern).
 
 -spec clear_payload(StoreId, PathPattern) -> Result when
       StoreId :: store_id(),
@@ -902,7 +899,7 @@ clear_payload(StoreId, PathPattern, Options) ->
 %% In other words, the payload is set to {@link khepri_payload:no_payload()}.
 %% Otherwise, the behavior is that of {@link put/5}.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the node to create or
 %%        modify.
 %% @param Extra extra options such as `keep_while' conditions.
@@ -930,7 +927,7 @@ clear_payload(StoreId, PathPattern, Extra, Options) ->
 %% @see delete/2.
 
 delete(PathPattern) ->
-    delete(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    delete(?DEFAULT_STORE_ID, PathPattern).
 
 -spec delete
 (StoreId, PathPattern) -> Result when
@@ -957,7 +954,7 @@ delete(PathPattern) ->
 delete(StoreId, PathPattern) when is_atom(StoreId) ->
     delete(StoreId, PathPattern, #{});
 delete(PathPattern, Options) when is_map(Options) ->
-    delete(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    delete(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec delete(StoreId, PathPattern, Options) -> Result when
       StoreId :: store_id(),
@@ -977,7 +974,7 @@ delete(PathPattern, Options) when is_map(Options) ->
 %% Example:
 %% ```
 %% %% Delete the node at `/:foo/:bar'.
-%% Result = khepri:delete(ra_cluster_name, [foo, bar]),
+%% Result = khepri:delete(StoreId, [foo, bar]),
 %%
 %% %% Here is the content of `Result'.
 %% {ok, #{[foo, bar] => #{data => new_value,
@@ -986,7 +983,7 @@ delete(PathPattern, Options) when is_map(Options) ->
 %%                        child_list_length => 0}}} = Result.
 %% '''
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to delete.
 %% @param Options command options such as the command type.
 %%
@@ -1010,7 +1007,7 @@ delete(StoreId, PathPattern, Options) ->
 %% @see exists/2.
 
 exists(PathPattern) ->
-    exists(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    exists(?DEFAULT_STORE_ID, PathPattern).
 
 -spec exists
 (StoreId, PathPattern) -> Exists when
@@ -1037,7 +1034,7 @@ exists(PathPattern) ->
 exists(StoreId, PathPattern) when is_atom(StoreId) ->
     exists(StoreId, PathPattern, #{});
 exists(PathPattern, Options) when is_map(Options) ->
-    exists(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    exists(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec exists(StoreId, PathPattern, Options) -> Exists when
       StoreId :: store_id(),
@@ -1053,7 +1050,7 @@ exists(PathPattern, Options) when is_map(Options) ->
 %% The `PathPattern' must point to a specific tree node and can't match
 %% multiple nodes.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to check.
 %% @param Options query options such as `favor'.
 %%
@@ -1080,7 +1077,7 @@ exists(StoreId, PathPattern, Options) ->
 %% @see get/2.
 
 get(PathPattern) ->
-    get(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    get(?DEFAULT_STORE_ID, PathPattern).
 
 -spec get
 (StoreId, PathPattern) -> Result when
@@ -1106,7 +1103,7 @@ get(PathPattern) ->
 get(StoreId, PathPattern) when is_atom(StoreId) ->
     get(StoreId, PathPattern, #{});
 get(PathPattern, Options) when is_map(Options) ->
-    get(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    get(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec get(StoreId, PathPattern, Options) -> Result when
       StoreId :: store_id(),
@@ -1132,7 +1129,7 @@ get(PathPattern, Options) when is_map(Options) ->
 %% Example:
 %% ```
 %% %% Query the node at `/:foo/:bar'.
-%% Result = khepri:get(ra_cluster_name, [foo, bar]),
+%% Result = khepri:get(StoreId, [foo, bar]),
 %%
 %% %% Here is the content of `Result'.
 %% {ok, #{[foo, bar] => #{data => new_value,
@@ -1141,7 +1138,7 @@ get(PathPattern, Options) when is_map(Options) ->
 %%                        child_list_length => 0}}} = Result.
 %% '''
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to get.
 %% @param Options query options such as `favor'.
 %%
@@ -1162,7 +1159,7 @@ get(StoreId, PathPattern, Options) ->
 %% @see get_node_props/2.
 
 get_node_props(PathPattern) ->
-    get_node_props(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    get_node_props(?DEFAULT_STORE_ID, PathPattern).
 
 -spec get_node_props
 (StoreId, PathPattern) -> NodeProps when
@@ -1189,7 +1186,7 @@ get_node_props(PathPattern) ->
 get_node_props(StoreId, PathPattern) when is_atom(StoreId) ->
     get_node_props(StoreId, PathPattern, #{});
 get_node_props(PathPattern, Options) when is_map(Options) ->
-    get_node_props(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    get_node_props(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec get_node_props(StoreId, PathPattern, Options) -> NodeProps when
       StoreId :: store_id(),
@@ -1208,7 +1205,7 @@ get_node_props(PathPattern, Options) when is_map(Options) ->
 %% properties directly. If the node does not exist or if there are any errors,
 %% an exception is raised.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to check.
 %% @param Options query options such as `favor'.
 %%
@@ -1239,7 +1236,7 @@ get_node_props(StoreId, PathPattern, Options) ->
 %% @see has_data/2.
 
 has_data(PathPattern) ->
-    has_data(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    has_data(?DEFAULT_STORE_ID, PathPattern).
 
 -spec has_data
 (StoreId, PathPattern) -> HasData when
@@ -1266,7 +1263,7 @@ has_data(PathPattern) ->
 has_data(StoreId, PathPattern) when is_atom(StoreId) ->
     has_data(StoreId, PathPattern, #{});
 has_data(PathPattern, Options) when is_map(Options) ->
-    has_data(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    has_data(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec has_data(StoreId, PathPattern, Options) -> HasData when
       StoreId :: store_id(),
@@ -1282,7 +1279,7 @@ has_data(PathPattern, Options) when is_map(Options) ->
 %% The `PathPattern' must point to a specific tree node and can't match
 %% multiple nodes.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to check.
 %% @param Options query options such as `favor'.
 %%
@@ -1311,7 +1308,7 @@ has_data(StoreId, PathPattern, Options) ->
 %% @see get_data/2.
 
 get_data(PathPattern) ->
-    get_data(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    get_data(?DEFAULT_STORE_ID, PathPattern).
 
 -spec get_data
 (StoreId, PathPattern) -> Data when
@@ -1337,7 +1334,7 @@ get_data(PathPattern) ->
 get_data(StoreId, PathPattern) when is_atom(StoreId) ->
     get_data(StoreId, PathPattern, #{});
 get_data(PathPattern, Options) when is_map(Options) ->
-    get_data(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    get_data(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec get_data(StoreId, PathPattern, Options) -> Data when
       StoreId :: store_id(),
@@ -1360,7 +1357,7 @@ get_data(PathPattern, Options) when is_map(Options) ->
 %% <li>the node holds a stored procedure</li>
 %% </ul>
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to check.
 %% @param Options query options such as `favor'.
 %%
@@ -1389,7 +1386,7 @@ get_data(StoreId, PathPattern, Options) ->
 %% @see get_data_or/3.
 
 get_data_or(PathPattern, Default) ->
-    get_data_or(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Default).
+    get_data_or(?DEFAULT_STORE_ID, PathPattern, Default).
 
 -spec get_data_or
 (StoreId, PathPattern, Default) -> Data when
@@ -1419,7 +1416,7 @@ get_data_or(PathPattern, Default) ->
 get_data_or(StoreId, PathPattern, Default) when is_atom(StoreId) ->
     get_data_or(StoreId, PathPattern, Default, #{});
 get_data_or(PathPattern, Default, Options) when is_map(Options) ->
-    get_data_or(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Default, Options).
+    get_data_or(?DEFAULT_STORE_ID, PathPattern, Default, Options).
 
 -spec get_data_or(StoreId, PathPattern, Default, Options) -> Data when
       StoreId :: store_id(),
@@ -1443,7 +1440,7 @@ get_data_or(PathPattern, Default, Options) when is_map(Options) ->
 %% <li>the node holds a stored procedure</li>
 %% </ul>
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to check.
 %% @param Default the default term to return if there is no data.
 %% @param Options query options such as `favor'.
@@ -1477,7 +1474,7 @@ get_data_or(StoreId, PathPattern, Default, Options) ->
 %% @see has_sproc/2.
 
 has_sproc(PathPattern) ->
-    has_sproc(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    has_sproc(?DEFAULT_STORE_ID, PathPattern).
 
 -spec has_sproc
 (StoreId, PathPattern) -> HasStoredProc when
@@ -1504,7 +1501,7 @@ has_sproc(PathPattern) ->
 has_sproc(StoreId, PathPattern) when is_atom(StoreId) ->
     has_sproc(StoreId, PathPattern, #{});
 has_sproc(PathPattern, Options) when is_map(Options) ->
-    has_sproc(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    has_sproc(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec has_sproc(StoreId, PathPattern, Options) -> HasStoredProc when
       StoreId :: store_id(),
@@ -1520,7 +1517,7 @@ has_sproc(PathPattern, Options) when is_map(Options) ->
 %% The `PathPattern' must point to a specific tree node and can't match
 %% multiple nodes.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to check.
 %% @param Options query options such as `favor'.
 %%
@@ -1552,7 +1549,7 @@ has_sproc(StoreId, PathPattern, Options) ->
 %% @see run_sproc/3.
 
 run_sproc(PathPattern, Args) ->
-    run_sproc(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Args).
+    run_sproc(?DEFAULT_STORE_ID, PathPattern, Args).
 
 -spec run_sproc
 (StoreId, PathPattern, Args) -> Result when
@@ -1582,7 +1579,7 @@ run_sproc(PathPattern, Args) ->
 run_sproc(StoreId, PathPattern, Args) when is_atom(StoreId) ->
     run_sproc(StoreId, PathPattern, Args, #{});
 run_sproc(PathPattern, Args, Options) when is_map(Options) ->
-    run_sproc(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Args, Options).
+    run_sproc(?DEFAULT_STORE_ID, PathPattern, Args, Options).
 
 -spec run_sproc(StoreId, PathPattern, Args, Options) -> Result when
       StoreId :: store_id(),
@@ -1602,7 +1599,7 @@ run_sproc(PathPattern, Args, Options) when is_map(Options) ->
 %% The `Args' list must match the number of arguments expected by the stored
 %% procedure.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to check.
 %% @param Args the list of args to pass to the stored procedure; its length
 %%        must be equal to the stored procedure arity.
@@ -1626,7 +1623,7 @@ run_sproc(StoreId, PathPattern, Args, Options) ->
 %% @see count/2.
 
 count(PathPattern) ->
-    count(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    count(?DEFAULT_STORE_ID, PathPattern).
 
 -spec count
 (StoreId, PathPattern) -> Result when
@@ -1652,7 +1649,7 @@ count(PathPattern) ->
 count(StoreId, PathPattern) when is_atom(StoreId) ->
     count(StoreId, PathPattern, #{});
 count(PathPattern, Options) when is_map(Options) ->
-    count(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    count(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec count(StoreId, PathPattern, Options) -> Result when
       StoreId :: store_id(),
@@ -1672,13 +1669,13 @@ count(PathPattern, Options) when is_map(Options) ->
 %% Example:
 %% ```
 %% %% Query the node at `/:foo/:bar'.
-%% Result = khepri:count(ra_cluster_name, [foo, ?STAR]),
+%% Result = khepri:count(StoreId, [foo, ?STAR]),
 %%
 %% %% Here is the content of `Result'.
 %% {ok, 3} = Result.
 %% '''
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to count.
 %% @param Options query options such as `favor'.
 %%
@@ -1703,7 +1700,7 @@ count(StoreId, PathPattern, Options) ->
 
 register_trigger(TriggerId, EventFilter, StoredProcPath) ->
     register_trigger(
-      ?DEFAULT_RA_CLUSTER_NAME, TriggerId, EventFilter, StoredProcPath).
+      ?DEFAULT_STORE_ID, TriggerId, EventFilter, StoredProcPath).
 
 -spec register_trigger
 (StoreId, TriggerId, EventFilter, StoredProcPath) -> Ret when
@@ -1740,7 +1737,7 @@ register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath)
 register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
   when is_map(Options) ->
     register_trigger(
-      ?DEFAULT_RA_CLUSTER_NAME, TriggerId, EventFilter, StoredProcPath,
+      ?DEFAULT_STORE_ID, TriggerId, EventFilter, StoredProcPath,
       Options).
 
 -spec register_trigger(
@@ -1793,7 +1790,7 @@ register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
 %% if the Ra leader changes, therefore the stored procedure must be
 %% idempotent.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param TriggerId the name of the trigger.
 %% @param EventFilter the event filter used to associate an event with a
 %%        stored procedure.
@@ -1818,7 +1815,7 @@ register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options) ->
 %% @see list/2.
 
 list(PathPattern) ->
-    list(?DEFAULT_RA_CLUSTER_NAME, PathPattern).
+    list(?DEFAULT_STORE_ID, PathPattern).
 
 -spec list
 (StoreId, PathPattern) -> Result when
@@ -1844,7 +1841,7 @@ list(PathPattern) ->
 list(StoreId, PathPattern) when is_atom(StoreId) ->
     list(StoreId, PathPattern, #{});
 list(PathPattern, Options) when is_map(Options) ->
-    list(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Options).
+    list(?DEFAULT_STORE_ID, PathPattern, Options).
 
 -spec list(StoreId, PathPattern, Options) -> Result when
       StoreId :: store_id(),
@@ -1859,7 +1856,7 @@ list(PathPattern, Options) when is_map(Options) ->
 %% Internally, an `#if_name_matches{regex = any}' condition is appended to the
 %% `PathPattern'. Otherwise, the behavior is that of {@link get/3}.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path (or path pattern) to the nodes to get.
 %% @param Options query options such as `favor'.
 %%
@@ -1885,7 +1882,7 @@ list(StoreId, PathPattern, Options) ->
 %% @see find/3.
 
 find(PathPattern, Condition) ->
-    find(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Condition).
+    find(?DEFAULT_STORE_ID, PathPattern, Condition).
 
 -spec find
 (StoreId, PathPattern, Condition) -> Result when
@@ -1914,7 +1911,7 @@ find(PathPattern, Condition) ->
 find(StoreId, PathPattern, Condition) when is_atom(StoreId) ->
     find(StoreId, PathPattern, Condition, #{});
 find(PathPattern, Condition, Options) when is_map(Options) ->
-    find(?DEFAULT_RA_CLUSTER_NAME, PathPattern, Condition, Options).
+    find(?DEFAULT_STORE_ID, PathPattern, Condition, Options).
 
 -spec find(StoreId, PathPattern, Condition, Options) -> Result when
       StoreId :: store_id(),
@@ -1934,7 +1931,7 @@ find(PathPattern, Condition, Options) when is_map(Options) ->
 %% ```
 %% %% Find nodes with data under `/:foo/:bar'.
 %% Result = khepri:find(
-%%            ra_cluster_name,
+%%            StoreId,
 %%            [foo, bar],
 %%            #if_has_data{has_data = true}),
 %%
@@ -1949,7 +1946,7 @@ find(PathPattern, Condition, Options) when is_map(Options) ->
 %%                                          child_list_length => 0}}} = Result.
 %% '''
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param PathPattern the path indicating where to start the search from.
 %% @param Condition the condition nodes must match to be part of the result.
 %%
@@ -1975,7 +1972,7 @@ find(StoreId, PathPattern, Condition, Options) ->
 %% @see transaction/2.
 
 transaction(Fun) ->
-    transaction(?DEFAULT_RA_CLUSTER_NAME, Fun).
+    transaction(?DEFAULT_STORE_ID, Fun).
 
 -spec transaction
 (StoreId, Fun) -> Ret when
@@ -2009,7 +2006,7 @@ transaction(Fun) ->
 transaction(StoreId, Fun) when is_function(Fun) ->
     transaction(StoreId, Fun, auto);
 transaction(Fun, ReadWriteOrOptions) when is_function(Fun) ->
-    transaction(?DEFAULT_RA_CLUSTER_NAME, Fun, ReadWriteOrOptions).
+    transaction(?DEFAULT_STORE_ID, Fun, ReadWriteOrOptions).
 
 -spec transaction
 (StoreId, Fun, ReadWrite) -> Ret when
@@ -2061,7 +2058,7 @@ transaction(StoreId, Fun, Options)
 transaction(Fun, ReadWrite, Options)
   when is_atom(ReadWrite) andalso is_map(Options) ->
     transaction(
-      ?DEFAULT_RA_CLUSTER_NAME, Fun, ReadWrite, Options).
+      ?DEFAULT_STORE_ID, Fun, ReadWrite, Options).
 
 -spec transaction(StoreId, Fun, ReadWrite, Options) -> Ret when
       StoreId :: store_id(),
@@ -2107,7 +2104,7 @@ transaction(Fun, ReadWrite, Options)
 %% sent by message if the transaction is asynchronous and a correlation ID was
 %% specified.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param Fun an arbitrary anonymous function.
 %% @param ReadWrite the read/write or read-only nature of the transaction.
 %% @param Options command options such as the command type.
@@ -2131,7 +2128,7 @@ transaction(StoreId, Fun, ReadWrite, Options) ->
 %% @see clear_store/1.
 
 clear_store() ->
-    clear_store(?DEFAULT_RA_CLUSTER_NAME).
+    clear_store(?DEFAULT_STORE_ID).
 
 -spec clear_store
 (StoreId) -> Result when
@@ -2155,7 +2152,7 @@ clear_store() ->
 clear_store(StoreId) when is_atom(StoreId) ->
     clear_store(StoreId, #{});
 clear_store(Options) when is_map(Options) ->
-    clear_store(?DEFAULT_RA_CLUSTER_NAME, Options).
+    clear_store(?DEFAULT_STORE_ID, Options).
 
 -spec clear_store(StoreId, Options) -> Result when
       StoreId :: store_id(),
@@ -2165,7 +2162,7 @@ clear_store(Options) when is_map(Options) ->
 %%
 %% Note that the root node will remain unmodified however.
 %%
-%% @param StoreId the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 %% @param Options command options such as the command type.
 %%
 %% @returns in the case of a synchronous delete, an `{ok, Result}' tuple with
@@ -2203,7 +2200,7 @@ info() ->
       StoreId :: store_id().
 %% @doc Lists the content of specified store on <em>stdout</em>.
 %%
-%% @param StoreID the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 
 info(StoreId) ->
     info(StoreId, #{}).
@@ -2213,7 +2210,7 @@ info(StoreId) ->
       Options :: query_options().
 %% @doc Lists the content of specified store on <em>stdout</em>.
 %%
-%% @param StoreID the name of the Ra cluster.
+%% @param StoreId the name of the Khepri store.
 
 info(StoreId, Options) ->
     io:format("~n\033[1;32m== CLUSTER MEMBERS ==\033[0m~n~n", []),

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -15,9 +15,9 @@
 %% the API to use inside transaction functions is provided by {@link
 %% khepri_tx}.
 %%
-%% This module also provides functions to start and stop (in the future) a
-%% simple unclustered Khepri store. For more advanced setup and clustering,
-%% see {@link khepri_cluster}.
+%% This module also provides functions to start and stop a simple unclustered
+%% Khepri store. For more advanced setup and clustering, see {@link
+%% khepri_cluster}.
 %%
 %% == A Khepri store ==
 %%
@@ -69,12 +69,11 @@
 -include("src/internal.hrl").
 
 -export([
-         %% Functions to start & stop (in the future) a Khepri store; for more
+         %% Functions to start & stop a Khepri store; for more
          %% advanced functions, including clustering, see `khepri_cluster'.
-         start/0,
-         start/1,
-         start/3,
-         reset/2,
+         start/0, start/1, start/2, start/3,
+         reset/0, reset/1, reset/2,
+         stop/0, stop/1,
          get_store_ids/0,
 
          %% Simple direct atomic operations & queries.
@@ -118,7 +117,8 @@
 %% please Dialyzer. So for now, let's disable this specific check for the
 %% problematic functions.
 -if(?OTP_RELEASE >= 24).
--dialyzer({no_underspecs, [start/1, start/3,
+-dialyzer({no_underspecs, [start/1, start/2,
+                           stop/0, stop/1,
 
                            put/2, put/3,
                            create/2, create/3,
@@ -297,64 +297,107 @@
 %% -------------------------------------------------------------------
 
 -spec start() -> Ret when
-      Ret :: ok(StoreId) | error(),
-      StoreId :: store_id().
-%% @doc Starts a store on the default Ra system.
-%%
-%% The store uses the default Ra cluster name and cluster friendly name.
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @doc Starts a store.
 %%
 %% @see khepri_cluster:start/0.
 
 start() ->
     khepri_cluster:start().
 
--spec start(RaSystem) -> Ret when
+-spec start(RaSystem | DataDir) -> Ret when
       RaSystem :: atom(),
-      Ret :: ok(StoreId) | error(),
-      StoreId :: store_id().
-%% @doc Starts a store on the specified Ra system.
-%%
-%% The store uses the default Ra cluster name and cluster friendly name.
-%%
-%% @param RaSystem the name of the Ra system.
+      DataDir :: file:filename_all(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @doc Starts a store.
 %%
 %% @see khepri_cluster:start/1.
 
-start(RaSystem) ->
-    khepri_cluster:start(RaSystem).
+start(RaSystemOrDataDir) ->
+    khepri_cluster:start(RaSystemOrDataDir).
 
--spec start(RaSystem, ClusterName, FriendlyName) -> Ret when
+-spec start(RaSystem | DataDir, ClusterName | RaServerConfig) -> Ret when
       RaSystem :: atom(),
+      DataDir :: file:filename_all(),
       ClusterName :: ra:cluster_name(),
-      FriendlyName :: string(),
-      Ret :: ok(StoreId) | error(),
-      StoreId :: store_id().
-%% @doc Starts a store on the specified Ra system.
+      RaServerConfig :: khepri_cluster:incomplete_ra_server_config(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @doc Starts a store.
 %%
-%% @param RaSystem the name of the Ra system.
-%% @param ClusterName the name of the Ra cluster.
-%% @param FriendlyName the friendly name of the Ra cluster.
+%% @see khepri_cluster:start/2.
+
+start(RaSystemOrDataDir, ClusterNameOrRaServerConfig) ->
+    khepri_cluster:start(RaSystemOrDataDir, ClusterNameOrRaServerConfig).
+
+-spec start(RaSystem | DataDir, ClusterName | RaServerConfig, Timeout) ->
+    Ret when
+      RaSystem :: atom(),
+      DataDir :: file:filename_all(),
+      ClusterName :: ra:cluster_name(),
+      RaServerConfig :: khepri_cluster:incomplete_ra_server_config(),
+      Timeout :: timeout(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @doc Starts a store.
 %%
 %% @see khepri_cluster:start/3.
 
-start(RaSystem, ClusterName, FriendlyName) ->
-    khepri_cluster:start(RaSystem, ClusterName, FriendlyName).
+start(RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout) ->
+    khepri_cluster:start(
+      RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout).
 
--spec reset(RaSystem, ClusterName) -> Ret when
-      RaSystem :: atom(),
-      ClusterName :: ra:cluster_name(),
-      Ret :: ok | error() | {badrpc, any()}.
+-spec reset() -> Ret when
+      Ret :: ok | error().
 %% @doc Resets the store on this Erlang node.
 %%
-%% It does that by force-deleting the Ra local server.
+%% @see khepri_cluster:reset/0.
+
+reset() ->
+    khepri_cluster:reset().
+
+-spec reset(StoreId | Timeout) -> Ret when
+      StoreId :: khepri:store_id(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @doc Resets the store on this Erlang node.
 %%
-%% @param RaSystem the name of the Ra system.
-%% @param ClusterName the name of the Ra cluster.
+%% @see khepri_cluster:reset/1.
+
+reset(StoreIdOrTimeout) ->
+    khepri_cluster:reset(StoreIdOrTimeout).
+
+-spec reset(StoreId, Timeout) -> Ret when
+      StoreId :: khepri:store_id(),
+      Timeout :: timeout(),
+      Ret :: ok | error().
+%% @doc Resets the store on this Erlang node.
 %%
 %% @see khepri_cluster:reset/2.
 
-reset(RaSystem, ClusterName) ->
-    khepri_cluster:reset(RaSystem, ClusterName).
+reset(StoreId, Timeout) ->
+    khepri_cluster:reset(StoreId, Timeout).
+
+-spec stop() -> Ret when
+      Ret :: ok | khepri:error().
+%% @doc Stops a store.
+%%
+%% @see khepri_cluster:stop/0.
+
+stop() ->
+    khepri_cluster:stop().
+
+-spec stop(StoreId) -> Ret when
+      StoreId :: khepri:store_id(),
+      Ret :: ok | khepri:error().
+%% @doc Stops a store.
+%%
+%% @see khepri_cluster:stop/1.
+
+stop(StoreId) ->
+    khepri_cluster:stop(StoreId).
 
 -spec get_store_ids() -> [StoreId] when
       StoreId :: store_id().

--- a/src/khepri_app.erl
+++ b/src/khepri_app.erl
@@ -27,9 +27,8 @@ start(normal, []) ->
 stop(_) ->
     StoreIds = khepri:get_store_ids(),
     lists:foreach(
-      fun(StoreId) -> khepri_machine:clear_cache(StoreId) end,
+      fun(StoreId) -> _ = khepri_cluster:stop(StoreId) end,
       StoreIds),
-    khepri_cluster:forget_store_ids(),
     ok.
 
 config_change(_Changed, _New, _Removed) ->

--- a/src/khepri_app.erl
+++ b/src/khepri_app.erl
@@ -10,6 +10,13 @@
 -module(khepri_app).
 -behaviour(application).
 
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("src/internal.hrl").
+
+-export([get_default_timeout/0]).
+
 -export([start/2,
          stop/1,
          config_change/3]).
@@ -27,3 +34,17 @@ stop(_) ->
 
 config_change(_Changed, _New, _Removed) ->
     ok.
+
+get_default_timeout() ->
+    Timeout = application:get_env(khepri, default_timeout, infinity),
+    if
+        ?IS_TIMEOUT(Timeout) ->
+            ok;
+        true ->
+            ?LOG_ERROR(
+               "Invalid timeout set in `default_timeout` "
+               "application environment: ~p",
+               [Timeout]),
+            throw({invalid_timeout, Timeout})
+    end,
+    Timeout.

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -9,99 +9,154 @@
 %%
 %% This module provides the public API for the service and cluster management.
 %% For convenience, some functions of this API are repeated in the {@link
-%% khepri} module.
+%% khepri} module for easier access.
 %%
-%% == Starting a Ra system ==
+%% == The Khepri store and the Ra cluster ==
 %%
-%% The default store is based on Ra's default system. You need to change the
-%% Ra application configuration if you want to set settings. That said, it is
-%% recommended to start your own Ra system. This way, even though Ra is
-%% already running, you can choose where the Khepri data should be stored.
-%% This is also required if you need to run multiple database instances in
-%% parallel.
+%% A Khepri store is a Ra server inside a Ra cluster. The Khepri store and the
+%% Ra cluster share the same name in fact. The only constraint is that the name
+%% must be an atom, even though Ra accepts other Erlang types as cluster names.
 %%
-%% Here is a quick start example:
+%% By default, Khepri uses `khepri' as the store ID (and thus Ra cluster name).
+%% This default can be overridden using an argument to the `start()' functions
+%% or the `default_ra_cluster_name' application environment variable.
+%%
+%% Examples:
+%% <ul>
+%% <li>Use the default Khepri store ID:
+%% <pre>{ok, khepri} = khepri:start().</pre></li>
+%% <li>Override the default store ID using an argument:
+%% <pre>{ok, my_store} = khepri:start("/var/lib/khepri", my_store).</pre></li>
+%% <li>Override the default store ID using an application environment variable:
+%% <pre>ok = application:set_env(
+%%        khepri, default_ra_cluster_name, my_store, [{persistent, true}]),
+%%
+%% {ok, my_store} = khepri:start("/var/lib/khepri", my_store).</pre></li>
+%% </ul>
+%%
+%% == The data directory and the Ra system ==
+%%
+%% A Ra server relies on a Ra system to provide various functions and to
+%% configure the directory where the data should be stored on disk.
+%%
+%% By default, Khepri will configure its own Ra system to write data under
+%% `khepri#Nodename' in the current working directory, where `Nodename' is
+%% the name of the Erlang node.
 %%
 %% ```
-%% %% We start Khepri. Ra is also started because Khepri depends on it.
-%% {ok, _} = application:ensure_all_started(khepri),
+%% {ok, StoreId} = khepri:start().
 %%
-%% %% We define the configuration of the Ra system for our database. Here, we
-%% %% only care about the directory where data will be written.
-%% RaSystem = my_ra_system,
-%% RaSystemDataDir = "/path/to/storage/dir",
-%% DefaultSystemConfig = ra_system:default_config(),
-%% RaSystemConfig = DefaultSystemConfig#{name => RaSystem,
-%%                                       data_dir => RaSystemDataDir,
-%%                                       wal_data_dir => RaSystemDataDir,
-%%                                       names => ra_system:derive_names(
-%%                                                  RaSystem)},
-%%
-%% %% The configuration is ready, let's start the Ra system.
-%% {ok, _RaSystemPid} = ra_system:start(RaSystemConfig),
-%%
-%% %% At last we can start Khepri! We need to choose a name for the Ra cluster
-%% %% running in the Ra system started above. This must be an atom.
-%% RaClusterName = my_khepri_db,
-%% RaClusterFriendlyName = "My Khepri DB",
-%% {ok, StoreId} = khepri:start(
-%%                   RaSystem,
-%%                   RaClusterName,
-%%                   RaClusterFriendlyName),
-%%
-%% %% The Ra cluster name is our <em>store ID</em> used everywhere in the
-%% Khepri API.
-%% khepri:insert(StoreId, [stock, wood], 156).
+%% %% If the Erlang node was started without distribution (the default), the
+%% %% statement above will start a Ra system called like the store (`khepri')
+%% %% and will use the `khepri#nonode@nohost' directory.
 %% '''
+%%
+%% The default data directory or Ra system name can be overridden using an
+%% argument to the `start()' or the `default_ra_system' application environment
+%% variable. Both a directory (string or binary) or the name of an already
+%% running Ra system are accepted.
+%%
+%% Examples:
+%% <ul>
+%% <li>Override the default with the name of a running Ra system using an
+%% argument:
+%% <pre>{ok, StoreId} = khepri:start(my_ra_system).</pre></li>
+%% <li>Override the default data directory using an application environment
+%% variable:
+%% <pre>ok = application:set_env(
+%%        khepri, default_ra_system, "/var/lib/khepri", [{persistent, true}]),
+%%
+%% {ok, StoreId} = khepri:start().</pre></li>
+%% </ul>
 %%
 %% Please refer to <a href="https://github.com/rabbitmq/ra">Ra
 %% documentation</a> to learn more about Ra systems and Ra clusters.
 %%
 %% == Managing Ra cluster members ==
 %%
-%% To add a member to your Ra cluster:
+%% A Khepri/Ra cluster can be expanded by telling a node to join a remote
+%% cluster. Node that the Khepri store/Ra server to add to the cluster must run
+%% before it can join.
 %%
 %% ```
-%% khepri_cluster:add_member(
-%%   RaSystem,
-%%   RaClusterName,
-%%   RaClusterFriendlyName,
-%%   NewMemberErlangNodename).
+%% %% Start the local Khepri store.
+%% {ok, StoreId} = khepri:start().
+%%
+%% %% Join a remote cluster.
+%% ok = khepri_cluster:join(RemoteNode).
 %% '''
 %%
-%% To remove a member from your Ra cluster:
+%% To remove the local Khepri store node from the cluster, it must be reset.
 %%
 %% ```
-%% khepri_cluster:remove_member(
-%%   RaClusterName,
-%%   MemberErlangNodenameToRemove).
+%% %% Start the local Khepri store.
+%% ok = khepri_cluster:reset().
 %% '''
 
 -module(khepri_cluster).
 
 -include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -include("include/khepri.hrl").
 -include("src/internal.hrl").
 
--export([start/0,
-         start/1,
-         start/3,
-         add_member/2,
-         add_member/4,
-         remove_member/1,
-         remove_member/2,
-         reset/2,
-         members/1,
-         locally_known_members/1,
+-export([start/0, start/1, start/2, start/3,
+         join/1, join/2,
+         reset/0, reset/1, reset/2,
+         stop/0, stop/1,
+         members/1, members/2,
+         locally_known_members/1, locally_known_members/2,
          nodes/1,
          locally_known_nodes/1,
-         get_store_ids/0,
-         forget_store_ids/0]).
+         get_default_ra_system_or_data_dir/0,
+         get_default_ra_cluster_name/0,
+         get_store_ids/0]).
+
+%% Internal.
+-export([node_to_member/2,
+         wait_for_cluster_readyness/2,
+         get_cached_leader/1,
+         cache_leader/2,
+         cache_leader_if_changed/3,
+         clear_cached_leader/1]).
+
+-ifdef(TEST).
+-export([wait_for_ra_server_exit/1,
+         generate_default_data_dir/0]).
+-endif.
 
 -if(?OTP_RELEASE >= 24).
--dialyzer({no_underspecs, [start/1]}).
+-dialyzer({no_underspecs, [start/1,
+                           stop/0, stop/1,
+                           stop_locked/1,
+                           join/2,
+                           wait_for_remote_cluster_readyness/3]}).
 -endif.
+
+-define(IS_RA_SYSTEM(RaSystem), is_atom(RaSystem)).
+-define(IS_DATA_DIR(DataDir), (is_list(DataDir) orelse is_binary(DataDir))).
+-define(IS_CLUSTER_NAME(ClusterName), is_atom(ClusterName)).
+
+-type incomplete_ra_server_config() :: map().
+%% A Ra server config map.
+%%
+%% This configuration map can lack the required parameters, Khepri will fill
+%% them if necessary. Important parameters for Khepri (e.g. `machine') will be
+%% overriden anyway.
+%%
+%% @see ra_server:ra_server_config/0.
+
+-type ra_server_config_with_cluster_name() :: #{cluster_name :=
+                                                khepri:store_id()}.
+%% Intermediate Ra server configuration with `cluster_name' set.
+
+-type ra_server_config_with_id_and_cn() :: #{id := ra:server_id(),
+                                             cluster_name :=
+                                             khepri:store_id()}.
+%% Intermediate Ra server configuration with `id' and `cluster_name' set.
+
+-export_type([incomplete_ra_server_config/0]).
 
 %% -------------------------------------------------------------------
 %% Database management.
@@ -110,55 +165,562 @@
 -spec start() -> Ret when
       Ret :: khepri:ok(StoreId) | khepri:error(),
       StoreId :: khepri:store_id().
-%% @doc Starts a store on the default Ra system.
+%% @doc Starts a store.
 %%
-%% The store uses the default Ra cluster name and cluster friendly name.
+%% Calling this function is the same as calling `start(DefaultRaSystem)' where
+%% `DefaultRaSystem' is returned by {@link
+%% get_default_ra_system_or_data_dir/0}.
+%%
+%% @see start/1.
 
 start() ->
-    case application:ensure_all_started(ra) of
+    case application:ensure_all_started(khepri) of
         {ok, _} ->
-            RaSystem = default,
-            case ra_system:start_default() of
-                {ok, _}                       -> start(RaSystem);
-                {error, {already_started, _}} -> start(RaSystem);
-                {error, _} = Error            -> Error
-            end;
-        {error, _} = Error ->
+            RaSystemOrDataDir = get_default_ra_system_or_data_dir(),
+            start(RaSystemOrDataDir);
+        Error ->
             Error
     end.
 
--spec start(RaSystem) -> Ret when
+-spec start(RaSystem | DataDir) -> Ret when
       RaSystem :: atom(),
+      DataDir :: file:filename_all(),
       Ret :: khepri:ok(StoreId) | khepri:error(),
       StoreId :: khepri:store_id().
-%% @doc Starts a store on the specified Ra system.
+%% @doc Starts a store.
 %%
-%% The store uses the default Ra cluster name and cluster friendly name.
+%% Calling this function is the same as calling `start(RaSystemOrDataDir,
+%% DefaultClusterName)' where `DefaultClusterName' is returned by {@link
+%% get_default_ra_cluster_name/0}.
 %%
-%% @param RaSystem the name of the Ra system.
+%% @see start/2.
 
-start(RaSystem) ->
-    start(RaSystem, ?DEFAULT_RA_CLUSTER_NAME, ?DEFAULT_RA_FRIENDLY_NAME).
-
--spec start(RaSystem, ClusterName, FriendlyName) -> Ret when
-      RaSystem :: atom(),
-      ClusterName :: ra:cluster_name(),
-      FriendlyName :: string(),
-      Ret :: khepri:ok(StoreId) | khepri:error(),
-      StoreId :: khepri:store_id().
-%% @doc Starts a store on the specified Ra system.
-%%
-%% @param RaSystem the name of the Ra system.
-%% @param ClusterName the name of the Ra cluster.
-%% @param FriendlyName the friendly name of the Ra cluster.
-
-start(RaSystem, ClusterName, FriendlyName) ->
+start(RaSystemOrDataDir) ->
     case application:ensure_all_started(khepri) of
         {ok, _} ->
-            case ensure_started(RaSystem, ClusterName, FriendlyName) of
+            ClusterName = get_default_ra_cluster_name(),
+            start(RaSystemOrDataDir, ClusterName);
+        Error ->
+            Error
+    end.
+
+-spec start(RaSystem | DataDir, ClusterName | RaServerConfig) -> Ret when
+      RaSystem :: atom(),
+      DataDir :: file:filename_all(),
+      ClusterName :: ra:cluster_name(),
+      RaServerConfig :: incomplete_ra_server_config(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @doc Starts a store.
+%%
+%% Calling this function is the same as calling `start(RaSystemOrDataDir,
+%% ClusterNameOrRaServerConfig, DefaultTimeout)' where `DefaultTimeout' is
+%% returned by {@link khepri_app:get_default_timeout/0}.
+%%
+%% @param RaSystem the name of the Ra system.
+%% @param DataDir a directory to write data.
+%% @param ClusterName the name of the Ra cluster.
+%% @param RaServerConfig the skeleton of each Ra server's configuration
+%%
+%% @see start/3.
+
+start(RaSystemOrDataDir, ClusterNameOrRaServerConfig) ->
+    %% FIXME: We force the cluster name to be an atom().
+    Timeout = khepri_app:get_default_timeout(),
+    start(RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout).
+
+-spec start(RaSystem | DataDir, ClusterName | RaServerConfig, Timeout) ->
+    Ret when
+      RaSystem :: atom(),
+      DataDir :: file:filename_all(),
+      ClusterName :: ra:cluster_name(),
+      RaServerConfig :: incomplete_ra_server_config(),
+      Timeout :: timeout(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @doc Starts a store.
+%%
+%% It accepts either a Ra system name (atom) or a data directory (string or
+%% binary) as its first argument. If a Ra system name is given, that Ra system
+%% must be running when this function is called. If a data directory is given,
+%% a new Ra system will be started, using this directory. The directory will
+%% be created automatically if it doesn't exist. The Ra system will use the
+%% same name as the Khepri store.
+%%
+%% It accepts a Ra cluster name or a Ra server configuration as its second
+%% argument. If a cluster name is given, a Ra server configuration will be
+%% created based on it. If a Ra server configuration is given, the name of the
+%% Khepri store will be derived from it.
+%%
+%% If this is a new store, the Ra server is started and an election is
+%% triggered so that it becomes its own leader and is ready to process
+%% commands and queries.
+%%
+%% If the store was started in the past and stopped, it will be restarted. In
+%% this case, `RaServerConfig' will be ignored. Ra will take care of the
+%% eletion automatically.
+%%
+%% @param RaSystem the name of the Ra system.
+%% @param DataDir a directory to write data.
+%% @param ClusterName the name of the Ra cluster.
+%% @param RaServerConfig the skeleton of each Ra server's configuration
+%% @param TImeout a timeout.
+%%
+%% @returns the ID of the started store in an "ok" tuple, or an error tuple if
+%% the store couldn't be started.
+
+start(RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout) ->
+    case application:ensure_all_started(khepri) of
+        {ok, _} ->
+            ensure_ra_server_config_and_start(
+              RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout);
+        Error ->
+            Error
+    end.
+
+-spec ensure_ra_server_config_and_start(
+        RaSystem | DataDir, ClusterName | RaServerConfig, Timeout) ->
+    Ret when
+      RaSystem :: atom(),
+      DataDir :: file:filename_all(),
+      ClusterName :: ra:cluster_name(),
+      RaServerConfig :: incomplete_ra_server_config(),
+      Timeout :: timeout(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @private
+
+ensure_ra_server_config_and_start(
+  RaSystemOrDataDir, ClusterNameOrRaServerConfig, Timeout)
+  when (?IS_DATA_DIR(RaSystemOrDataDir) orelse
+        ?IS_RA_SYSTEM(RaSystemOrDataDir)) andalso
+       (?IS_CLUSTER_NAME(ClusterNameOrRaServerConfig) orelse
+        is_map(ClusterNameOrRaServerConfig)) ->
+    %% If `cluster_name' in `ClusterNameOrRaServerConfig' is not an atom, it
+    %% will cause a cause clause exception below.
+    RaServerConfig =
+    case ClusterNameOrRaServerConfig of
+        _ when ?IS_CLUSTER_NAME(ClusterNameOrRaServerConfig) ->
+            #{cluster_name => ClusterNameOrRaServerConfig};
+        #{cluster_name := CN} when ?IS_CLUSTER_NAME(CN) ->
+            ClusterNameOrRaServerConfig;
+        #{} when not is_map_key(cluster_name, ClusterNameOrRaServerConfig) ->
+            ClusterNameOrRaServerConfig#{
+              cluster_name => get_default_ra_cluster_name()
+             }
+    end,
+    verify_ra_system_and_start(RaSystemOrDataDir, RaServerConfig, Timeout).
+
+-spec verify_ra_system_and_start(
+        RaSystem | DataDir, RaServerConfig, Timeout) ->
+    Ret when
+      RaSystem :: atom(),
+      DataDir :: file:filename_all(),
+      RaServerConfig :: ra_server_config_with_cluster_name(),
+      Timeout :: timeout(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @private
+
+verify_ra_system_and_start(RaSystem, RaServerConfig, Timeout)
+  when ?IS_RA_SYSTEM(RaSystem) ->
+    ensure_server_started(RaSystem, RaServerConfig, Timeout);
+verify_ra_system_and_start(DataDir, RaServerConfig, Timeout)
+  when is_list(DataDir) ->
+    RaSystem = ?DEFAULT_RA_SYSTEM_NAME,
+    DefaultConfig = ra_system:default_config(),
+    RaSystemConfig = DefaultConfig#{name => RaSystem,
+                                    data_dir => DataDir,
+                                    wal_data_dir => DataDir,
+                                    names => ra_system:derive_names(RaSystem)},
+    ?LOG_DEBUG(
+       "Starting Ra system \"~s\" using data dir \"~ts\"",
+       [RaSystem, DataDir]),
+    case ra_system:start(RaSystemConfig) of
+        {ok, _} ->
+            ensure_server_started(RaSystem, RaServerConfig, Timeout);
+        {error, {already_started, _}} ->
+            ensure_server_started(RaSystem, RaServerConfig, Timeout);
+        Error ->
+            Error
+    end;
+verify_ra_system_and_start(DataDir, RaServerConfig, Timeout)
+  when is_binary(DataDir) ->
+    DataDir1 = unicode:characters_to_list(DataDir),
+    verify_ra_system_and_start(DataDir1, RaServerConfig, Timeout).
+
+-spec ensure_server_started(RaSystem, RaServerConfig, Timeout) -> Ret when
+      RaSystem :: atom(),
+      RaServerConfig :: ra_server_config_with_cluster_name(),
+      Timeout :: timeout(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @private
+
+ensure_server_started(
+  RaSystem, #{cluster_name := ClusterName} = RaServerConfig, Timeout) ->
+    Lock = server_start_lock(ClusterName),
+    global:set_lock(Lock),
+    try
+        Ret = ensure_server_started_locked(RaSystem, RaServerConfig, Timeout),
+        global:del_lock(Lock),
+        Ret
+    catch
+        Class:Reason:Stacktrace ->
+            global:del_lock(Lock),
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
+
+-spec ensure_server_started_locked(RaSystem, RaServerConfig, Timeout) ->
+    Ret when
+      RaSystem :: atom(),
+      RaServerConfig :: ra_server_config_with_cluster_name(),
+      Timeout :: timeout(),
+      Ret :: khepri:ok(StoreId) | khepri:error(),
+      StoreId :: khepri:store_id().
+%% @private
+
+ensure_server_started_locked(
+  RaSystem, #{cluster_name := ClusterName} = RaServerConfig, Timeout) ->
+    ThisNode = node(),
+    ThisMember = node_to_member(ClusterName, ThisNode),
+    ?LOG_DEBUG(
+       "Trying to restart local Ra server for cluster \"~s\" "
+       "in Ra system \"~s\"",
+       [ClusterName, RaSystem]),
+    case ra:restart_server(RaSystem, ThisMember) of
+        {error, name_not_registered} ->
+            ?LOG_DEBUG(
+               "Ra server for cluster \"~s\" not registered in Ra system "
+               "\"~s\", try to start a new one",
+               [ClusterName, RaSystem]),
+            RaServerConfig1 = RaServerConfig#{id => ThisMember},
+            case do_start_server(RaSystem, RaServerConfig1) of
                 ok ->
-                    ok = remember_store_id(ClusterName),
+                    ok = trigger_election(RaServerConfig1, Timeout),
                     {ok, ClusterName};
+                Error ->
+                    Error
+            end;
+        ok ->
+            ok = remember_store(RaSystem, RaServerConfig),
+            {ok, ClusterName};
+        {error, {already_started, _}} ->
+            {ok, ClusterName};
+        Error ->
+            Error
+    end.
+
+-spec do_start_server(RaSystem, RaServerConfig) -> Ret when
+      RaSystem :: atom(),
+      RaServerConfig :: ra_server_config_with_id_and_cn(),
+      Ret :: ok | khepri:error().
+%% @private
+
+do_start_server(RaSystem, RaServerConfig) ->
+    RaServerConfig1 = complete_ra_server_config(RaServerConfig),
+    #{cluster_name := ClusterName} = RaServerConfig1,
+    ?LOG_DEBUG(
+       "Starting a Ra server with the following configuration:~n~p",
+       [RaServerConfig1]),
+    case ra:start_server(RaSystem, RaServerConfig1) of
+        ok ->
+            ok = remember_store(RaSystem, RaServerConfig1),
+            ?LOG_DEBUG(
+               "Started Ra server for cluster \"~s\"",
+               [ClusterName]),
+            ok;
+        {error, _} = Error ->
+            ?LOG_ERROR(
+               "Failed to start Ra server for cluster \"~s\" using the "
+               "following Ra server configuration:~n~p",
+               [ClusterName, RaServerConfig1]),
+            Error
+    end.
+
+-spec trigger_election(Member | RaServerConfig, Timeout) -> ok when
+      Member :: ra:server_id(),
+      RaServerConfig :: ra_server_config_with_id_and_cn(),
+      Timeout :: timeout().
+%% @private
+
+trigger_election(#{id := Member}, Timeout) ->
+    trigger_election(Member, Timeout);
+trigger_election({ClusterName, _Node} = Member, Timeout) ->
+    ?LOG_DEBUG("Trigger election in store \"~s\"", [ClusterName]),
+    ok = ra:trigger_election(Member, Timeout),
+    ok.
+
+-spec stop() -> Ret when
+      Ret :: ok | khepri:error().
+%% @doc Stops a store.
+%%
+%% Calling this function is the same as calling `stop(DefaultClusterName)'
+%% where `DefaultClusterName' is returned by {@link
+%% get_default_ra_cluster_name/0}.
+%%
+%% @see stop/1.
+
+stop() ->
+    ClusterName = get_default_ra_cluster_name(),
+    stop(ClusterName).
+
+-spec stop(StoreId) -> Ret when
+      StoreId :: khepri:store_id(),
+      Ret :: ok | khepri:error().
+%% @doc Stops a store.
+%%
+%% @param StoreId the ID of the store to stop.
+%%
+%% @returns `ok' if it succeeds, an error tuple otherwise.
+
+stop(StoreId) ->
+    Lock = server_start_lock(StoreId),
+    global:set_lock(Lock),
+    try
+        Ret = stop_locked(StoreId),
+        global:del_lock(Lock),
+        Ret
+    catch
+        Class:Reason:Stacktrace ->
+            global:del_lock(Lock),
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
+
+-spec stop_locked(StoreId) -> Ret when
+      StoreId :: khepri:store_id(),
+      Ret :: ok | khepri:error().
+
+stop_locked(StoreId) ->
+    ThisNode = node(),
+    ThisMember = node_to_member(StoreId, ThisNode),
+    case get_store_prop(StoreId, ra_system) of
+        {ok, RaSystem} ->
+            ?LOG_DEBUG(
+               "Stopping member ~0p in cluster \"~s\"",
+               [ThisMember, StoreId]),
+            case ra:stop_server(RaSystem, ThisMember) of
+                ok ->
+                    forget_store(StoreId),
+                    wait_for_ra_server_exit(ThisMember);
+                %% TODO: Handle idempotency: if the Ra server is not running,
+                %% don't fail.
+                {error, _} = Error ->
+                    %% We don't call `forget_store()' in case the caller wants
+                    %% to try again.
+                    Error
+            end;
+        {error, _} ->
+            %% The store is unknown, it must have been stopped already.
+            ok
+    end.
+
+-spec wait_for_ra_server_exit(Member) -> ok when
+      Member :: ra:server_id().
+%% @private
+
+wait_for_ra_server_exit({StoreId, _} = Member) ->
+    %% FIXME: This monitoring can go away when/if the following pull request
+    %% in Ra is merged:
+    %% https://github.com/rabbitmq/ra/pull/270
+    ?LOG_DEBUG(
+       "Wait for Ra server ~0p to exit in cluster \"~s\"",
+       [Member, StoreId]),
+    MRef = erlang:monitor(process, Member),
+    receive
+        {'DOWN', MRef, _, _, Reason} ->
+            ?LOG_DEBUG(
+               "Ra server ~0p in cluster \"~s\" exited: ~p",
+               [Member, StoreId, Reason]),
+            ok
+    end.
+
+-spec join(RemoteMember | RemoteNode) -> Ret when
+      RemoteMember :: ra:server_id(),
+      RemoteNode :: node(),
+      Ret :: ok | khepri:error().
+%% @doc Adds the local running Khepri store to a remote cluster.
+%%
+%% This function accepts the following forms:
+%% <ul>
+%% <li>`join(RemoteNode)'. Calling it is the same as calling
+%% `join(DefaultClusterName, RemoteNode)' where `DefaultClusterName' is
+%% returned by {@link get_default_ra_cluster_name/0}.</li>
+%% <li>`join(RemoteMember)'. Calling it is the same as calling
+%% `join(ClusterName, RemoteNode)' where `ClusterName' and `RemoteNode' are
+%% derived from `RemoteMember'.</li>
+%% </ul>
+%%
+%% @see join/2.
+
+join(RemoteNode) when is_atom(RemoteNode) ->
+    ClusterName = get_default_ra_cluster_name(),
+    join(ClusterName, RemoteNode);
+join({ClusterName, RemoteNode} = _RemoteMember) ->
+    join(ClusterName, RemoteNode).
+
+-spec join(
+        RemoteMember | RemoteNode | ClusterName, Timeout | RemoteNode) ->
+    Ret when
+      RemoteMember :: ra:server_id(),
+      RemoteNode :: node(),
+      ClusterName :: khepri:store_id(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @doc Adds the local running Khepri store to a remote cluster.
+%%
+%% This function accepts the following forms:
+%% <ul>
+%% <li>`join(RemoteNode, Timeout)'. Calling it is the same as calling
+%% `join(DefaultClusterName, RemoteNode, Timeout)' where `DefaultClusterName'
+%% is returned by {@link get_default_ra_cluster_name/0}.</li>
+%% <li>`join(ClusterName, RemoteNode)'. Calling it is the same as calling
+%% `join(ClusterName, RemoteNode, DefaultTimeout)' where `DefaultTimeout' is
+%% returned by {@link khepri_app:get_default_timeout/0}.</li>
+%% <li>`join(RemoteMember, Timeout)'. Calling it is the same as calling
+%% `join(ClusterName, RemoteNode, Timeout)' where `ClusterName' and
+%% `RemoteNode' are derived from `RemoteMember'.</li>
+%% </ul>
+%%
+%% @see join/3.
+
+join(RemoteNode, Timeout)
+  when is_atom(RemoteNode) andalso ?IS_TIMEOUT(Timeout) ->
+    ClusterName = get_default_ra_cluster_name(),
+    join(ClusterName, RemoteNode, Timeout);
+join(ClusterName, RemoteNode)
+  when ?IS_CLUSTER_NAME(ClusterName) andalso is_atom(RemoteNode) ->
+    Timeout = khepri_app:get_default_timeout(),
+    join(ClusterName, RemoteNode, Timeout);
+join({ClusterName, RemoteNode} = _RemoteMember, Timeout) ->
+    join(ClusterName, RemoteNode, Timeout).
+
+-spec join(ClusterName, RemoteMember | RemoteNode, Timeout) -> Ret when
+      ClusterName :: khepri:store_id(),
+      RemoteMember :: ra:server_id(),
+      RemoteNode :: node(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @doc Adds the local running Khepri store to a remote cluster.
+%%
+%% The local Khepri store must have been started with {@link start/3} before
+%% it can be added to a cluster. It is also expected that the remote store ID
+%% is the same as the local one.
+%%
+%% `RemoteNode' is the entry point to the remote cluster. It must run for this
+%% function to work. A cluster membership also requires a quorum, therefore
+%% this join depends on it to succeed.
+%%
+%% If `RemoteMember' is specified, the remote node is derived from it. At the
+%% same time, the function asserts that the specified `ClusterName' matches
+%% the one derived from `RemoteMember'.
+%%
+%% As part of this function, the local Khepri store will reset. It means it
+%% will leave the cluster it is already part of (if any) and all its data
+%% removed.
+%%
+%% @param ClusterName the ID of the local Khepri store.
+%% @param RemoteNode the name of remote Erlang node running Khepri to join.
+%% @param Timeout the timeout.
+%%
+%% @returns `ok' if it succeeds, an error tuple otherwise.
+
+join(ClusterName, RemoteNode, Timeout) when is_atom(RemoteNode) ->
+    %% We first ping the remote node. It serves two purposes:
+    %% 1. Make sure we can reach it
+    %% 2. Make sure they are connected before acquiring a lock, so that the
+    %%    global lock is really global.
+    case net_adm:ping(RemoteNode) of
+        pong ->
+            Lock = server_start_lock(ClusterName),
+            global:set_lock(Lock),
+            try
+                Ret = check_status_and_join_locked(
+                        ClusterName, RemoteNode, Timeout),
+                global:del_lock(Lock),
+                Ret
+            catch
+                Class:Reason:Stacktrace ->
+                    global:del_lock(Lock),
+                    erlang:raise(Class, Reason, Stacktrace)
+            end;
+        pang ->
+            {error, {nodedown, RemoteNode}}
+    end;
+join(ClusterName, {ClusterName, RemoteNode} = _RemoteMember, Timeout) ->
+    join(ClusterName, RemoteNode, Timeout).
+
+-spec check_status_and_join_locked(ClusterName, RemoteNode, Timeout) ->
+    Ret when
+      ClusterName :: khepri:store_id(),
+      RemoteNode :: node(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @private
+
+check_status_and_join_locked(ClusterName, RemoteNode, Timeout) ->
+    ThisNode = node(),
+    ThisMember = node_to_member(ClusterName, ThisNode),
+    RaServerRunning = erlang:is_pid(erlang:whereis(ClusterName)),
+    Prop1 = get_store_prop(ClusterName, ra_system),
+    Prop2 = get_store_prop(ClusterName, ra_server_config),
+    case {RaServerRunning, Prop1, Prop2} of
+        {true, {ok, RaSystem}, {ok, RaServerConfig}} ->
+            reset_and_join_locked(
+              ClusterName, ThisMember, RaSystem, RaServerConfig,
+              RemoteNode, Timeout);
+        {false, {error, _} = Error, _} ->
+            Error;
+        {false, _, {error, _} = Error} ->
+            Error;
+        {false, _, _} ->
+            ?LOG_ERROR(
+               "Local Ra server ~0p not running for store \"~s\", "
+               "but properties are still available: ~0p and ~0p",
+               [ThisMember, ClusterName, Prop1, Prop2]),
+            throw(
+              {ra_server_not_running_but_props_available,
+               ThisMember, ClusterName, Prop1, Prop2})
+    end.
+
+-spec reset_and_join_locked(
+  ClusterName, ThisMember, RaSystem, RaServerConfig, RemoteNode, Timeout) ->
+    Ret when
+      ClusterName :: khepri:store_id(),
+      ThisMember :: ra:server_id(),
+      RaSystem :: atom(),
+      RaServerConfig :: ra_server:config(),
+      RemoteNode :: node(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @private
+
+reset_and_join_locked(
+  ClusterName, ThisMember, RaSystem, RaServerConfig, RemoteNode, Timeout) ->
+    %% The local node is reset in case it is already a standalone elected
+    %% leader (which would be the case after a successful call to
+    %% `khepri_cluster:start()') or part of a cluster, and have any data.
+    %%
+    %% Just after the reset, we restart it skipping the `trigger_election()'
+    %% step: this is required so that it does not become a leader before
+    %% joining the remote node. Otherwise, we hit an assertion in Ra.
+    %%
+    %% TODO: Should we verify the cluster membership first? To avoid resetting
+    %% a node which is already part of the cluster? On the other hand, such a
+    %% check would not be atomic and the membership could change between the
+    %% check and the reset...
+    %%
+    %% TODO: Do we want to provide an option to verify the state of the local
+    %% node before resetting it? Like "if it has data in the Khepri database,
+    %% abort". It may be difficult to make this kind of check atomic though.
+    T0 = khepri_utils:start_timeout_window(Timeout),
+    case do_reset(RaSystem, ClusterName, ThisMember, Timeout) of
+        ok ->
+            NewTimeout = khepri_utils:end_timeout_window(Timeout, T0),
+            case do_start_server(RaSystem, RaServerConfig) of
+                ok ->
+                    do_join_locked(
+                      ClusterName, ThisMember, RemoteNode, NewTimeout);
                 Error ->
                     Error
             end;
@@ -166,254 +728,320 @@ start(RaSystem, ClusterName, FriendlyName) ->
             Error
     end.
 
-ensure_started(RaSystem, ClusterName, FriendlyName) ->
-    ThisNode = node(),
-    ThisMember = node_to_member(ClusterName, ThisNode),
-    ?LOG_DEBUG(
-       "Check if a local Ra server is running for cluster \"~s\"",
-       [ClusterName],
-       #{domain => [khepri, clustering]}),
-    case whereis(ClusterName) of
-        undefined ->
-            ?LOG_DEBUG(
-               "No local Ra server running for cluster \"~s\", "
-               "try to restart it",
-               [ClusterName],
-               #{domain => [khepri, clustering]}),
-            Lock = {ClusterName, self()},
-            global:set_lock(Lock),
-            Ret = case ra:restart_server(RaSystem, ThisMember) of
-                      {error, Reason}
-                        when Reason == not_started orelse
-                             Reason == name_not_registered ->
-                          ?LOG_DEBUG(
-                             "Ra cluster not running, try to start it",
-                             [],
-                             #{domain => [khepri, clustering]}),
-                          do_start(
-                            RaSystem, ClusterName, FriendlyName,
-                            [ThisMember]);
-                      ok ->
-                          ok;
-                      {error, {already_started, _}} ->
-                          ok;
-                      _ ->
-                          ok
-                  end,
-            global:del_lock(Lock),
-            Ret;
-        _ ->
-            ?LOG_DEBUG(
-               "Local Ra server running, part of cluster \"~s\"",
-               [ClusterName],
-               #{domain => [khepri, clustering]}),
-            ok
-    end.
+-spec do_join_locked(
+  ClusterName, ThisMember, RemoteNode, Timeout) ->
+    Ret when
+      ClusterName :: khepri:store_id(),
+      ThisMember :: ra:server_id(),
+      RemoteNode :: node(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @private
 
-do_start(RaSystem, ClusterName, FriendlyName, Members) ->
-    RaServerConfigs = [make_ra_server_config(
-                         ClusterName, FriendlyName, Member, Members)
-                       || Member <- Members],
+do_join_locked(ClusterName, ThisMember, RemoteNode, Timeout) ->
+    RemoteMember = node_to_member(ClusterName, RemoteNode),
     ?LOG_DEBUG(
-       "Starting a cluster, named \"~s\", with the following Ra server "
-       "configuration:~n~p",
-       [ClusterName, hd(RaServerConfigs)],
-       #{domain => [khepri, clustering]}),
-    case ra:start_cluster(RaSystem, RaServerConfigs) of
-        {ok, Started, _} ->
+       "Adding this node (~0p) to the remote node's cluster (~0p)",
+       [ThisMember, RemoteMember]),
+    T1 = khepri_utils:start_timeout_window(Timeout),
+    Ret1 = rpc:call(
+             RemoteNode,
+             ra, add_member, [ClusterName, ThisMember, Timeout],
+             Timeout),
+    Timeout1 = khepri_utils:end_timeout_window(Timeout, T1),
+    case Ret1 of
+        {ok, _, _ClusterName} ->
             ?LOG_DEBUG(
-               "Started Ra server for cluster \"~s\" on ~p",
-               [ClusterName, Started],
-               #{domain => [khepri, clustering]}),
+               "Cluster \"~s\" successfully expanded",
+               [ClusterName]),
             ok;
-        {error, cluster_not_formed} = Error ->
-            ?LOG_ERROR(
-               "Failed to start Ra server for cluster \"~s\" using the "
-               "following Ra server configuration:~n~p",
-               [ClusterName, hd(RaServerConfigs)],
-               #{domain => [khepri, clustering]}),
-            Error
-    end.
-
-add_member(RaSystem, NewNode) ->
-    add_member(
-      RaSystem, ?DEFAULT_RA_CLUSTER_NAME, ?DEFAULT_RA_FRIENDLY_NAME,
-      NewNode).
-
-add_member(RaSystem, ClusterName, FriendlyName, NewNode) ->
-    ?LOG_DEBUG(
-       "Querying members of cluster \"~s\"",
-       [ClusterName],
-       #{domain => [khepri, clustering]}),
-    case members(ClusterName) of
-        ExistingMembers when ExistingMembers =/= [] ->
-            NewMember = node_to_member(ClusterName, NewNode),
-            case lists:member(NewMember, ExistingMembers) of
-                false ->
-                    start_ra_server_and_add_member(
-                      RaSystem, ClusterName, FriendlyName, ExistingMembers,
-                      NewMember);
-                true ->
-                    ?LOG_DEBUG(
-                       "Member ~p is already part of cluster \"~s\"",
-                       [NewMember, ClusterName],
-                       #{domain => [khepri, clustering]}),
-                    ok
+        {error, cluster_change_not_permitted} ->
+            T2 = khepri_utils:start_timeout_window(Timeout1),
+            ?LOG_DEBUG(
+               "Remote cluster (reached through node node ~0p) is not ready "
+               "for a membership change yet; waiting", [RemoteNode]),
+            Ret2 = wait_for_remote_cluster_readyness(
+                     ClusterName, RemoteNode, Timeout1),
+            Timeout2 = khepri_utils:end_timeout_window(Timeout1, T2),
+            case Ret2 of
+                ok ->
+                    do_join_locked(
+                      ClusterName, ThisMember, RemoteNode, Timeout2);
+                Error ->
+                    Error
             end;
-        [] ->
-            ?LOG_ERROR(
-               "Failed to query members of cluster \"~s\"",
-               [ClusterName],
-               #{domain => [khepri, clustering]}),
-            {error, failed_to_query_cluster_members}
-    end.
-
-start_ra_server_and_add_member(
-  RaSystem, ClusterName, FriendlyName, ExistingMembers, NewMember) ->
-    Lock = {ClusterName, self()},
-    global:set_lock(Lock),
-    RaServerConfig = make_ra_server_config(
-                       ClusterName, FriendlyName, NewMember, ExistingMembers),
-    ?LOG_DEBUG(
-       "Adding member ~p to cluster \"~s\" with the following "
-       "configuration:~n~p",
-       [NewMember, ClusterName, RaServerConfig],
-       #{domain => [khepri, clustering]}),
-    case ra:start_server(RaSystem, RaServerConfig) of
-        ok ->
-            %% TODO: Take the timeout as an argument (+ have a default).
-            Timeout = 30000,
-            Ret = do_add_member(
-                    ClusterName, ExistingMembers, NewMember, Timeout),
-            global:del_lock(Lock),
-            Ret;
         Error ->
-            global:del_lock(Lock),
             ?LOG_ERROR(
-               "Failed to start member ~p, required to add it to "
-               "cluster \"~s\": ~p",
-               [NewMember, ClusterName, Error],
-               #{domain => [khepri, clustering]}),
-            Error
+               "Failed to expand cluster for store \"~s\": ~p; aborting",
+               [ClusterName, Error]),
+            %% After failing to join, the local Ra server is running
+            %% standalone (after a reset) and needs an election to be in a
+            %% working state again. We don't care about the result at this
+            %% point.
+            _ = trigger_election(ThisMember, Timeout1),
+            case Error of
+                {badrpc, _} -> {error, Error};
+                _           -> Error
+            end
     end.
 
-do_add_member(ClusterName, ExistingMembers, NewMember, Timeout) ->
-    T0 = erlang:monotonic_time(),
-    Ret = ra:add_member(ExistingMembers, NewMember),
+-spec wait_for_cluster_readyness(ClusterName, Timeout) ->
+    Ret when
+      ClusterName :: khepri:store_id(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error(timeout).
+%% @private
+
+wait_for_cluster_readyness(ClusterName, Timeout) ->
+    %% If querying the cluster members succeeds, we must have a quorum, right?
+    case members(ClusterName, Timeout) of
+        [_ | _]     -> ok;
+        []          -> {error, timeout}
+    end.
+
+-spec wait_for_remote_cluster_readyness(ClusterName, RemoteNode, Timeout) ->
+    Ret when
+      ClusterName :: khepri:store_id(),
+      RemoteNode :: node(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @private
+
+wait_for_remote_cluster_readyness(ClusterName, RemoteNode, Timeout) ->
+    Ret = rpc:call(
+            RemoteNode,
+            khepri_cluster, wait_for_cluster_readyness, [ClusterName, Timeout],
+            Timeout),
     case Ret of
-        {ok, _, _} ->
-            ok;
-        Error when Timeout >= 0 ->
-            ?LOG_NOTICE(
-               "Failed to add member ~p to cluster \"~s\": ~p; "
-               "will retry for ~b milliseconds",
-               [NewMember, ClusterName, Error, Timeout],
-               #{domain => [khepri, clustering]}),
-            timer:sleep(500),
-            T1 = erlang:monotonic_time(),
-            TDiff = erlang:convert_time_unit(T1 - T0, native, millisecond),
-            TimeLeft = Timeout - TDiff,
-            do_add_member(
-              ClusterName, ExistingMembers, NewMember, TimeLeft);
-        Error ->
-            ?LOG_ERROR(
-               "Failed to add member ~p to cluster \"~s\": ~p; "
-               "aborting",
-               [NewMember, ClusterName, Error],
-               #{domain => [khepri, clustering]}),
-            Error
+        {badrpc, _} -> {error, Ret};
+        _           -> Ret
     end.
 
-remove_member(NodeToRemove) ->
-    remove_member(?DEFAULT_RA_CLUSTER_NAME, NodeToRemove).
+-spec reset() -> Ret when
+      Ret :: ok | khepri:error().
+%% @doc Resets the store on this Erlang node.
 
-remove_member(ClusterName, NodeToRemove) ->
-    ?LOG_DEBUG(
-       "Querying members of cluster \"~s\"",
-       [ClusterName],
-       #{domain => [khepri, clustering]}),
-    case members(ClusterName) of
-        ExistingMembers when ExistingMembers =/= [] ->
-            MemberToRemove = node_to_member(ClusterName, NodeToRemove),
-            case lists:member(MemberToRemove, ExistingMembers) of
-                true ->
-                    do_remove_member(
-                      ClusterName, ExistingMembers, MemberToRemove);
-                false ->
-                    ?LOG_DEBUG(
-                       "Member ~p is not part of cluster \"~s\"",
-                       [MemberToRemove, ClusterName],
-                       #{domain => [khepri, clustering]}),
-                    ok
-            end;
-        [] ->
-            ?LOG_ERROR(
-               "Failed to query members of cluster \"~s\"",
-               [ClusterName],
-               #{domain => [khepri, clustering]}),
-            {error, failed_to_query_cluster_members}
-    end.
+reset() ->
+    ClusterName = get_default_ra_cluster_name(),
+    reset(ClusterName).
 
-do_remove_member(ClusterName, ExistingMembers, MemberToRemove) ->
-    case ra:remove_member(ExistingMembers, MemberToRemove) of
-        {ok, _, _} ->
-            ok;
-        Error ->
-            ?LOG_ERROR(
-               "Failed to remove member ~p from cluster \"~s\": ~p; "
-               "aborting",
-               [MemberToRemove, ClusterName, Error],
-               #{domain => [khepri, clustering]}),
-            Error
-    end.
+-spec reset(StoreId | Timeout) -> Ret when
+      StoreId :: khepri:store_id(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @doc Resets the store on this Erlang node.
 
--spec reset(RaSystem, ClusterName) -> Ret when
-      RaSystem :: atom(),
-      ClusterName :: ra:cluster_name(),
-      Ret :: ok | khepri:error() | {badrpc, any()}.
+reset(Timeout)
+  when ?IS_TIMEOUT(Timeout) ->
+    ClusterName = get_default_ra_cluster_name(),
+    reset(ClusterName, Timeout);
+reset(StoreId)
+  when ?IS_CLUSTER_NAME(StoreId) ->
+    Timeout = khepri_app:get_default_timeout(),
+    reset(StoreId, Timeout).
+
+-spec reset(StoreId, Timeout) -> Ret when
+      StoreId :: khepri:store_id(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
 %% @doc Resets the store on this Erlang node.
 %%
 %% It does that by force-deleting the Ra local server.
 %%
-%% @param RaSystem the name of the Ra system.
-%% @param ClusterName the name of the Ra cluster.
+%% This function is also used to gracefully remove the local Khepri store node
+%% from a cluster.
+%%
+%% @param StoreId the name of the Khepri store.
 
-reset(RaSystem, ClusterName) ->
+reset(StoreId, Timeout) ->
+    Lock = server_start_lock(StoreId),
+    global:set_lock(Lock),
+    try
+        Ret = reset_locked(StoreId, Timeout),
+        global:del_lock(Lock),
+        Ret
+    catch
+        Class:Reason:Stacktrace ->
+            global:del_lock(Lock),
+            erlang:raise(Class, Reason, Stacktrace)
+    end.
+
+reset_locked(StoreId, Timeout) ->
     ThisNode = node(),
-    ThisMember = node_to_member(ClusterName, ThisNode),
+    ThisMember = node_to_member(StoreId, ThisNode),
+    case get_store_prop(StoreId, ra_system) of
+        {ok, RaSystem}     -> do_reset(RaSystem, StoreId, ThisMember, Timeout);
+        {error, _} = Error -> Error
+    end.
+
+do_reset(RaSystem, StoreId, ThisMember, Timeout) ->
     ?LOG_DEBUG(
-       "Resetting member ~p in cluster \"~s\"",
-       [ThisMember, ClusterName],
-       #{domain => [khepri, clustering]}),
-    ra:force_delete_server(RaSystem, ThisMember).
+       "Detaching this node (~0p) in store \"~s\" from cluster (if any) "
+       "before reset",
+       [ThisMember, StoreId]),
+    T1 = khepri_utils:start_timeout_window(Timeout),
+    Ret1 = ra:remove_member(ThisMember, ThisMember, Timeout),
+    Timeout1 = khepri_utils:end_timeout_window(Timeout, T1),
+    case Ret1 of
+        {ok, _, _} ->
+            force_stop(RaSystem, StoreId, ThisMember);
+        {error, not_member} ->
+            force_stop(RaSystem, StoreId, ThisMember);
+        {error, cluster_change_not_permitted} ->
+            T2 = khepri_utils:start_timeout_window(Timeout1),
+            ?LOG_DEBUG(
+               "Cluster is not ready for a membership change yet; waiting",
+               []),
+            Ret2 = wait_for_cluster_readyness(StoreId, Timeout1),
+            Timeout2 = khepri_utils:end_timeout_window(Timeout1, T2),
+            case Ret2 of
+                ok    -> do_reset(RaSystem, StoreId, ThisMember, Timeout2);
+                Error -> Error
+            end;
+        {timeout, _} = TimedOut ->
+            {error, TimedOut};
+        {error, _} = Error ->
+            Error
+    end.
+
+force_stop(RaSystem, StoreId, ThisMember) ->
+    ?LOG_DEBUG(
+       "Resetting member ~0p in store \"~s\"",
+       [ThisMember, StoreId]),
+    case ra:force_delete_server(RaSystem, ThisMember) of
+        ok ->
+            forget_store(StoreId),
+            wait_for_ra_server_exit(ThisMember);
+        {error, noproc} = Error ->
+            forget_store(StoreId),
+            Error;
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec get_default_ra_system_or_data_dir() -> RaSystem | DataDir when
+      RaSystem :: atom(),
+      DataDir :: file:filename_all().
+%% @doc Returns the default Ra system name or data directory.
+%%
+%% This is based on Khepri's `default_ra_system` application environment
+%% variable. The variable can be set to:
+%% <ul>
+%% <li>A directory (a string or binary) where data should be stored. A new Ra
+%% system called `khepri` will be initialized with this directory.</li>
+%% <li>A Ra system name (an atom). In this case, the user is expected to
+%% configure and start the Ra system before starting Khepri.</li>
+%% </ul>
+%%
+%% If this application environment variable is unset, the default is to
+%% configure a Ra system called `khepri' which will write data in
+%% `"khepri-$NODE"' in the current working directory where `$NODE' is the
+%% Erlang node name.
+%%
+%% Example of an Erlang configuration file for Khepri:
+%% ```
+%% {khepri, [{default_ra_system, "/var/db/khepri"}]}.
+%% '''
+%%
+%% @returns the value of the `default_ra_system' application environment
+%% variable.
+
+get_default_ra_system_or_data_dir() ->
+    RaSystemOrDataDir = application:get_env(
+                          khepri, default_ra_system,
+                          generate_default_data_dir()),
+    if
+        ?IS_DATA_DIR(RaSystemOrDataDir) ->
+            ok;
+        ?IS_RA_SYSTEM(RaSystemOrDataDir) ->
+            ok;
+        true ->
+            ?LOG_ERROR(
+               "Invalid Ra system or data directory set in "
+               "`default_ra_system` application environment: ~p",
+               [RaSystemOrDataDir]),
+            throw({invalid_ra_system_or_data_dir, RaSystemOrDataDir})
+    end,
+    RaSystemOrDataDir.
+
+generate_default_data_dir() ->
+    lists:flatten(io_lib:format("khepri#~s", [node()])).
+
+-spec get_default_ra_cluster_name() -> ClusterName when
+      ClusterName :: khepri:store_id().
+%% @doc Returns the default Ra cluster name.
+%%
+%% This is based on Khepri's `default_ra_cluster_name' application environment
+%% variable. The variable can be set to an atom. The default is `khepri'.
+%%
+%% @returns the value of the `default_ra_cluster_name' application environment
+%% variable.
+
+get_default_ra_cluster_name() ->
+    ClusterName = application:get_env(
+                    khepri, default_ra_cluster_name,
+                    ?DEFAULT_RA_CLUSTER_NAME),
+    if
+        is_atom(ClusterName) ->
+            ok;
+        true ->
+            ?LOG_ERROR(
+               "Invalid Ra cluster name set in `default_ra_cluster_name` "
+               "application environment: ~p",
+               [ClusterName]),
+            throw({invalid_ra_cluster_name, ClusterName})
+    end,
+    ClusterName.
 
 members(ClusterName) ->
-    Fun = fun ra:members/1,
-    do_query_members(ClusterName, Fun).
+    Timeout = khepri_app:get_default_timeout(),
+    members(ClusterName, Timeout).
 
-locally_known_members(ClusterName) ->
-    Fun = fun(CN) -> ra:members({local, CN}) end,
-    do_query_members(ClusterName, Fun).
-
-do_query_members(ClusterName, Fun) ->
+members(ClusterName, Timeout) ->
     ThisNode = node(),
     ThisMember = node_to_member(ClusterName, ThisNode),
-    ?LOG_DEBUG(
-       "Query members in cluster \"~s\"",
-       [ClusterName],
-       #{domain => [khepri, clustering]}),
-    case Fun(ThisMember) of
+    do_query_members(ClusterName, ThisMember, leader, Timeout).
+
+locally_known_members(ClusterName) ->
+    Timeout = khepri_app:get_default_timeout(),
+    locally_known_members(ClusterName, Timeout).
+
+locally_known_members(ClusterName, Timeout) ->
+    ThisNode = node(),
+    ThisMember = node_to_member(ClusterName, ThisNode),
+    do_query_members(ClusterName, ThisMember, local, Timeout).
+
+do_query_members(ClusterName, RaServer, QueryType, Timeout) ->
+    ?LOG_DEBUG("Query members in cluster \"~s\"", [ClusterName]),
+    T0 = khepri_utils:start_timeout_window(Timeout),
+    Arg = case QueryType of
+              leader -> RaServer;
+              local  -> {local, RaServer}
+          end,
+    case ra:members(Arg, Timeout) of
         {ok, Members, _} ->
             ?LOG_DEBUG(
                "Found the following members in cluster \"~s\": ~p",
-               [ClusterName, Members],
-               #{domain => [khepri, clustering]}),
+               [ClusterName, Members]),
             Members;
+        {error, noproc} = Error ->
+            case khepri_utils:is_ra_server_alive(RaServer) of
+                true ->
+                    NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),
+                    NewTimeout = khepri_utils:sleep(
+                                   ?NOPROC_RETRY_INTERVAL, NewTimeout0),
+                    do_query_members(
+                      ClusterName, RaServer, QueryType, NewTimeout);
+                false ->
+                    ?LOG_WARNING(
+                       "Failed to query members in cluster \"~s\": ~p",
+                       [ClusterName, Error]),
+                    []
+            end;
         Error ->
             ?LOG_WARNING(
                "Failed to query members in cluster \"~s\": ~p",
-               [ClusterName, Error],
-               #{domain => [khepri, clustering]}),
+               [ClusterName, Error]),
             []
     end.
 
@@ -423,25 +1051,101 @@ nodes(ClusterName) ->
 locally_known_nodes(ClusterName) ->
     [Node || {_, Node} <- locally_known_members(ClusterName)].
 
+-spec node_to_member(ClusterName, Node) -> Member when
+      ClusterName :: ra:cluster_name(),
+      Node :: node(),
+      Member :: ra:server_id().
+%% @private
+
 node_to_member(ClusterName, Node) ->
     {ClusterName, Node}.
 
-make_ra_server_config(ClusterName, FriendlyName, Member, Members) ->
+server_start_lock(ClusterName) ->
+    {{khepri, ClusterName}, self()}.
+
+complete_ra_server_config(#{cluster_name := ClusterName,
+                            id := Member} = RaServerConfig) ->
+    %% We warn the caller if he sets `initial_members' that the setting will
+    %% be ignored. The reason is we mandate the use of
+    %% `khepri_cluster:start()' to start the local node (and can't use on the
+    %% "auto-cluster start" of Ra) because we also populate a few
+    %% persistent_term for Ra system & server config bookkeeping.
+    RaServerConfig1 = case RaServerConfig of
+                          #{initial_members := _} ->
+                              ?LOG_WARNING(
+                                 "Initial Ra cluster members in the "
+                                 "following Ra server config "
+                                 "(`initial_members`) will be ignored: ~p",
+                                 [RaServerConfig]),
+                              maps:remove(initial_members, RaServerConfig);
+                          _ ->
+                              RaServerConfig
+                      end,
+
+    %% We set a default friendly name for this Ra server if the caller didn't
+    %% set any.
+    RaServerConfig2 = case RaServerConfig1 of
+                          #{friendly_name := _} ->
+                              RaServerConfig1;
+                          _ ->
+                              FriendlyName = lists:flatten(
+                                               io_lib:format(
+                                                 "Khepri store \"~s\"",
+                                                 [ClusterName])),
+                              RaServerConfig1#{friendly_name => FriendlyName}
+                      end,
+
     UId = ra:new_uid(ra_lib:to_binary(ClusterName)),
-    #{cluster_name => ClusterName,
-      id => Member,
-      uid => UId,
-      friendly_name => FriendlyName,
-      initial_members => Members,
-      log_init_args => #{uid => UId},
-      machine => {module, khepri_machine, #{store_id => ClusterName}}}.
+    MachineConfig = #{store_id => ClusterName,
+                      member => Member},
+    Machine = {module, khepri_machine, MachineConfig},
+    RaServerConfig2#{uid => UId,
+                     log_init_args => #{uid => UId},
+                     machine => Machine}.
 
 -define(PT_STORE_IDS, {khepri, store_ids}).
 
-remember_store_id(ClusterName) ->
+-spec remember_store(RaSystem, RaServerConfig) -> ok when
+      RaSystem :: atom(),
+      RaServerConfig :: ra_server:ra_server_config().
+%% @private
+
+remember_store(
+  RaSystem, #{cluster_name := ClusterName} = RaServerConfig) ->
     StoreIds = persistent_term:get(?PT_STORE_IDS, #{}),
-    StoreIds1 = StoreIds#{ClusterName => true},
+    Props = #{ra_system => RaSystem,
+              ra_server_config => RaServerConfig},
+    StoreIds1 = StoreIds#{ClusterName => Props},
     persistent_term:put(?PT_STORE_IDS, StoreIds1),
+    ok.
+
+-spec get_store_prop(StoreId, PropName) -> PropValue when
+      StoreId :: khepri:store_id(),
+      PropName :: atom(),
+      PropValue :: any().
+%% @private
+
+get_store_prop(StoreId, PropName) ->
+    case persistent_term:get(?PT_STORE_IDS, #{}) of
+        #{StoreId := #{PropName := PropValue}} ->
+            {ok, PropValue};
+        _ ->
+            {error, {not_a_khepri_store, StoreId}}
+    end.
+
+-spec forget_store(StoreId) -> ok when
+      StoreId :: khepri:store_id().
+%% @private
+
+forget_store(StoreId) ->
+    ok = khepri_machine:clear_cache(StoreId),
+    ok = clear_cached_leader(StoreId),
+    StoreIds = persistent_term:get(?PT_STORE_IDS, #{}),
+    StoreIds1 = maps:remove(StoreId, StoreIds),
+    case maps:size(StoreIds1) of
+        0 -> _ = persistent_term:erase(?PT_STORE_IDS);
+        _ -> ok = persistent_term:put(?PT_STORE_IDS, StoreIds1)
+    end,
     ok.
 
 -spec get_store_ids() -> [StoreId] when
@@ -451,11 +1155,48 @@ remember_store_id(ClusterName) ->
 get_store_ids() ->
     maps:keys(persistent_term:get(?PT_STORE_IDS, #{})).
 
--spec forget_store_ids() -> ok.
-%% @doc Clears the remembered store IDs.
-%%
-%% @private
+%% Cache the Ra leader ID to avoid command/query redirections from a follower
+%% to the leader. The leader ID is returned after each command or query. If we
+%% don't know it yet, wait for a leader election using khepri_event_handler.
 
-forget_store_ids() ->
-    _ = persistent_term:erase(?PT_STORE_IDS),
+-define(RA_LEADER_CACHE_KEY(StoreId), {khepri, ra_leader_cache, StoreId}).
+
+-spec get_cached_leader(StoreId) -> Ret when
+      StoreId :: khepri:store_id(),
+      Ret :: LeaderId | undefined,
+      LeaderId :: ra:server_id().
+
+get_cached_leader(StoreId) ->
+    Key = ?RA_LEADER_CACHE_KEY(StoreId),
+    persistent_term:get(Key, undefined).
+
+-spec cache_leader(StoreId, LeaderId) -> ok when
+      StoreId :: khepri:store_id(),
+      LeaderId :: ra:server_id().
+
+cache_leader(StoreId, LeaderId) ->
+    ok = persistent_term:put(?RA_LEADER_CACHE_KEY(StoreId), LeaderId).
+
+-spec cache_leader_if_changed(StoreId, LeaderId, NewLeaderId) -> ok when
+      StoreId :: khepri:store_id(),
+      LeaderId :: ra:server_id(),
+      NewLeaderId :: ra:server_id().
+
+cache_leader_if_changed(_StoreId, LeaderId, LeaderId) ->
+    ok;
+cache_leader_if_changed(StoreId, undefined, NewLeaderId) ->
+    case persistent_term:get(?RA_LEADER_CACHE_KEY(StoreId), undefined) of
+        LeaderId when LeaderId =/= undefined ->
+            cache_leader_if_changed(StoreId, LeaderId, NewLeaderId);
+        undefined ->
+            cache_leader(StoreId, NewLeaderId)
+    end;
+cache_leader_if_changed(StoreId, _OldLeaderId, NewLeaderId) ->
+    cache_leader(StoreId, NewLeaderId).
+
+-spec clear_cached_leader(StoreId) -> ok when
+      StoreId :: khepri:store_id().
+
+clear_cached_leader(StoreId) ->
+    _ = persistent_term:erase(?RA_LEADER_CACHE_KEY(StoreId)),
     ok.

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -115,6 +115,7 @@
 
 %% Internal.
 -export([node_to_member/2,
+         this_member/1,
          wait_for_cluster_readyness/2,
          get_cached_leader/1,
          cache_leader/2,
@@ -377,8 +378,7 @@ ensure_server_started(
 
 ensure_server_started_locked(
   RaSystem, #{cluster_name := StoreId} = RaServerConfig, Timeout) ->
-    ThisNode = node(),
-    ThisMember = node_to_member(StoreId, ThisNode),
+    ThisMember = this_member(StoreId),
     ?LOG_DEBUG(
        "Trying to restart local Ra server for store \"~s\" "
        "in Ra system \"~s\"",
@@ -487,8 +487,7 @@ stop(StoreId) when ?IS_STORE_ID(StoreId) ->
       Ret :: ok | khepri:error().
 
 stop_locked(StoreId) ->
-    ThisNode = node(),
-    ThisMember = node_to_member(StoreId, ThisNode),
+    ThisMember = this_member(StoreId),
     case get_store_prop(StoreId, ra_system) of
         {ok, RaSystem} ->
             ?LOG_DEBUG(
@@ -654,8 +653,7 @@ join(StoreId, {StoreId, RemoteNode} = _RemoteMember, Timeout) ->
 %% @private
 
 check_status_and_join_locked(StoreId, RemoteNode, Timeout) ->
-    ThisNode = node(),
-    ThisMember = node_to_member(StoreId, ThisNode),
+    ThisMember = this_member(StoreId),
     RaServerRunning = erlang:is_pid(erlang:whereis(StoreId)),
     Prop1 = get_store_prop(StoreId, ra_system),
     Prop2 = get_store_prop(StoreId, ra_server_config),
@@ -862,8 +860,7 @@ reset(StoreId, Timeout) ->
     end.
 
 reset_locked(StoreId, Timeout) ->
-    ThisNode = node(),
-    ThisMember = node_to_member(StoreId, ThisNode),
+    ThisMember = this_member(StoreId),
     case get_store_prop(StoreId, ra_system) of
         {ok, RaSystem}     -> do_reset(RaSystem, StoreId, ThisMember, Timeout);
         {error, _} = Error -> Error
@@ -993,8 +990,7 @@ members(StoreId) ->
     members(StoreId, Timeout).
 
 members(StoreId, Timeout) ->
-    ThisNode = node(),
-    ThisMember = node_to_member(StoreId, ThisNode),
+    ThisMember = this_member(StoreId),
     do_query_members(StoreId, ThisMember, leader, Timeout).
 
 locally_known_members(StoreId) ->
@@ -1002,8 +998,7 @@ locally_known_members(StoreId) ->
     locally_known_members(StoreId, Timeout).
 
 locally_known_members(StoreId, Timeout) ->
-    ThisNode = node(),
-    ThisMember = node_to_member(StoreId, ThisNode),
+    ThisMember = this_member(StoreId),
     do_query_members(StoreId, ThisMember, local, Timeout).
 
 do_query_members(StoreId, RaServer, QueryType, Timeout) ->
@@ -1054,6 +1049,15 @@ locally_known_nodes(StoreId) ->
 
 node_to_member(StoreId, Node) ->
     {StoreId, Node}.
+
+-spec this_member(StoreId) -> Member when
+      StoreId :: khepri:store_id(),
+      Member :: ra:server_id().
+%% @private
+
+this_member(StoreId) ->
+    ThisNode = node(),
+    node_to_member(StoreId, ThisNode).
 
 server_start_lock(StoreId) ->
     {{khepri, StoreId}, self()}.

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -772,7 +772,7 @@ get_last_consistent_call_atomics(StoreId) ->
 %% @private
 
 get_timeout(#{timeout := Timeout}) -> Timeout;
-get_timeout(_)                     -> infinity.
+get_timeout(_)                     -> khepri_app:get_default_timeout().
 
 -spec clear_cache(StoreId) -> ok when
       StoreId :: khepri:store_id().

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -51,7 +51,6 @@
          get_root/1,
          get_keep_while_conds/1,
          get_keep_while_conds_revidx/1,
-         get_cached_leader/1,
          get_last_consistent_call_atomics/1]).
 -endif.
 
@@ -481,22 +480,42 @@ process_command(StoreId, Command, Options) ->
     end.
 
 process_sync_command(StoreId, Command, Options) ->
-    case get_leader(StoreId) of
-        LeaderId when LeaderId =/= undefined ->
-            Timeout = get_timeout(Options),
-            case ra:process_command(LeaderId, Command, Timeout) of
-                {ok, Ret, NewLeaderId} ->
-                    cache_leader_if_changed(
-                      StoreId, LeaderId, NewLeaderId),
-                    just_did_consistent_call(StoreId),
-                    Ret;
-                {timeout, _} = TimedOut ->
-                    {error, TimedOut};
-                {error, _} = Error ->
+    Timeout = get_timeout(Options),
+    T0 = khepri_utils:start_timeout_window(Timeout),
+    LeaderId = khepri_cluster:get_cached_leader(StoreId),
+    RaServer = use_leader_or_local_ra_server(StoreId, LeaderId),
+    case ra:process_command(RaServer, Command, Timeout) of
+        {ok, Ret, NewLeaderId} ->
+            khepri_cluster:cache_leader_if_changed(
+              StoreId, LeaderId, NewLeaderId),
+            just_did_consistent_call(StoreId),
+            Ret;
+        {timeout, _} = TimedOut ->
+            {error, TimedOut};
+        {error, noproc}
+          when LeaderId =/= undefined andalso ?HAS_TIME_LEFT(Timeout) ->
+            %% The cached leader is no more. We simply clear the cache
+            %% entry and retry.
+            khepri_cluster:clear_cached_leader(StoreId),
+            NewTimeout = khepri_utils:end_timeout_window(Timeout, T0),
+            Options1 = Options#{timeout => NewTimeout},
+            process_sync_command(StoreId, Command, Options1);
+        {error, noproc} = Error
+          when LeaderId =:= undefined andalso ?HAS_TIME_LEFT(Timeout) ->
+            case khepri_utils:is_ra_server_alive(RaServer) of
+                true ->
+                    %% The follower doesn't know about the new leader yet.
+                    %% Retry again after waiting a bit.
+                    NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),
+                    NewTimeout = khepri_utils:sleep(
+                                   ?NOPROC_RETRY_INTERVAL, NewTimeout0),
+                    Options1 = Options#{timeout => NewTimeout},
+                    process_sync_command(StoreId, Command, Options1);
+                false ->
                     Error
             end;
-        undefined ->
-            {error, ra_leader_unknown}
+        {error, _} = Error ->
+            Error
     end.
 
 process_async_command(StoreId, Command, Correlation, Priority) ->
@@ -572,7 +591,8 @@ process_query(StoreId, QueryFun, Options) ->
 process_local_query(StoreId, QueryFun, Timeout) ->
     LocalServerId = {StoreId, node()},
     Ret = ra:local_query(LocalServerId, QueryFun, Timeout),
-    process_query_response(StoreId, undefined, local, Ret).
+    process_query_response(
+      StoreId, LocalServerId, false, QueryFun, local, Timeout, Ret).
 
 -spec process_non_local_query(StoreId, QueryFun, QueryType, Timeout) ->
     Ret when
@@ -585,27 +605,31 @@ process_local_query(StoreId, QueryFun, Timeout) ->
 process_non_local_query(StoreId, QueryFun, QueryType, Timeout)
   when QueryType =:= leader orelse
        QueryType =:= consistent ->
-    case get_leader(StoreId) of
-        LeaderId when LeaderId =/= undefined ->
-            Ret = case QueryType of
-                      leader ->
-                          ra:leader_query(LeaderId, QueryFun, Timeout);
-                      consistent ->
-                          ra:consistent_query(LeaderId, QueryFun, Timeout)
-                  end,
-            %% TODO: If the consistent query times out in the context of
-            %% `QueryType=compromise`, should we retry with a local query to
-            %% never block the query and let the caller continue?
-            process_query_response(StoreId, LeaderId, QueryType, Ret);
-        undefined ->
-            {error, ra_leader_unknown}
-    end.
+    T0 = khepri_utils:start_timeout_window(Timeout),
+    LeaderId = khepri_cluster:get_cached_leader(StoreId),
+    RaServer = use_leader_or_local_ra_server(StoreId, LeaderId),
+    Ret = case QueryType of
+              leader     -> ra:leader_query(RaServer, QueryFun, Timeout);
+              consistent -> ra:consistent_query(RaServer, QueryFun, Timeout)
+          end,
+    NewTimeout = khepri_utils:end_timeout_window(Timeout, T0),
+    %% TODO: If the consistent query times out in the context of
+    %% `QueryType=compromise`, should we retry with a local query to
+    %% never block the query and let the caller continue?
+    process_query_response(
+      StoreId, RaServer, LeaderId =/= undefined, QueryFun, QueryType,
+      NewTimeout, Ret).
 
--spec process_query_response(StoreId, LeaderId, QueryType, Response) ->
+-spec process_query_response(
+        StoreId, RaServer, IsLeader, QueryFun, QueryType, Timeout,
+        Response) ->
     Ret when
       StoreId :: khepri:store_id(),
-      LeaderId :: ra:server_id() | undefined,
+      RaServer :: ra:server_id(),
+      IsLeader :: boolean(),
+      QueryFun :: query_fun(),
       QueryType :: local | leader | consistent,
+      Timeout :: timeout(),
       Response :: {ok, {RaIndex, any()}, NewLeaderId} |
                   {ok, any(), NewLeaderId} |
                   {error, any()} |
@@ -615,79 +639,57 @@ process_non_local_query(StoreId, QueryFun, QueryType, Timeout)
       Ret :: any().
 
 process_query_response(
-  StoreId, LeaderId, consistent, {ok, Ret, NewLeaderId}) ->
-    cache_leader_if_changed(StoreId, LeaderId, NewLeaderId),
+  StoreId, RaServer, IsLeader, _QueryFun, consistent, _Timeout,
+  {ok, Ret, NewLeaderId}) ->
+    case IsLeader of
+        true ->
+            khepri_cluster:cache_leader_if_changed(
+              StoreId, RaServer, NewLeaderId);
+        false ->
+            khepri_cluster:cache_leader(StoreId, NewLeaderId)
+    end,
     just_did_consistent_call(StoreId),
     Ret;
 process_query_response(
-  StoreId, LeaderId, _QueryType, {ok, {_RaIndex, Ret}, NewLeaderId}) ->
-    cache_leader_if_changed(StoreId, LeaderId, NewLeaderId),
+  StoreId, RaServer, IsLeader, _QueryFun, _QueryType, _Timeout,
+  {ok, {_RaIndex, Ret}, NewLeaderId}) ->
+    case IsLeader of
+        true ->
+            khepri_cluster:cache_leader_if_changed(
+              StoreId, RaServer, NewLeaderId);
+        false ->
+            khepri_cluster:cache_leader(StoreId, NewLeaderId)
+    end,
     Ret;
 process_query_response(
-  _StoreId, _LeaderId, _QueryType, {timeout, _} = TimedOut) ->
+  _StoreId, _RaServer, _IsLeader, _QueryFun, _QueryType, _Timeout,
+  {timeout, _} = TimedOut) ->
     {error, TimedOut};
 process_query_response(
-  _StoreId, _LeaderId, _QueryType, {error, _} = Error) ->
-    Error.
-
-%% Cache the Ra leader ID to avoid command/query redirections from a follower
-%% to the leader. The leader ID is returned after each command or query. If we
-%% don't know it yet, ask Ra what the leader ID is.
-
--define(RA_LEADER_CACHE_KEY(StoreId), {khepri, ra_leader_cache, StoreId}).
-
--spec get_leader(StoreId) -> Ret when
-      StoreId :: khepri:store_id(),
-      Ret :: LeaderId | undefined,
-      LeaderId :: ra:server_id().
-
-get_leader(StoreId) ->
-    case get_cached_leader(StoreId) of
-        LeaderId when LeaderId =/= undefined ->
-            LeaderId;
-        undefined ->
-            %% StoreId is the same as Ra's cluster name.
-            case ra_leaderboard:lookup_leader(StoreId) of
-                LeaderId when LeaderId =/= undefined ->
-                    cache_leader(StoreId, LeaderId),
-                    LeaderId;
-                undefined ->
-                    undefined
-            end
-    end.
-
--spec get_cached_leader(StoreId) -> Ret when
-      StoreId :: khepri:store_id(),
-      Ret :: LeaderId | undefined,
-      LeaderId :: ra:server_id().
-
-get_cached_leader(StoreId) ->
-    Key = ?RA_LEADER_CACHE_KEY(StoreId),
-    persistent_term:get(Key, undefined).
-
--spec cache_leader(StoreId, LeaderId) -> ok when
-      StoreId :: khepri:store_id(),
-      LeaderId :: ra:server_id().
-
-cache_leader(StoreId, LeaderId) ->
-    ok = persistent_term:put(?RA_LEADER_CACHE_KEY(StoreId), LeaderId).
-
--spec cache_leader_if_changed(StoreId, LeaderId, NewLeaderId) -> ok when
-      StoreId :: khepri:store_id(),
-      LeaderId :: ra:server_id(),
-      NewLeaderId :: ra:server_id().
-
-cache_leader_if_changed(_StoreId, LeaderId, LeaderId) ->
-    ok;
-cache_leader_if_changed(StoreId, undefined, NewLeaderId) ->
-    case persistent_term:get(?RA_LEADER_CACHE_KEY(StoreId), undefined) of
-        LeaderId when LeaderId =/= undefined ->
-            cache_leader_if_changed(StoreId, LeaderId, NewLeaderId);
-        undefined ->
-            cache_leader(StoreId, NewLeaderId)
+  StoreId, _RaServer, true = _IsLeader, QueryFun, QueryType, Timeout,
+  {error, noproc})
+  when QueryType =/= local andalso ?HAS_TIME_LEFT(Timeout) ->
+    %% The cached leader is no more. We simply clear the cache
+    %% entry and retry. It may time out eventually.
+    khepri_cluster:clear_cached_leader(StoreId),
+    process_non_local_query(StoreId, QueryFun, QueryType, Timeout);
+process_query_response(
+  StoreId, RaServer, false = _IsLeader, QueryFun, QueryType, Timeout,
+  {error, noproc} = Error)
+  when QueryType =/= local andalso ?HAS_TIME_LEFT(Timeout) ->
+    case khepri_utils:is_ra_server_alive(RaServer) of
+        true ->
+            %% The follower doesn't know about the new leader yet. Retry again
+            %% after waiting a bit.
+            NewTimeout = khepri_utils:sleep(?NOPROC_RETRY_INTERVAL, Timeout),
+            process_non_local_query(StoreId, QueryFun, QueryType, NewTimeout);
+        false ->
+            Error
     end;
-cache_leader_if_changed(StoreId, _OldLeaderId, NewLeaderId) ->
-    cache_leader(StoreId, NewLeaderId).
+process_query_response(
+  _StoreId, _RaServer, _IsLeader, _QueryFun, _QueryType, _Timeout,
+  {error, _} = Error) ->
+    Error.
 
 -spec select_query_type(StoreId, Options) -> QueryType when
       StoreId :: khepri:store_id(),
@@ -774,6 +776,13 @@ get_last_consistent_call_atomics(StoreId) ->
 get_timeout(#{timeout := Timeout}) -> Timeout;
 get_timeout(_)                     -> khepri_app:get_default_timeout().
 
+use_leader_or_local_ra_server(_StoreId, LeaderId)
+  when LeaderId =/= undefined ->
+    LeaderId;
+use_leader_or_local_ra_server(StoreId, undefined) ->
+    ThisNode = node(),
+    khepri_cluster:node_to_member(StoreId, ThisNode).
+
 -spec clear_cache(StoreId) -> ok when
       StoreId :: khepri:store_id().
 %% @doc Clears the cached data for the given `StoreId'.
@@ -781,7 +790,6 @@ get_timeout(_)                     -> khepri_app:get_default_timeout().
 %% @private
 
 clear_cache(StoreId) ->
-    _ = persistent_term:erase(?RA_LEADER_CACHE_KEY(StoreId)),
     _ = persistent_term:erase(?LAST_CONSISTENT_CALL_TS_REF(StoreId)),
     ok.
 
@@ -794,13 +802,16 @@ clear_cache(StoreId) ->
       State :: state().
 %% @private
 
-init(#{store_id := StoreId} = Params) ->
+init(#{store_id := StoreId,
+       member := Member} = Params) ->
     Config = case Params of
                  #{snapshot_interval := SnapshotInterval} ->
                      #config{store_id = StoreId,
+                             member = Member,
                              snapshot_interval = SnapshotInterval};
                  _ ->
-                     #config{store_id = StoreId}
+                     #config{store_id = StoreId,
+                             member = Member}
              end,
     State = #?MODULE{config = Config},
 
@@ -915,11 +926,17 @@ reset_applied_command_count(#?MODULE{metrics = Metrics} = State) ->
 
 %% @private
 
-state_enter(
+state_enter(StateName, State) ->
+    SideEffects1 = emitted_triggers_to_side_effects(StateName, State),
+    SideEffects1.
+
+%% @private
+
+emitted_triggers_to_side_effects(
   leader,
   #?MODULE{emitted_triggers = []}) ->
     [];
-state_enter(
+emitted_triggers_to_side_effects(
   leader,
   #?MODULE{config = #config{store_id = StoreId},
            emitted_triggers = EmittedTriggers}) ->
@@ -928,7 +945,7 @@ state_enter(
                   handle_triggered_sprocs,
                   [StoreId, EmittedTriggers]},
     [SideEffect];
-state_enter(_StateName, _State) ->
+emitted_triggers_to_side_effects(_StateName, _State) ->
     [].
 
 %% -------------------------------------------------------------------

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -10,6 +10,7 @@
 
 -record(config,
         {store_id :: khepri:store_id(),
+         member :: ra:server_id(),
          snapshot_interval = ?SNAPSHOT_INTERVAL :: non_neg_integer()}).
 
 -record(khepri_machine,

--- a/src/khepri_sup.erl
+++ b/src/khepri_sup.erl
@@ -18,7 +18,7 @@ start_link() ->
 
 init(_) ->
     SupFlags = #{strategy => one_for_one},
-    EventHandlerSpec = #{id => khepri_event_handler,
+    EventHandlerSpec = #{id => event_handler,
                          start => {khepri_event_handler, start_link, []},
                          type => worker},
     ChildSpecs = [EventHandlerSpec],

--- a/test/app.erl
+++ b/test/app.erl
@@ -34,3 +34,48 @@ event_handler_gen_server_callbacks_test() ->
     ?assertEqual(ok, gen_server:call(khepri_event_handler, any_call)),
     ?assert(is_process_alive(whereis(khepri_event_handler))),
     ?assertEqual(ok, application:stop(khepri)).
+
+get_default_timeout_with_no_app_env_test() ->
+    ?assertEqual(
+       infinity,
+       khepri_app:get_default_timeout()).
+
+get_default_timeout_with_infinity_app_env_test() ->
+    Timeout = infinity,
+    application:set_env(
+      khepri, default_timeout, Timeout, [{persistent, true}]),
+    ?assertEqual(
+       Timeout,
+       khepri_app:get_default_timeout()),
+    application:unset_env(
+      khepri, default_timeout, [{persistent, true}]).
+
+get_default_timeout_with_non_neg_integer_app_env_test() ->
+    Timeout = 0,
+    application:set_env(
+      khepri, default_timeout, Timeout, [{persistent, true}]),
+    ?assertEqual(
+       Timeout,
+       khepri_app:get_default_timeout()),
+    application:unset_env(
+      khepri, default_timeout, [{persistent, true}]).
+
+get_default_timeout_with_neg_integer_app_env_test() ->
+    Timeout = -5000,
+    application:set_env(
+      khepri, default_timeout, Timeout, [{persistent, true}]),
+    ?assertThrow(
+       {invalid_timeout, Timeout},
+       khepri_app:get_default_timeout()),
+    application:unset_env(
+      khepri, default_timeout, [{persistent, true}]).
+
+get_default_timeout_with_invalid_app_env_test() ->
+    Invalid = {invalid},
+    application:set_env(
+      khepri, default_timeout, Invalid, [{persistent, true}]),
+    ?assertThrow(
+       {invalid_timeout, Invalid},
+       khepri_app:get_default_timeout()),
+    application:unset_env(
+      khepri, default_timeout, [{persistent, true}]).

--- a/test/app.erl
+++ b/test/app.erl
@@ -136,35 +136,35 @@ get_default_ra_system_or_data_dir_with_invalid_app_env_test() ->
     application:unset_env(
       khepri, default_ra_system, [{persistent, true}]).
 
-get_default_ra_cluster_name_with_no_app_env_test() ->
+get_default_store_id_with_no_app_env_test() ->
     ?assertEqual(
        khepri,
-       khepri_cluster:get_default_ra_cluster_name()).
+       khepri_cluster:get_default_store_id()).
 
-get_default_ra_cluster_name_with_atom_app_env_test() ->
-    ClusterName = my_cluster,
+get_default_store_id_with_atom_app_env_test() ->
+    StoreId = my_store,
     application:set_env(
-      khepri, default_ra_cluster_name, ClusterName, [{persistent, true}]),
+      khepri, default_store_id, StoreId, [{persistent, true}]),
     ?assertEqual(
-       ClusterName,
-       khepri_cluster:get_default_ra_cluster_name()),
+       StoreId,
+       khepri_cluster:get_default_store_id()),
     application:unset_env(
-      khepri, default_ra_cluster_name, [{persistent, true}]).
+      khepri, default_store_id, [{persistent, true}]).
 
-get_default_ra_cluster_name_with_invalid_app_env_test() ->
+get_default_store_id_with_invalid_app_env_test() ->
     Invalid = {invalid},
     application:set_env(
-      khepri, default_ra_cluster_name, Invalid, [{persistent, true}]),
+      khepri, default_store_id, Invalid, [{persistent, true}]),
     ?assertThrow(
-       {invalid_ra_cluster_name, Invalid},
-       khepri_cluster:get_default_ra_cluster_name()),
+       {invalid_store_id, Invalid},
+       khepri_cluster:get_default_store_id()),
     application:unset_env(
-      khepri, default_ra_cluster_name, [{persistent, true}]).
+      khepri, default_store_id, [{persistent, true}]).
 
 start_with_default_settings_test() ->
     DataDir = khepri_cluster:generate_default_data_dir(),
     ?assertNot(filelib:is_dir(DataDir)),
-    ?assertEqual({ok, ?DEFAULT_RA_CLUSTER_NAME}, khepri_cluster:start()),
+    ?assertEqual({ok, ?DEFAULT_STORE_ID}, khepri_cluster:start()),
     ?assert(filelib:is_dir(DataDir)),
     ?assertEqual(ok, khepri_cluster:stop()),
 
@@ -176,7 +176,7 @@ start_with_data_dir_in_args_test() ->
     DataDir = helpers:store_dir_name(?FUNCTION_NAME),
     ?assertNot(filelib:is_dir(DataDir)),
     ?assertEqual(
-       {ok, ?DEFAULT_RA_CLUSTER_NAME},
+       {ok, ?DEFAULT_STORE_ID},
        khepri_cluster:start(DataDir)),
     ?assert(filelib:is_dir(DataDir)),
     ?assertEqual(ok, khepri_cluster:stop()),
@@ -190,7 +190,7 @@ start_with_data_dir_in_app_env_test() ->
     ?assertNot(filelib:is_dir(DataDir)),
     application:set_env(
       khepri, default_ra_system, DataDir, [{persistent, true}]),
-    ?assertEqual({ok, ?DEFAULT_RA_CLUSTER_NAME}, khepri_cluster:start()),
+    ?assertEqual({ok, ?DEFAULT_STORE_ID}, khepri_cluster:start()),
     ?assert(filelib:is_dir(DataDir)),
     ?assertEqual(ok, khepri_cluster:stop()),
 
@@ -206,10 +206,10 @@ start_with_ra_system_in_args_test() ->
       store_dir := DataDir} = Props,
     ?assert(filelib:is_dir(DataDir)),
     ?assertEqual(
-       {ok, ?DEFAULT_RA_CLUSTER_NAME},
+       {ok, ?DEFAULT_STORE_ID},
        khepri_cluster:start(RaSystem)),
     ?assert(filelib:is_dir(DataDir)),
-    ?assertEqual(ok, khepri_cluster:stop(?DEFAULT_RA_CLUSTER_NAME)),
+    ?assertEqual(ok, khepri_cluster:stop(?DEFAULT_STORE_ID)),
     helpers:stop_ra_system(Props),
     ?assertNot(filelib:is_dir(DataDir)),
 
@@ -224,7 +224,7 @@ start_with_ra_system_in_app_env_test() ->
     ?assert(filelib:is_dir(DataDir)),
     application:set_env(
       khepri, default_ra_system, RaSystem, [{persistent, true}]),
-    ?assertEqual({ok, ?DEFAULT_RA_CLUSTER_NAME}, khepri_cluster:start()),
+    ?assertEqual({ok, ?DEFAULT_STORE_ID}, khepri_cluster:start()),
     ?assert(filelib:is_dir(DataDir)),
     ?assertEqual(ok, khepri_cluster:stop()),
     helpers:stop_ra_system(Props),

--- a/test/app.erl
+++ b/test/app.erl
@@ -9,6 +9,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+-include("src/internal.hrl").
+
 app_starts_workers_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
@@ -71,6 +73,12 @@ get_default_timeout_with_neg_integer_app_env_test() ->
       khepri, default_timeout, [{persistent, true}]).
 
 get_default_timeout_with_invalid_app_env_test() ->
+    %% We change the log level so that another branch of the `?LOG_*' macro is
+    %% taken, to improve code coverage. It is not necessary for the testcase
+    %% itself.
+    #{level := LogLevel} = logger:get_primary_config(),
+    ok = logger:set_primary_config(level, none),
+
     Invalid = {invalid},
     application:set_env(
       khepri, default_timeout, Invalid, [{persistent, true}]),
@@ -78,4 +86,155 @@ get_default_timeout_with_invalid_app_env_test() ->
        {invalid_timeout, Invalid},
        khepri_app:get_default_timeout()),
     application:unset_env(
-      khepri, default_timeout, [{persistent, true}]).
+      khepri, default_timeout, [{persistent, true}]),
+
+    %% Restore the previously changed log level.
+    ok = logger:set_primary_config(level, LogLevel).
+
+get_default_ra_system_or_data_dir_with_no_app_env_test() ->
+    ?assertEqual(
+       khepri_cluster:generate_default_data_dir(),
+       khepri_cluster:get_default_ra_system_or_data_dir()).
+
+get_default_ra_system_or_data_dir_with_atom_app_env_test() ->
+    RaSystem = my_ra_system,
+    application:set_env(
+      khepri, default_ra_system, RaSystem, [{persistent, true}]),
+    ?assertEqual(
+       RaSystem,
+       khepri_cluster:get_default_ra_system_or_data_dir()),
+    application:unset_env(
+      khepri, default_ra_system, [{persistent, true}]).
+
+get_default_ra_system_or_data_dir_with_string_app_env_test() ->
+    DataDir = "/tmp",
+    application:set_env(
+      khepri, default_ra_system, DataDir, [{persistent, true}]),
+    ?assertEqual(
+       DataDir,
+       khepri_cluster:get_default_ra_system_or_data_dir()),
+    application:unset_env(
+      khepri, default_ra_system, [{persistent, true}]).
+
+get_default_ra_system_or_data_dir_with_binary_app_env_test() ->
+    DataDir = <<"/tmp">>,
+    application:set_env(
+      khepri, default_ra_system, DataDir, [{persistent, true}]),
+    ?assertEqual(
+       DataDir,
+       khepri_cluster:get_default_ra_system_or_data_dir()),
+    application:unset_env(
+      khepri, default_ra_system, [{persistent, true}]).
+
+get_default_ra_system_or_data_dir_with_invalid_app_env_test() ->
+    Invalid = {invalid},
+    application:set_env(
+      khepri, default_ra_system, Invalid, [{persistent, true}]),
+    ?assertThrow(
+       {invalid_ra_system_or_data_dir, Invalid},
+       khepri_cluster:get_default_ra_system_or_data_dir()),
+    application:unset_env(
+      khepri, default_ra_system, [{persistent, true}]).
+
+get_default_ra_cluster_name_with_no_app_env_test() ->
+    ?assertEqual(
+       khepri,
+       khepri_cluster:get_default_ra_cluster_name()).
+
+get_default_ra_cluster_name_with_atom_app_env_test() ->
+    ClusterName = my_cluster,
+    application:set_env(
+      khepri, default_ra_cluster_name, ClusterName, [{persistent, true}]),
+    ?assertEqual(
+       ClusterName,
+       khepri_cluster:get_default_ra_cluster_name()),
+    application:unset_env(
+      khepri, default_ra_cluster_name, [{persistent, true}]).
+
+get_default_ra_cluster_name_with_invalid_app_env_test() ->
+    Invalid = {invalid},
+    application:set_env(
+      khepri, default_ra_cluster_name, Invalid, [{persistent, true}]),
+    ?assertThrow(
+       {invalid_ra_cluster_name, Invalid},
+       khepri_cluster:get_default_ra_cluster_name()),
+    application:unset_env(
+      khepri, default_ra_cluster_name, [{persistent, true}]).
+
+start_with_default_settings_test() ->
+    DataDir = khepri_cluster:generate_default_data_dir(),
+    ?assertNot(filelib:is_dir(DataDir)),
+    ?assertEqual({ok, ?DEFAULT_RA_CLUSTER_NAME}, khepri_cluster:start()),
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual(ok, khepri_cluster:stop()),
+
+    ?assertEqual(ok, application:stop(khepri)),
+    ?assertEqual(ok, application:stop(ra)),
+    ?assertEqual(ok, helpers:remove_store_dir(DataDir)).
+
+start_with_data_dir_in_args_test() ->
+    DataDir = helpers:store_dir_name(?FUNCTION_NAME),
+    ?assertNot(filelib:is_dir(DataDir)),
+    ?assertEqual(
+       {ok, ?DEFAULT_RA_CLUSTER_NAME},
+       khepri_cluster:start(DataDir)),
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual(ok, khepri_cluster:stop()),
+
+    ?assertEqual(ok, application:stop(khepri)),
+    ?assertEqual(ok, application:stop(ra)),
+    ?assertEqual(ok, helpers:remove_store_dir(DataDir)).
+
+start_with_data_dir_in_app_env_test() ->
+    DataDir = helpers:store_dir_name(?FUNCTION_NAME),
+    ?assertNot(filelib:is_dir(DataDir)),
+    application:set_env(
+      khepri, default_ra_system, DataDir, [{persistent, true}]),
+    ?assertEqual({ok, ?DEFAULT_RA_CLUSTER_NAME}, khepri_cluster:start()),
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual(ok, khepri_cluster:stop()),
+
+    ?assertEqual(ok, application:stop(khepri)),
+    ?assertEqual(ok, application:stop(ra)),
+    ?assertEqual(ok, helpers:remove_store_dir(DataDir)),
+    application:unset_env(
+      khepri, default_ra_system, [{persistent, true}]).
+
+start_with_ra_system_in_args_test() ->
+    Props = helpers:start_ra_system(?FUNCTION_NAME),
+    #{ra_system := RaSystem,
+      store_dir := DataDir} = Props,
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual(
+       {ok, ?DEFAULT_RA_CLUSTER_NAME},
+       khepri_cluster:start(RaSystem)),
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual(ok, khepri_cluster:stop(?DEFAULT_RA_CLUSTER_NAME)),
+    helpers:stop_ra_system(Props),
+    ?assertNot(filelib:is_dir(DataDir)),
+
+    ?assertEqual(ok, application:stop(khepri)),
+    ?assertEqual(ok, application:stop(ra)),
+    ?assertEqual(ok, helpers:remove_store_dir(DataDir)).
+
+start_with_ra_system_in_app_env_test() ->
+    Props = helpers:start_ra_system(?FUNCTION_NAME),
+    #{ra_system := RaSystem,
+      store_dir := DataDir} = Props,
+    ?assert(filelib:is_dir(DataDir)),
+    application:set_env(
+      khepri, default_ra_system, RaSystem, [{persistent, true}]),
+    ?assertEqual({ok, ?DEFAULT_RA_CLUSTER_NAME}, khepri_cluster:start()),
+    ?assert(filelib:is_dir(DataDir)),
+    ?assertEqual(ok, khepri_cluster:stop()),
+    helpers:stop_ra_system(Props),
+    ?assertNot(filelib:is_dir(DataDir)),
+
+    ?assertEqual(ok, application:stop(khepri)),
+    ?assertEqual(ok, application:stop(ra)),
+    ?assertEqual(ok, helpers:remove_store_dir(DataDir)),
+    application:unset_env(
+      khepri, default_ra_system, [{persistent, true}]).
+
+for_code_coverage_test() ->
+    ?assertEqual(ok, khepri_app:config_change([], [], [])).

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1,0 +1,904 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates. All rights reserved.
+%%
+
+-module(cluster_SUITE).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("include/khepri.hrl").
+
+-export([all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2,
+
+         setup_node/0,
+
+         can_start_a_single_node/1,
+         fail_to_start_with_bad_ra_server_config/1,
+         initial_members_are_ignored/1,
+         can_start_a_three_node_cluster/1,
+         can_restart_nodes_in_a_three_node_cluster/1,
+         can_reset_a_cluster_member/1,
+         fail_to_join_if_not_started/1,
+         fail_to_join_non_existing_node/1,
+         fail_to_join_non_existing_store/1,
+         can_use_default_store_on_single_node/1,
+         can_start_store_in_specified_data_dir_on_single_node/1]).
+
+all() ->
+    [can_start_a_single_node,
+     fail_to_start_with_bad_ra_server_config,
+     initial_members_are_ignored,
+     can_start_a_three_node_cluster,
+     can_restart_nodes_in_a_three_node_cluster,
+     can_reset_a_cluster_member,
+     fail_to_join_if_not_started,
+     fail_to_join_non_existing_node,
+     fail_to_join_non_existing_store,
+     can_use_default_store_on_single_node,
+     can_start_store_in_specified_data_dir_on_single_node].
+
+groups() ->
+    [].
+
+init_per_suite(Config) ->
+    setup_node(),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(Testcase, Config)
+  when Testcase =:= can_start_a_single_node orelse
+       Testcase =:= fail_to_start_with_bad_ra_server_config orelse
+       Testcase =:= initial_members_are_ignored orelse
+       Testcase =:= fail_to_join_non_existing_node ->
+    {ok, _} = application:ensure_all_started(khepri),
+    Props = helpers:start_ra_system(Testcase),
+    [{ra_system_props, #{node() => Props}} | Config];
+init_per_testcase(Testcase, Config)
+  when Testcase =:= can_start_a_three_node_cluster orelse
+       Testcase =:= can_restart_nodes_in_a_three_node_cluster orelse
+       Testcase =:= can_reset_a_cluster_member orelse
+       Testcase =:= fail_to_join_if_not_started orelse
+       Testcase =:= fail_to_join_non_existing_store ->
+    Nodes = start_n_nodes(Testcase, 3),
+    PropsPerNode0 = [begin
+                         {ok, _} = rpc:call(
+                                     Node, application, ensure_all_started,
+                                     [khepri]),
+                         Props = rpc:call(
+                                   Node, helpers, start_ra_system,
+                                   [Testcase]),
+                         {Node, Props}
+                     end || Node <- Nodes],
+    PropsPerNode = maps:from_list(PropsPerNode0),
+    [{ra_system_props, PropsPerNode} | Config];
+init_per_testcase(Testcase, Config)
+  when Testcase =:= can_use_default_store_on_single_node orelse
+       Testcase =:= can_start_store_in_specified_data_dir_on_single_node ->
+    Config.
+
+end_per_testcase(Testcase, _Config)
+  when Testcase =:= can_use_default_store_on_single_node orelse
+       Testcase =:= can_start_store_in_specified_data_dir_on_single_node ->
+    ok;
+end_per_testcase(_Testcase, Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    maps:fold(
+      fun(Node, Props, Acc) ->
+              ok = rpc:call(Node, helpers, stop_ra_system, [Props]),
+              Acc
+      end, ok, PropsPerNode),
+    ok.
+
+can_start_a_single_node(Config) ->
+    Node = node(),
+    #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Use database before starting it"),
+    ?assertEqual(
+       {error, noproc},
+       khepri:put(StoreId, [foo], value1)),
+    ?assertEqual(
+       {error, noproc},
+       khepri:get(StoreId, [foo])),
+
+    ct:pal("Start database"),
+    ?assertEqual(
+       {ok, StoreId},
+       khepri:start(RaSystem, ClusterName)),
+
+    ct:pal("Use database after starting it"),
+    ?assertEqual(
+       {ok, #{[foo] => #{}}},
+       khepri:put(StoreId, [foo], value2)),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value2,
+                         payload_version => 1,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:get(StoreId, [foo])),
+
+    ct:pal("Stop database"),
+    ?assertEqual(
+       ok,
+       khepri:stop(StoreId)),
+
+    %% TODO: Verify that the server process exited.
+
+    ct:pal("Use database after stopping it"),
+    ?assertEqual(
+       {error, noproc},
+       khepri:put(StoreId, [foo], value3)),
+    ?assertEqual(
+       {error, noproc},
+       khepri:get(StoreId, [foo])),
+
+    ok.
+
+fail_to_start_with_bad_ra_server_config(Config) ->
+    Node = node(),
+    #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Start database"),
+    ?assertExit(
+       {{{bad_action_from_state_function,
+          {{timeout, tick}, not_a_timeout, tick_timeout}},
+         _},
+        _},
+       khepri:start(RaSystem, #{cluster_name => ClusterName,
+                                tick_timeout => not_a_timeout})),
+
+    ThisMember = khepri_cluster:node_to_member(StoreId, node()),
+    ok = khepri_cluster:wait_for_ra_server_exit(ThisMember),
+
+    %% The process is restarted by its supervisor. Depending on the timing, we
+    %% may get a `noproc' or an exception.
+    ct:pal("Database unusable after failing to start it"),
+    Ret = (catch khepri:get(StoreId, [foo])),
+    ct:pal("Return value of khepri:get/2: ~p", [Ret]),
+    ?assert(
+       case Ret of
+           {'EXIT',
+            {{{bad_action_from_state_function,
+               {{timeout, tick}, not_a_timeout, tick_timeout}},
+              _},
+             _}} ->
+               true;
+           {error, noproc} ->
+               true;
+           _ ->
+               false
+       end),
+
+    ok.
+
+initial_members_are_ignored(Config) ->
+    Node = node(),
+    #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Start database"),
+    ?assertEqual(
+       {ok, StoreId},
+       khepri:start(RaSystem, #{cluster_name => ClusterName,
+                                initial_members => [{StoreId, a},
+                                                    {StoreId, b},
+                                                    {StoreId, c}]})),
+
+    ct:pal("This member is alone in the \"cluster\""),
+    ThisMember = khepri_cluster:node_to_member(StoreId, node()),
+    ?assertEqual(
+       [ThisMember],
+       khepri_cluster:members(StoreId)),
+
+    ct:pal("Stop database"),
+    ?assertEqual(
+       ok,
+       khepri:stop(StoreId)),
+
+    ok.
+
+can_start_a_three_node_cluster(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1, Node2, Node3] = Nodes = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Use database before starting it"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:put() from node ~s", [Node]),
+              ?assertEqual(
+                 {error, noproc},
+                 rpc:call(Node, khepri, put, [StoreId, [foo], value1])),
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {error, noproc},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, Nodes),
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 rpc:call(Node, khepri, start, [RaSystem, ClusterName]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 rpc:call(Node, khepri_cluster, join, [ClusterName, Node3]))
+      end, [Node1, Node2]),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:members() from node ~s", [Node]),
+              ExpectedMembers = lists:sort([{ClusterName, N} || N <- Nodes]),
+              ?assertEqual(
+                 ExpectedMembers,
+                 lists:sort(
+                   rpc:call(Node, khepri_cluster, members, [ClusterName]))),
+              ?assertEqual(
+                 ExpectedMembers,
+                 lists:sort(
+                   rpc:call(
+                     Node, khepri_cluster, locally_known_members,
+                     [ClusterName]))),
+
+              ExpectedNodes = lists:sort(Nodes),
+              ?assertEqual(
+                 ExpectedNodes,
+                 lists:sort(
+                   rpc:call(Node, khepri_cluster, nodes, [ClusterName]))),
+              ?assertEqual(
+                 ExpectedNodes,
+                 lists:sort(
+                   rpc:call(
+                     Node, khepri_cluster, locally_known_nodes,
+                     [ClusterName])))
+      end, Nodes),
+
+    ct:pal("Use database after starting it"),
+    ?assertEqual(
+       {ok, #{[foo] => #{}}},
+       rpc:call(Node1, khepri, put, [StoreId, [foo], value2])),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, #{[foo] => #{data => value2,
+                                   payload_version => 1,
+                                   child_list_version => 1,
+                                   child_list_length => 0}}},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, Nodes),
+
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, StoppedLeaderNode1} = LeaderId1,
+    RunningNodes1 = Nodes -- [StoppedLeaderNode1],
+
+    ct:pal("Stop database on leader node (quorum is maintained)"),
+    ?assertEqual(
+       ok,
+       rpc:call(StoppedLeaderNode1, khepri, stop, [StoreId])),
+
+    ct:pal("Use database having it running on 2 out of 3 nodes"),
+    %% We try a put from the stopped leader and it should fail because the
+    %% leaderboard on that node is stale.
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(StoppedLeaderNode1, khepri, put, [StoreId, [foo], value3])),
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(StoppedLeaderNode1, khepri, get, [StoreId, [foo]])),
+
+    %% Querying running nodes should be fine however.
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, #{[foo] => #{data => value2,
+                                   payload_version => 1,
+                                   child_list_version => 1,
+                                   child_list_length => 0}}},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, RunningNodes1),
+
+    %% Likewise, a put from a running node should succeed.
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value2,
+                         payload_version => 1,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       rpc:call(hd(RunningNodes1), khepri, put, [StoreId, [foo], value4])),
+
+    %% The stopped leader should still fail to respond because it is stopped
+    %% and again, the leaderboard is stale on this node.
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(StoppedLeaderNode1, khepri, get, [StoreId, [foo]])),
+
+    %% Running nodes should see the updated value however.
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, #{[foo] => #{data => value4,
+                                   payload_version => 2,
+                                   child_list_version => 1,
+                                   child_list_length => 0}}},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, RunningNodes1),
+
+    LeaderId2 = get_leader_in_store(StoreId, RunningNodes1),
+    {StoreId, StoppedLeaderNode2} = LeaderId2,
+    RunningNodes2 = RunningNodes1 -- [StoppedLeaderNode2],
+
+    ct:pal("Stop database on the new leader node (quorum is lost)"),
+    ?assertEqual(
+       ok,
+       rpc:call(StoppedLeaderNode2, khepri, stop, [StoreId])),
+
+    ct:pal("Use database having it running on 1 out of 3 nodes"),
+    %% We try a put from the second old leader and it should fail.
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(StoppedLeaderNode2, khepri, put, [StoreId, [foo], value5])),
+
+    %% The last running node should fail to respond as well because the quorum
+    %% is lost.
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              Member = khepri_cluster:node_to_member(StoreId, Node),
+              ?assertEqual(
+                 {error, {timeout, Member}},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, RunningNodes2),
+
+    ok.
+
+can_restart_nodes_in_a_three_node_cluster(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1, Node2, Node3] = Nodes = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 rpc:call(Node, khepri, start, [RaSystem, ClusterName]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 rpc:call(Node, khepri_cluster, join, [ClusterName, Node3]))
+      end, [Node1, Node2]),
+
+    ct:pal("Use database after starting it"),
+    ?assertEqual(
+       {ok, #{[foo] => #{}}},
+       rpc:call(Node1, khepri, put, [StoreId, [foo], value1])),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, #{[foo] => #{data => value1,
+                                   payload_version => 1,
+                                   child_list_version => 1,
+                                   child_list_length => 0}}},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, Nodes),
+
+    %% Stop the current leader.
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, StoppedLeaderNode1} = LeaderId1,
+    RunningNodes1 = Nodes -- [StoppedLeaderNode1],
+
+    ct:pal(
+      "Stop database on leader node ~s (quorum is maintained)",
+      [StoppedLeaderNode1]),
+    ?assertEqual(
+       ok,
+       rpc:call(StoppedLeaderNode1, khepri, stop, [StoreId])),
+
+    %% Stop the next elected leader.
+    LeaderId2 = get_leader_in_store(StoreId, RunningNodes1),
+    ?assertNotEqual(LeaderId1, LeaderId2),
+    {StoreId, StoppedLeaderNode2} = LeaderId2,
+    RunningNodes2 = RunningNodes1 -- [StoppedLeaderNode2],
+
+    ct:pal(
+      "Stop database on the new leader node ~s (quorum is lost)",
+      [StoppedLeaderNode2]),
+    ?assertEqual(
+       ok,
+       rpc:call(StoppedLeaderNode2, khepri, stop, [StoreId])),
+
+    ct:pal(
+      "Restart database on node ~s (quorum is restored)",
+      [StoppedLeaderNode1]),
+    ?assertEqual(
+       {ok, StoreId},
+       rpc:call(StoppedLeaderNode1, khepri, start, [RaSystem, StoreId])),
+    RunningNodes3 = RunningNodes2 ++ [StoppedLeaderNode1],
+
+    ct:pal("Use database after having it running on 2 out of 3 nodes"),
+    %% We try a put from the stopped leader and it should fail because the
+    %% leaderboard on that node is stale.
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(StoppedLeaderNode2, khepri, put, [StoreId, [foo], value2])),
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(StoppedLeaderNode2, khepri, get, [StoreId, [foo]])),
+
+    %% Querying running nodes should be fine however.
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, #{[foo] => #{data => value1,
+                                   payload_version => 1,
+                                   child_list_version => 1,
+                                   child_list_length => 0}}},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, RunningNodes3),
+
+    %% Likewise, a put from a running node should succeed.
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value1,
+                         payload_version => 1,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       rpc:call(hd(RunningNodes3), khepri, put, [StoreId, [foo], value3])),
+
+    %% The stopped leader should still fail to respond because it is stopped
+    %% and again, the leaderboard is stale on this node.
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(StoppedLeaderNode2, khepri, get, [StoreId, [foo]])),
+
+    %% Running nodes should see the updated value however.
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, #{[foo] => #{data => value3,
+                                   payload_version => 2,
+                                   child_list_version => 1,
+                                   child_list_length => 0}}},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, RunningNodes3),
+
+    ok.
+
+can_reset_a_cluster_member(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1, Node2, Node3] = Nodes = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 rpc:call(Node, khepri, start, [RaSystem, ClusterName]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 rpc:call(Node, khepri_cluster, join, [ClusterName, Node3]))
+      end, [Node1, Node2]),
+
+    ct:pal("Check membership on all nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:nodes() from node ~s", [Node]),
+              ?assertEqual(
+                 lists:sort(Nodes),
+                 lists:sort(rpc:call(
+                              Node, khepri_cluster, nodes, [ClusterName])))
+      end, Nodes),
+
+    %% Reset the current leader.
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, StoppedLeaderNode1} = LeaderId1,
+    RunningNodes1 = Nodes -- [StoppedLeaderNode1],
+
+    ct:pal(
+      "Reset database on leader node ~s",
+      [StoppedLeaderNode1]),
+    ?assertEqual(
+       ok,
+       rpc:call(StoppedLeaderNode1, khepri_cluster, reset, [StoreId])),
+
+    ct:pal("Check membership on remaining nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:nodes() from node ~s", [Node]),
+              ?assertEqual(
+                 lists:sort(RunningNodes1),
+                 lists:sort(rpc:call(
+                              Node, khepri_cluster, nodes, [ClusterName])))
+      end, RunningNodes1),
+
+    ok.
+
+fail_to_join_if_not_started(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1, Node2, _Node3] = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
+    ClusterName = RaSystem,
+
+    ct:pal("Cluster node"),
+    ?assertEqual(
+       {error, {not_a_khepri_store, ClusterName}},
+       rpc:call(
+         Node1, khepri_cluster, join, [ClusterName, Node2])),
+
+    ok.
+
+fail_to_join_non_existing_node(Config) ->
+    Node = node(),
+    #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Start database"),
+    ?assertEqual(
+       {ok, StoreId},
+       khepri:start(RaSystem, ClusterName)),
+
+    ct:pal("Cluster node"),
+    RemoteNode = non_existing@localhost,
+    ?assertEqual(
+       {error, {nodedown, RemoteNode}},
+       khepri_cluster:join(ClusterName, RemoteNode)),
+
+    ThisMember = khepri_cluster:node_to_member(StoreId, node()),
+    ?assertEqual(
+       [ThisMember],
+       khepri_cluster:members(StoreId)),
+
+    ct:pal("Stop database"),
+    ?assertEqual(
+       ok,
+       khepri:stop(StoreId)),
+
+    ok.
+
+fail_to_join_non_existing_store(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1, Node2, _Node3] = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
+    StoreId = ClusterName = RaSystem,
+
+    ct:pal("Start database"),
+    ?assertEqual(
+       {ok, StoreId},
+       rpc:call(Node1, khepri, start, [RaSystem, ClusterName])),
+
+    ct:pal("Cluster node"),
+    ?assertEqual(
+       {error, noproc},
+       rpc:call(
+         Node1, khepri_cluster, join, [ClusterName, Node2])),
+
+    ?assertEqual(
+       [khepri_cluster:node_to_member(StoreId, Node1)],
+       rpc:call(
+         Node1, khepri_cluster, members, [ClusterName])),
+
+    ct:pal("Stop database"),
+    ?assertEqual(
+       ok,
+       rpc:call(Node1, khepri, stop, [StoreId])),
+
+    ok.
+
+can_use_default_store_on_single_node(_Config) ->
+    ?assertMatch({ok, _}, application:ensure_all_started(khepri)),
+    DataDir = khepri_cluster:get_default_ra_system_or_data_dir(),
+    ?assertNot(filelib:is_dir(DataDir)),
+
+    ?assertEqual({error, noproc}, khepri:get([foo])),
+
+    {ok, StoreId} = khepri:start(),
+    ?assert(filelib:is_dir(DataDir)),
+
+    ?assertEqual(
+       {ok, #{[foo] => #{}}},
+       khepri:create([foo], value1)),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value1,
+                         payload_version => 1,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:put([foo], value2)),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value2,
+                         payload_version => 2,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:update([foo], value3)),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value3,
+                         payload_version => 3,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:compare_and_swap([foo], value3, value4)),
+
+    ?assertEqual(true, khepri:exists([foo])),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value4,
+                         payload_version => 4,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:get([foo])),
+
+    ?assertEqual(ok, khepri:stop()),
+    ?assertEqual({error, noproc}, khepri:get([foo])),
+
+    ?assertEqual({ok, StoreId}, khepri:start()),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value4,
+                         payload_version => 4,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:get([foo])),
+    ?assertEqual(
+       #{data => value4,
+         payload_version => 4,
+         child_list_version => 1,
+         child_list_length => 0},
+       khepri:get_node_props([foo])),
+    ?assertEqual(true, khepri:has_data([foo])),
+    ?assertEqual(value4, khepri:get_data([foo])),
+    ?assertEqual(value4, khepri:get_data_or([foo], no_data)),
+    ?assertEqual(false, khepri:has_sproc([foo])),
+    ?assertThrow(
+       {invalid_sproc_fun,
+        {no_sproc, [foo], #{data := value4,
+                            payload_version := 4,
+                            child_list_version := 1,
+                            child_list_length := 0}}},
+       khepri:run_sproc([foo], [])),
+    ?assertEqual({ok, 1}, khepri:count("**")),
+    ?assertEqual({ok, #{}}, khepri:list([bar])),
+    ?assertEqual({ok, #{}}, khepri:find([bar], ?STAR)),
+
+    ?assertEqual(
+       {ok, #{[bar] => #{}}},
+       khepri:create([bar], value1)),
+    ?assertEqual(
+       {ok, #{[bar] => #{data => value1,
+                         payload_version => 1,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:clear_payload([bar])),
+    ?assertEqual(
+       {ok, #{[bar] => #{payload_version => 2,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:delete([bar])),
+
+    ?assertEqual({ok, StoreId}, khepri:start()),
+    ?assertEqual(ok, khepri:reset()),
+    ?assertEqual({error, noproc}, khepri:get([foo])),
+
+    ?assertEqual({ok, StoreId}, khepri:start()),
+    ?assertEqual({ok, #{}}, khepri:get([foo])),
+
+    ?assertEqual(ok, khepri:stop()),
+    ?assertEqual(ok, application:stop(khepri)),
+    ?assertEqual(ok, application:stop(ra)),
+
+    helpers:remove_store_dir(DataDir),
+    ?assertNot(filelib:is_dir(DataDir)).
+
+can_start_store_in_specified_data_dir_on_single_node(_Config) ->
+    DataDir = atom_to_list(?FUNCTION_NAME),
+    ?assertNot(filelib:is_dir(DataDir)),
+
+    ?assertEqual({error, noproc}, khepri:get([foo])),
+
+    {ok, StoreId} = khepri:start(DataDir),
+    ?assert(filelib:is_dir(DataDir)),
+
+    ?assertEqual(
+       {ok, #{[foo] => #{}}},
+       khepri:create(StoreId, [foo], value1, #{})),
+    ?assertMatch(
+       {error, {mismatching_node, _}},
+       khepri:create(StoreId, [foo], value1, #{keep_while => #{}})),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value1,
+                         payload_version => 1,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:put(StoreId, [foo], value2)),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value2,
+                         payload_version => 2,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:update(StoreId, [foo], value3, #{})),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value3,
+                         payload_version => 3,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:update(StoreId, [foo], value3, #{keep_while => #{}})),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value3,
+                         payload_version => 3,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:compare_and_swap([foo], value3, value4)),
+
+    ?assertEqual(true, khepri:exists([foo], #{})),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value4,
+                         payload_version => 4,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:get([foo], #{})),
+
+    ?assertEqual(ok, khepri:stop()),
+    ?assertEqual({error, noproc}, khepri:get([foo])),
+
+    ?assertEqual({ok, StoreId}, khepri:start(list_to_binary(DataDir))),
+    ?assertEqual(
+       {ok, #{[foo] => #{data => value4,
+                         payload_version => 4,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:get([foo])),
+    ?assertEqual(
+       #{data => value4,
+         payload_version => 4,
+         child_list_version => 1,
+         child_list_length => 0},
+       khepri:get_node_props([foo], #{})),
+    ?assertEqual(true, khepri:has_data([foo], #{})),
+    ?assertEqual(value4, khepri:get_data([foo], #{})),
+    ?assertEqual(value4, khepri:get_data_or([foo], no_data, #{})),
+    ?assertEqual(false, khepri:has_sproc([foo], #{})),
+    ?assertThrow(
+       {invalid_sproc_fun,
+        {no_sproc, [foo], #{data := value4,
+                            payload_version := 4,
+                            child_list_version := 1,
+                            child_list_length := 0}}},
+       khepri:run_sproc([foo], [], #{})),
+    ?assertEqual({ok, 1}, khepri:count("**", #{})),
+    ?assertEqual({ok, #{}}, khepri:list([bar], #{})),
+    ?assertEqual({ok, #{}}, khepri:find([bar], ?STAR, #{})),
+
+    ?assertEqual(
+       {ok, #{[bar] => #{}}},
+       khepri:create([bar], value1)),
+    ?assertEqual(
+       {ok, #{[bar] => #{data => value1,
+                         payload_version => 1,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:clear_payload([bar])),
+    ?assertEqual(
+       {ok, #{[bar] => #{payload_version => 2,
+                         child_list_version => 1,
+                         child_list_length => 0}}},
+       khepri:delete([bar], #{})),
+
+    ?assertEqual({ok, StoreId}, khepri:start(DataDir)),
+    ?assertEqual(ok, khepri:reset(10000)),
+    ?assertEqual({error, noproc}, khepri:get([foo])),
+
+    ?assertEqual({ok, StoreId}, khepri:start(DataDir)),
+    ?assertEqual({ok, #{}}, khepri:get([foo])),
+
+    ?assertEqual(ok, khepri:stop()),
+    ?assertEqual(ok, application:stop(khepri)),
+    ?assertEqual(ok, application:stop(ra)),
+
+    helpers:remove_store_dir(DataDir),
+    ?assertNot(filelib:is_dir(DataDir)).
+
+%% -------------------------------------------------------------------
+%% Internal functions
+%% -------------------------------------------------------------------
+
+setup_node() ->
+    _ = logger:set_handler_config(
+          default, formatter,
+          {logger_formatter, #{single_line => true}}),
+    _ = logger:add_handler_filter(
+          default, progress,
+          {fun logger_filters:progress/2,stop}),
+    _ = logger:set_primary_config(level, debug),
+
+    ok = application:set_env(
+           khepri, default_timeout, 2000, [{persistent, true}]),
+
+    ok.
+
+start_n_nodes(NamePrefix, Count) ->
+    ct:pal("Start ~b Erlang nodes:", [Count]),
+    Nodes = [begin
+                 Name = lists:flatten(
+                          io_lib:format(
+                            "~s-~s-~b", [?MODULE, NamePrefix, I])),
+                 ct:pal("- ~s", [Name]),
+                 start_erlang_node(Name)
+             end || I <- lists:seq(1, Count)],
+    ct:pal("Started nodes: ~p", [Nodes]),
+    CodePath = code:get_path(),
+    lists:foreach(
+      fun(Node) ->
+              rpc:call(Node, code, add_pathsz, [CodePath]),
+              ok = rpc:call(Node, ?MODULE, setup_node, [])
+      end, Nodes),
+    Nodes.
+
+-if(?OTP_RELEASE >= 25).
+start_erlang_node(Name) ->
+    Name1 = list_to_atom(Name),
+    {ok, _, Node} = peer:start(#{name => Name1,
+                                 wait_boot => infinity}),
+    Node.
+-else.
+start_erlang_node(Name) ->
+    Name1 = list_to_atom(Name),
+    Options = [{monitor_master, true}],
+    {ok, Node} = ct_slave:start(Name1, Options),
+    Node.
+-endif.
+
+get_leader_in_store(StoreId, [Node | _] = _RunningNodes) ->
+    %% Query members; this is used to make sure there is an elected leader.
+    ct:pal("Trying to figure who the leader is in \"~s\"", [StoreId]),
+    [_ | _] = rpc:call(Node, khepri_cluster, members, [StoreId]),
+    LeaderId = rpc:call(Node, ra_leaderboard, lookup_leader, [StoreId]),
+    ?assertNotEqual(undefined, LeaderId),
+    LeaderId.

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -111,7 +111,7 @@ end_per_testcase(_Testcase, Config) ->
 can_start_a_single_node(Config) ->
     Node = node(),
     #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Use database before starting it"),
     ?assertEqual(
@@ -124,7 +124,7 @@ can_start_a_single_node(Config) ->
     ct:pal("Start database"),
     ?assertEqual(
        {ok, StoreId},
-       khepri:start(RaSystem, ClusterName)),
+       khepri:start(RaSystem, StoreId)),
 
     ct:pal("Use database after starting it"),
     ?assertEqual(
@@ -157,7 +157,7 @@ can_start_a_single_node(Config) ->
 fail_to_start_with_bad_ra_server_config(Config) ->
     Node = node(),
     #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Start database"),
     ?assertExit(
@@ -165,7 +165,7 @@ fail_to_start_with_bad_ra_server_config(Config) ->
           {{timeout, tick}, not_a_timeout, tick_timeout}},
          _},
         _},
-       khepri:start(RaSystem, #{cluster_name => ClusterName,
+       khepri:start(RaSystem, #{cluster_name => StoreId,
                                 tick_timeout => not_a_timeout})),
 
     ThisMember = khepri_cluster:node_to_member(StoreId, node()),
@@ -195,12 +195,12 @@ fail_to_start_with_bad_ra_server_config(Config) ->
 initial_members_are_ignored(Config) ->
     Node = node(),
     #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Start database"),
     ?assertEqual(
        {ok, StoreId},
-       khepri:start(RaSystem, #{cluster_name => ClusterName,
+       khepri:start(RaSystem, #{cluster_name => StoreId,
                                 initial_members => [{StoreId, a},
                                                     {StoreId, b},
                                                     {StoreId, c}]})),
@@ -224,7 +224,7 @@ can_start_a_three_node_cluster(Config) ->
 
     %% We assume all nodes are using the same Ra system name & store ID.
     #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Use database before starting it"),
     lists:foreach(
@@ -245,41 +245,41 @@ can_start_a_three_node_cluster(Config) ->
               ct:pal("- khepri:start() from node ~s", [Node]),
               ?assertEqual(
                  {ok, StoreId},
-                 rpc:call(Node, khepri, start, [RaSystem, ClusterName]))
+                 rpc:call(Node, khepri, start, [RaSystem, StoreId]))
       end, Nodes),
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri_cluster:join() from node ~s", [Node]),
               ?assertEqual(
                  ok,
-                 rpc:call(Node, khepri_cluster, join, [ClusterName, Node3]))
+                 rpc:call(Node, khepri_cluster, join, [StoreId, Node3]))
       end, [Node1, Node2]),
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri_cluster:members() from node ~s", [Node]),
-              ExpectedMembers = lists:sort([{ClusterName, N} || N <- Nodes]),
+              ExpectedMembers = lists:sort([{StoreId, N} || N <- Nodes]),
               ?assertEqual(
                  ExpectedMembers,
                  lists:sort(
-                   rpc:call(Node, khepri_cluster, members, [ClusterName]))),
+                   rpc:call(Node, khepri_cluster, members, [StoreId]))),
               ?assertEqual(
                  ExpectedMembers,
                  lists:sort(
                    rpc:call(
                      Node, khepri_cluster, locally_known_members,
-                     [ClusterName]))),
+                     [StoreId]))),
 
               ExpectedNodes = lists:sort(Nodes),
               ?assertEqual(
                  ExpectedNodes,
                  lists:sort(
-                   rpc:call(Node, khepri_cluster, nodes, [ClusterName]))),
+                   rpc:call(Node, khepri_cluster, nodes, [StoreId]))),
               ?assertEqual(
                  ExpectedNodes,
                  lists:sort(
                    rpc:call(
                      Node, khepri_cluster, locally_known_nodes,
-                     [ClusterName])))
+                     [StoreId])))
       end, Nodes),
 
     ct:pal("Use database after starting it"),
@@ -388,7 +388,7 @@ can_restart_nodes_in_a_three_node_cluster(Config) ->
 
     %% We assume all nodes are using the same Ra system name & store ID.
     #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Start database + cluster nodes"),
     lists:foreach(
@@ -396,14 +396,14 @@ can_restart_nodes_in_a_three_node_cluster(Config) ->
               ct:pal("- khepri:start() from node ~s", [Node]),
               ?assertEqual(
                  {ok, StoreId},
-                 rpc:call(Node, khepri, start, [RaSystem, ClusterName]))
+                 rpc:call(Node, khepri, start, [RaSystem, StoreId]))
       end, Nodes),
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri_cluster:join() from node ~s", [Node]),
               ?assertEqual(
                  ok,
-                 rpc:call(Node, khepri_cluster, join, [ClusterName, Node3]))
+                 rpc:call(Node, khepri_cluster, join, [StoreId, Node3]))
       end, [Node1, Node2]),
 
     ct:pal("Use database after starting it"),
@@ -510,7 +510,7 @@ can_reset_a_cluster_member(Config) ->
 
     %% We assume all nodes are using the same Ra system name & store ID.
     #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Start database + cluster nodes"),
     lists:foreach(
@@ -518,14 +518,14 @@ can_reset_a_cluster_member(Config) ->
               ct:pal("- khepri:start() from node ~s", [Node]),
               ?assertEqual(
                  {ok, StoreId},
-                 rpc:call(Node, khepri, start, [RaSystem, ClusterName]))
+                 rpc:call(Node, khepri, start, [RaSystem, StoreId]))
       end, Nodes),
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri_cluster:join() from node ~s", [Node]),
               ?assertEqual(
                  ok,
-                 rpc:call(Node, khepri_cluster, join, [ClusterName, Node3]))
+                 rpc:call(Node, khepri_cluster, join, [StoreId, Node3]))
       end, [Node1, Node2]),
 
     ct:pal("Check membership on all nodes"),
@@ -535,7 +535,7 @@ can_reset_a_cluster_member(Config) ->
               ?assertEqual(
                  lists:sort(Nodes),
                  lists:sort(rpc:call(
-                              Node, khepri_cluster, nodes, [ClusterName])))
+                              Node, khepri_cluster, nodes, [StoreId])))
       end, Nodes),
 
     %% Reset the current leader.
@@ -557,7 +557,7 @@ can_reset_a_cluster_member(Config) ->
               ?assertEqual(
                  lists:sort(RunningNodes1),
                  lists:sort(rpc:call(
-                              Node, khepri_cluster, nodes, [ClusterName])))
+                              Node, khepri_cluster, nodes, [StoreId])))
       end, RunningNodes1),
 
     ok.
@@ -568,31 +568,31 @@ fail_to_join_if_not_started(Config) ->
 
     %% We assume all nodes are using the same Ra system name & store ID.
     #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
-    ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Cluster node"),
     ?assertEqual(
-       {error, {not_a_khepri_store, ClusterName}},
+       {error, {not_a_khepri_store, StoreId}},
        rpc:call(
-         Node1, khepri_cluster, join, [ClusterName, Node2])),
+         Node1, khepri_cluster, join, [StoreId, Node2])),
 
     ok.
 
 fail_to_join_non_existing_node(Config) ->
     Node = node(),
     #{Node := #{ra_system := RaSystem}} = ?config(ra_system_props, Config),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Start database"),
     ?assertEqual(
        {ok, StoreId},
-       khepri:start(RaSystem, ClusterName)),
+       khepri:start(RaSystem, StoreId)),
 
     ct:pal("Cluster node"),
     RemoteNode = non_existing@localhost,
     ?assertEqual(
        {error, {nodedown, RemoteNode}},
-       khepri_cluster:join(ClusterName, RemoteNode)),
+       khepri_cluster:join(StoreId, RemoteNode)),
 
     ThisMember = khepri_cluster:node_to_member(StoreId, node()),
     ?assertEqual(
@@ -612,23 +612,23 @@ fail_to_join_non_existing_store(Config) ->
 
     %% We assume all nodes are using the same Ra system name & store ID.
     #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
-    StoreId = ClusterName = RaSystem,
+    StoreId = RaSystem,
 
     ct:pal("Start database"),
     ?assertEqual(
        {ok, StoreId},
-       rpc:call(Node1, khepri, start, [RaSystem, ClusterName])),
+       rpc:call(Node1, khepri, start, [RaSystem, StoreId])),
 
     ct:pal("Cluster node"),
     ?assertEqual(
        {error, noproc},
        rpc:call(
-         Node1, khepri_cluster, join, [ClusterName, Node2])),
+         Node1, khepri_cluster, join, [StoreId, Node2])),
 
     ?assertEqual(
        [khepri_cluster:node_to_member(StoreId, Node1)],
        rpc:call(
-         Node1, khepri_cluster, members, [ClusterName])),
+         Node1, khepri_cluster, members, [StoreId])),
 
     ct:pal("Stop database"),
     ?assertEqual(

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -168,7 +168,7 @@ fail_to_start_with_bad_ra_server_config(Config) ->
        khepri:start(RaSystem, #{cluster_name => StoreId,
                                 tick_timeout => not_a_timeout})),
 
-    ThisMember = khepri_cluster:node_to_member(StoreId, node()),
+    ThisMember = khepri_cluster:this_member(StoreId),
     ok = khepri_cluster:wait_for_ra_server_exit(ThisMember),
 
     %% The process is restarted by its supervisor. Depending on the timing, we
@@ -206,7 +206,7 @@ initial_members_are_ignored(Config) ->
                                                     {StoreId, c}]})),
 
     ct:pal("This member is alone in the \"cluster\""),
-    ThisMember = khepri_cluster:node_to_member(StoreId, node()),
+    ThisMember = khepri_cluster:this_member(StoreId),
     ?assertEqual(
        [ThisMember],
        khepri_cluster:members(StoreId)),
@@ -594,7 +594,7 @@ fail_to_join_non_existing_node(Config) ->
        {error, {nodedown, RemoteNode}},
        khepri_cluster:join(StoreId, RemoteNode)),
 
-    ThisMember = khepri_cluster:node_to_member(StoreId, node()),
+    ThisMember = khepri_cluster:this_member(StoreId),
     ?assertEqual(
        [ThisMember],
        khepri_cluster:members(StoreId)),

--- a/test/cth_log_redirect_any_domains.erl
+++ b/test/cth_log_redirect_any_domains.erl
@@ -1,0 +1,23 @@
+-module(cth_log_redirect_any_domains).
+
+-export([log/2]).
+
+-define(BACKEND_MODULE, cth_log_redirect).
+
+%% Reversed behavior compared to `cth_log_redirect': log events with an
+%% unknown domain are sent to the `cth_log_redirect' server, others are
+%% dropped (as they are already handled by `cth_log_redirect').
+log(#{msg:={report,_Msg},meta:=#{domain:=[otp,sasl]}},_Config) ->
+    ok;
+log(#{meta:=#{domain:=[otp]}},_Config) ->
+    ok;
+log(#{meta:=#{domain:=_}}=Log,Config) ->
+    do_log(add_log_category(Log,error_logger),Config);
+log(_Log,_Config) ->
+    ok.
+
+add_log_category(#{meta:=Meta}=Log,Category) ->
+    Log#{meta=>Meta#{?BACKEND_MODULE=>#{category=>Category}}}.
+
+do_log(Log,Config) ->
+    gen_server:call(?BACKEND_MODULE,{log,Log,Config}).

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -69,7 +69,7 @@ get_store_info_on_non_existing_store_test_() ->
          "\033[1;32m== CLUSTER MEMBERS ==\033[0m\n"
          "\n",
          begin
-             khepri:info(non_existing_store),
+             khepri:info(non_existing_store, #{timeout => 1000}),
              ?capturedOutput
          end)]}.
 

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -136,3 +136,24 @@ get_store_info_with_keep_while_conds_test_() ->
              khepri:info(?FUNCTION_NAME),
              ?capturedOutput
          end)]}.
+
+get_all_stores_info_with_no_store_test() ->
+    ?assertEqual(
+       "No stores running\n",
+       begin
+           khepri:info(),
+           ?capturedOutput
+       end).
+
+get_all_stores_info_with_one_store_test_() ->
+    StoreId = ?FUNCTION_NAME,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         "Running stores:\n"
+         "  " ++ atom_to_list(StoreId) ++ "\n",
+         begin
+             khepri:info(),
+             ?capturedOutput
+         end)]}.

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -18,7 +18,9 @@
 -dialyzer(no_missing_calls).
 
 delete_non_existing_node_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #delete{path = [foo]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
@@ -28,7 +30,9 @@ delete_non_existing_node_test() ->
     ?assertEqual([], SE).
 
 delete_non_existing_node_under_non_existing_parent_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #delete{path = [foo, bar, baz]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
@@ -41,6 +45,8 @@ delete_existing_node_with_data_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [foo]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -63,6 +69,8 @@ delete_existing_node_with_data_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [foo, ?THIS_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -85,6 +93,8 @@ delete_existing_node_with_child_nodes_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [foo]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -106,6 +116,8 @@ delete_a_node_deep_into_the_tree_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [foo, bar, baz]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -138,6 +150,8 @@ delete_existing_node_with_condition_true_test() ->
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [#if_data_matches{pattern = bar_value}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -165,6 +179,8 @@ delete_existing_node_with_condition_false_test() ->
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [#if_data_matches{pattern = other_value}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -192,6 +208,8 @@ delete_existing_node_with_condition_true_using_dot_test() ->
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path =
                       [bar,
@@ -223,6 +241,8 @@ delete_existing_node_with_condition_false_using_dot_test() ->
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path =
                       [bar,
@@ -256,6 +276,8 @@ delete_many_nodes_at_once_test() ->
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [#if_name_matches{regex = "a"}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -284,6 +306,8 @@ delete_many_nodes_at_once_test() ->
 delete_command_bumps_applied_command_count_test() ->
     Commands = [#delete{path = [foo]}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                snapshot_interval => 3,
                                commands => Commands}),
 

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -18,9 +18,7 @@
 -dialyzer(no_missing_calls).
 
 delete_non_existing_node_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #delete{path = [foo]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
@@ -30,9 +28,7 @@ delete_non_existing_node_test() ->
     ?assertEqual([], SE).
 
 delete_non_existing_node_under_non_existing_parent_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #delete{path = [foo, bar, baz]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
@@ -44,10 +40,7 @@ delete_non_existing_node_under_non_existing_parent_test() ->
 delete_existing_node_with_data_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [foo]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -68,10 +61,7 @@ delete_existing_node_with_data_test() ->
 delete_existing_node_with_data_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [foo, ?THIS_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -92,10 +82,7 @@ delete_existing_node_with_data_using_dot_test() ->
 delete_existing_node_with_child_nodes_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [foo]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -115,10 +102,7 @@ delete_existing_node_with_child_nodes_test() ->
 delete_a_node_deep_into_the_tree_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [foo, bar, baz]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -149,10 +133,7 @@ delete_existing_node_with_condition_true_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [#if_data_matches{pattern = bar_value}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -178,10 +159,7 @@ delete_existing_node_with_condition_false_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [#if_data_matches{pattern = other_value}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -207,10 +185,7 @@ delete_existing_node_with_condition_true_using_dot_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path =
                       [bar,
                        #if_all{conditions =
@@ -240,10 +215,7 @@ delete_existing_node_with_condition_false_using_dot_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path =
                       [bar,
                        #if_all{conditions =
@@ -275,10 +247,7 @@ delete_many_nodes_at_once_test() ->
                      payload = khepri_payload:data(bar_value)},
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [#if_name_matches{regex = "a"}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -306,8 +275,8 @@ delete_many_nodes_at_once_test() ->
 delete_command_bumps_applied_command_count_test() ->
     Commands = [#delete{path = [foo]}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
+                               member => khepri_cluster:this_member(
+                                           ?FUNCTION_NAME),
                                snapshot_interval => 3,
                                commands => Commands}),
 

--- a/test/display_tree.erl
+++ b/test/display_tree.erl
@@ -26,6 +26,8 @@ complex_flat_struct_to_tree_test() ->
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -360,6 +362,8 @@ display_simple_tree_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -399,6 +403,8 @@ display_large_tree_test() ->
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -456,6 +462,8 @@ display_tree_with_plaintext_lines_test() ->
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -513,6 +521,8 @@ display_tree_without_colors_test() ->
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -570,6 +580,8 @@ display_tree_with_plaintext_lines_and_without_colors_test() ->
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -611,6 +623,8 @@ display_tree_with_binary_key_test() ->
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
@@ -636,6 +650,8 @@ display_tree_with_similar_atom_and_binary_keys_test() ->
                 #put{path = [foo],
                      payload = khepri_payload:data(foo_atom)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(

--- a/test/display_tree.erl
+++ b/test/display_tree.erl
@@ -25,10 +25,7 @@ complex_flat_struct_to_tree_test() ->
                      payload = khepri_payload:data(baz_value)},
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,
@@ -361,10 +358,7 @@ flat_struct_with_children_before_parents_test() ->
 display_simple_tree_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,
@@ -402,10 +396,7 @@ display_large_tree_test() ->
                                   cupidatat, non, proident, sunt, in, culpa,
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,
@@ -461,10 +452,7 @@ display_tree_with_plaintext_lines_test() ->
                                   cupidatat, non, proident, sunt, in, culpa,
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,
@@ -520,10 +508,7 @@ display_tree_without_colors_test() ->
                                   cupidatat, non, proident, sunt, in, culpa,
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,
@@ -579,10 +564,7 @@ display_tree_with_plaintext_lines_and_without_colors_test() ->
                                   cupidatat, non, proident, sunt, in, culpa,
                                   qui, officia, deserunt, mollit, anim, id,
                                   est, laborum])}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,
@@ -622,10 +604,7 @@ display_tree_with_binary_key_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,
@@ -649,10 +628,7 @@ display_tree_with_similar_atom_and_binary_keys_test() ->
                      payload = khepri_payload:data(foo_binary)},
                 #put{path = [foo],
                      payload = khepri_payload:data(foo_atom)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     {ok, FlatStruct} = khepri_machine:find_matching_nodes(
                          Root,

--- a/test/favor_option.erl
+++ b/test/favor_option.erl
@@ -21,7 +21,7 @@ favor_compromise_in_get_test_() ->
          begin
              ?assertEqual(
                 undefined,
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -34,7 +34,7 @@ favor_compromise_in_get_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              Ref = khepri_machine:get_last_consistent_call_atomics(
                      ?FUNCTION_NAME),
              TS1 = atomics:get(Ref, 1),
@@ -49,7 +49,7 @@ favor_compromise_in_get_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              TS2 = atomics:get(Ref, 1),
              ?assertEqual(TS1, TS2),
 
@@ -62,7 +62,7 @@ favor_compromise_in_get_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              TS3 = atomics:get(Ref, 1),
              ?assertNotEqual(TS1, TS3),
 
@@ -78,7 +78,7 @@ favor_consistency_in_get_test_() ->
          begin
              ?assertEqual(
                 undefined,
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -91,7 +91,7 @@ favor_consistency_in_get_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              Ref = khepri_machine:get_last_consistent_call_atomics(
                      ?FUNCTION_NAME),
              TS1 = atomics:get(Ref, 1),
@@ -106,7 +106,7 @@ favor_consistency_in_get_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              TS2 = atomics:get(Ref, 1),
              ?assertNotEqual(TS1, TS2),
 
@@ -122,7 +122,7 @@ favor_low_latency_in_get_test_() ->
          begin
              ?assertEqual(
                 undefined,
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -135,7 +135,7 @@ favor_low_latency_in_get_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -148,7 +148,7 @@ favor_low_latency_in_get_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -168,7 +168,7 @@ favor_compromise_in_transaction_test_() ->
 
              ?assertEqual(
                 undefined,
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -181,7 +181,7 @@ favor_compromise_in_transaction_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              Ref = khepri_machine:get_last_consistent_call_atomics(
                      ?FUNCTION_NAME),
              TS1 = atomics:get(Ref, 1),
@@ -196,7 +196,7 @@ favor_compromise_in_transaction_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              TS2 = atomics:get(Ref, 1),
              ?assertEqual(TS1, TS2),
 
@@ -209,7 +209,7 @@ favor_compromise_in_transaction_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              TS3 = atomics:get(Ref, 1),
              ?assertNotEqual(TS1, TS3),
 
@@ -227,7 +227,7 @@ favor_consistency_in_transaction_test_() ->
 
              ?assertEqual(
                 undefined,
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -240,7 +240,7 @@ favor_consistency_in_transaction_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              Ref = khepri_machine:get_last_consistent_call_atomics(
                      ?FUNCTION_NAME),
              TS1 = atomics:get(Ref, 1),
@@ -255,7 +255,7 @@ favor_consistency_in_transaction_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              TS2 = atomics:get(Ref, 1),
              ?assertNotEqual(TS1, TS2),
 
@@ -273,7 +273,7 @@ favor_low_latency_in_transaction_test_() ->
 
              ?assertEqual(
                 undefined,
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -286,7 +286,7 @@ favor_low_latency_in_transaction_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(
@@ -299,7 +299,7 @@ favor_low_latency_in_transaction_test_() ->
 
              ?assertEqual(
                 {?FUNCTION_NAME, node()},
-                khepri_machine:get_cached_leader(?FUNCTION_NAME)),
+                khepri_cluster:get_cached_leader(?FUNCTION_NAME)),
              ?assertEqual(
                 undefined,
                 khepri_machine:get_last_consistent_call_atomics(

--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -1,0 +1,68 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(helpers).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-export([start_ra_system/1,
+         stop_ra_system/1,
+         store_dir_name/1,
+         remove_store_dir/1]).
+
+start_ra_system(RaSystem) ->
+    {ok, _} = application:ensure_all_started(ra),
+    StoreDir = store_dir_name(RaSystem),
+    _ = remove_store_dir(StoreDir),
+    Default = ra_system:default_config(),
+    RaSystemConfig = Default#{name => RaSystem,
+                              data_dir => StoreDir,
+                              wal_data_dir => StoreDir,
+                              wal_max_size_bytes => 16 * 1024,
+                              names => ra_system:derive_names(RaSystem)},
+    case ra_system:start(RaSystemConfig) of
+        {ok, RaSystemPid} ->
+            #{ra_system => RaSystem,
+              ra_system_pid => RaSystemPid,
+              store_dir => StoreDir};
+        {error, _} = Error ->
+            throw(Error)
+    end.
+
+stop_ra_system(#{ra_system := RaSystem,
+                 store_dir := StoreDir}) ->
+    ?assertEqual(ok, supervisor:terminate_child(ra_systems_sup, RaSystem)),
+    ?assertEqual(ok, supervisor:delete_child(ra_systems_sup, RaSystem)),
+    _ = remove_store_dir(StoreDir),
+    ok.
+
+store_dir_name(RaSystem) ->
+    Node = node(),
+    lists:flatten(
+      io_lib:format("_test.~s.~s", [RaSystem, Node])).
+
+remove_store_dir(StoreDir) ->
+    OnWindows = case os:type() of
+                    {win32, _} -> true;
+                    _          -> false
+                end,
+    case file:del_dir_r(StoreDir) of
+        ok ->
+            ok;
+        {error, enoent} ->
+            ok;
+        {error, eexist} when OnWindows ->
+            %% FIXME: Some files are not deleted on Windows... Are they still
+            %% open in Ra?
+            io:format(
+              standard_error,
+              "Files remaining in ~ts: ~p~n",
+              [StoreDir, file:list_dir_all(StoreDir)]),
+            ok;
+        Error ->
+            throw(Error)
+    end.

--- a/test/helpers.hrl
+++ b/test/helpers.hrl
@@ -8,3 +8,11 @@
 -define(META, #{index => ?LINE,
                 term => 1,
                 system_time => ?LINE}).
+
+-define(MACH_PARAMS(),
+        #{store_id => ?FUNCTION_NAME,
+          member => khepri_cluster:this_member(?FUNCTION_NAME)}).
+-define(MACH_PARAMS(Commands),
+        #{store_id => ?FUNCTION_NAME,
+          member => khepri_cluster:this_member(?FUNCTION_NAME),
+          commands => Commands}).

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -25,6 +25,8 @@ are_keep_while_conditions_met_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
 
@@ -63,6 +65,8 @@ insert_when_keep_while_true_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     KeepWhile = #{[foo] => #if_node_exists{exists = true}},
@@ -102,6 +106,8 @@ insert_when_keep_while_false_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     %% The targeted keep_while node does not exist.
@@ -142,7 +148,9 @@ insert_when_keep_while_false_test() ->
     ?assertEqual([], SE2).
 
 insert_when_keep_while_true_on_self_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = 0}},
     Command = #put{path = [foo],
                    payload = khepri_payload:data(foo_value),
@@ -165,7 +173,9 @@ insert_when_keep_while_true_on_self_test() ->
     ?assertEqual([], SE).
 
 insert_when_keep_while_false_on_self_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = 1}},
     Command = #put{path = [foo],
                    payload = khepri_payload:data(foo_value),
@@ -195,6 +205,8 @@ keep_while_still_true_after_command_test() ->
                      payload = khepri_payload:data(baz_value),
                      extra = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [foo],
@@ -232,6 +244,8 @@ keep_while_now_false_after_command_test() ->
                      payload = khepri_payload:data(baz_value),
                      extra = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [foo, bar],
@@ -269,6 +283,8 @@ recursive_automatic_cleanup_test() ->
                 #put{path = [foo, bar, baz],
                      payload = khepri_payload:data(baz_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #delete{path = [foo, bar, baz]},
@@ -296,6 +312,8 @@ keep_while_now_false_after_delete_command_test() ->
                      payload = khepri_payload:data(baz_value),
                      extra = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #delete{path = [foo]},

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -24,10 +24,7 @@
 are_keep_while_conditions_met_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
 
     %% TODO: Add more testcases.
@@ -64,10 +61,7 @@ are_keep_while_conditions_met_test() ->
 insert_when_keep_while_true_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     KeepWhile = #{[foo] => #if_node_exists{exists = true}},
     Command = #put{path = [baz],
@@ -105,10 +99,7 @@ insert_when_keep_while_true_test() ->
 insert_when_keep_while_false_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     %% The targeted keep_while node does not exist.
     KeepWhile1 = #{[foo, bar] => #if_node_exists{exists = true}},
@@ -148,9 +139,7 @@ insert_when_keep_while_false_test() ->
     ?assertEqual([], SE2).
 
 insert_when_keep_while_true_on_self_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = 0}},
     Command = #put{path = [foo],
                    payload = khepri_payload:data(foo_value),
@@ -173,9 +162,7 @@ insert_when_keep_while_true_on_self_test() ->
     ?assertEqual([], SE).
 
 insert_when_keep_while_false_on_self_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     KeepWhile = #{[?THIS_NODE] => #if_child_list_length{count = 1}},
     Command = #put{path = [foo],
                    payload = khepri_payload:data(foo_value),
@@ -204,10 +191,7 @@ keep_while_still_true_after_command_test() ->
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value),
                      extra = #{keep_while => KeepWhile}}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [foo],
                    payload = khepri_payload:data(new_foo_value)},
@@ -243,10 +227,7 @@ keep_while_now_false_after_command_test() ->
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value),
                      extra = #{keep_while => KeepWhile}}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [foo, bar],
                    payload = khepri_payload:data(bar_value)},
@@ -282,10 +263,7 @@ recursive_automatic_cleanup_test() ->
                      extra = #{keep_while => KeepWhile}},
                 #put{path = [foo, bar, baz],
                      payload = khepri_payload:data(baz_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #delete{path = [foo, bar, baz]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -311,10 +289,7 @@ keep_while_now_false_after_delete_command_test() ->
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value),
                      extra = #{keep_while => KeepWhile}}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #delete{path = [foo]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -80,7 +80,7 @@ query_keep_while_conds_state_test_() ->
         ?_assertEqual(
            {ok, #{[foo] =>
                   #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
-           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{}))
        ]}]}.
 
 use_unix_string_path_in_keep_while_cond_test_() ->
@@ -99,7 +99,7 @@ use_unix_string_path_in_keep_while_cond_test_() ->
         ?_assertEqual(
            {ok, #{[foo] =>
                   #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
-           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{}))
        ]}]}.
 
 use_unix_binary_path_in_keep_while_cond_test_() ->
@@ -118,7 +118,7 @@ use_unix_binary_path_in_keep_while_cond_test_() ->
         ?_assertEqual(
            {ok, #{[foo] =>
                   #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
-           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{}))
        ]}]}.
 
 use_an_invalid_path_test_() ->

--- a/test/put_command.erl
+++ b/test/put_command.erl
@@ -22,10 +22,7 @@ initialize_machine_with_genesis_data_test() ->
                      payload = khepri_payload:data(foobar_value)},
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
 
     ?assertEqual(
@@ -50,9 +47,7 @@ initialize_machine_with_genesis_data_test() ->
        Root).
 
 insert_a_node_at_the_root_of_an_empty_db_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [foo],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -73,9 +68,7 @@ insert_a_node_at_the_root_of_an_empty_db_test() ->
     ?assertEqual([], SE).
 
 insert_a_node_at_the_root_of_an_empty_db_with_conditions_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [#if_all{conditions =
                                    [foo,
                                     #if_any{conditions =
@@ -103,10 +96,7 @@ insert_a_node_at_the_root_of_an_empty_db_with_conditions_test() ->
 overwrite_an_existing_node_data_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [foo],
                    payload = khepri_payload:data(value2)},
@@ -132,9 +122,7 @@ overwrite_an_existing_node_data_test() ->
     ?assertEqual([], SE).
 
 insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [foo, ?PARENT_NODE, foo, bar, ?THIS_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -159,9 +147,7 @@ insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
     ?assertEqual([], SE).
 
 insert_a_node_under_an_nonexisting_parents_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [foo, bar, baz, qux],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -196,10 +182,7 @@ insert_a_node_under_an_nonexisting_parents_test() ->
 insert_a_node_with_condition_true_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [#if_all{conditions =
                                    [foo,
@@ -228,10 +211,7 @@ insert_a_node_with_condition_true_on_self_test() ->
 insert_a_node_with_condition_false_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     %% We compile the condition beforehand because we need the compiled
     %% version to make an exact match on the returned error later.
@@ -257,10 +237,7 @@ insert_a_node_with_condition_false_on_self_test() ->
 insert_a_node_with_condition_true_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [foo,
                            #if_all{conditions =
@@ -290,10 +267,7 @@ insert_a_node_with_condition_true_on_self_using_dot_test() ->
 insert_a_node_with_condition_false_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     %% We compile the condition beforehand because we need the compiled
     %% version to make an exact match on the returned error later.
@@ -320,10 +294,7 @@ insert_a_node_with_condition_false_on_self_using_dot_test() ->
 insert_a_node_with_condition_true_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [#if_all{conditions =
                                    [foo,
@@ -355,10 +326,7 @@ insert_a_node_with_condition_true_on_parent_test() ->
 insert_a_node_with_condition_false_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     %% We compile the condition beforehand because we need the compiled
     %% version to make an exact match on the returned error later.
@@ -389,10 +357,7 @@ insert_a_node_with_condition_false_on_parent_test() ->
 insert_a_node_with_if_node_exists_true_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
@@ -440,10 +405,7 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
 insert_a_node_with_if_node_exists_false_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
@@ -493,10 +455,7 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
 insert_a_node_with_if_node_exists_true_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
@@ -547,10 +506,7 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
 insert_a_node_with_if_node_exists_false_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command1 = #put{path = [#if_all{conditions =
                                     [foo,
@@ -608,10 +564,7 @@ insert_with_a_path_matching_many_nodes_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [#if_name_matches{regex = any}],
                    payload = khepri_payload:data(new_value)},
@@ -628,10 +581,7 @@ insert_with_a_path_matching_many_nodes_test() ->
 clear_payload_in_an_existing_node_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [foo],
                    payload = ?NO_PAYLOAD},
@@ -660,8 +610,8 @@ put_command_bumps_applied_command_count_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
+                               member => khepri_cluster:this_member(
+                                           ?FUNCTION_NAME),
                                snapshot_interval => 3,
                                commands => Commands}),
 

--- a/test/put_command.erl
+++ b/test/put_command.erl
@@ -23,6 +23,8 @@ initialize_machine_with_genesis_data_test() ->
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
 
@@ -48,7 +50,9 @@ initialize_machine_with_genesis_data_test() ->
        Root).
 
 insert_a_node_at_the_root_of_an_empty_db_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [foo],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -69,7 +73,9 @@ insert_a_node_at_the_root_of_an_empty_db_test() ->
     ?assertEqual([], SE).
 
 insert_a_node_at_the_root_of_an_empty_db_with_conditions_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [#if_all{conditions =
                                    [foo,
                                     #if_any{conditions =
@@ -98,6 +104,8 @@ overwrite_an_existing_node_data_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [foo],
@@ -124,7 +132,9 @@ overwrite_an_existing_node_data_test() ->
     ?assertEqual([], SE).
 
 insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [foo, ?PARENT_NODE, foo, bar, ?THIS_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -149,7 +159,9 @@ insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
     ?assertEqual([], SE).
 
 insert_a_node_under_an_nonexisting_parents_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [foo, bar, baz, qux],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -185,6 +197,8 @@ insert_a_node_with_condition_true_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [#if_all{conditions =
@@ -215,6 +229,8 @@ insert_a_node_with_condition_false_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     %% We compile the condition beforehand because we need the compiled
@@ -242,6 +258,8 @@ insert_a_node_with_condition_true_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [foo,
@@ -273,6 +291,8 @@ insert_a_node_with_condition_false_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     %% We compile the condition beforehand because we need the compiled
@@ -301,6 +321,8 @@ insert_a_node_with_condition_true_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [#if_all{conditions =
@@ -334,6 +356,8 @@ insert_a_node_with_condition_false_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     %% We compile the condition beforehand because we need the compiled
@@ -366,6 +390,8 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
@@ -415,6 +441,8 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
@@ -466,6 +494,8 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
@@ -518,6 +548,8 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value1)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command1 = #put{path = [#if_all{conditions =
@@ -577,6 +609,8 @@ insert_with_a_path_matching_many_nodes_test() ->
                 #put{path = [bar],
                      payload = khepri_payload:data(bar_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [#if_name_matches{regex = any}],
@@ -595,6 +629,8 @@ clear_payload_in_an_existing_node_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
 
     Command = #put{path = [foo],
@@ -624,6 +660,8 @@ put_command_bumps_applied_command_count_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                snapshot_interval => 3,
                                commands => Commands}),
 

--- a/test/queries.erl
+++ b/test/queries.erl
@@ -17,9 +17,7 @@
 -dialyzer(no_missing_calls).
 
 query_a_non_existing_node_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo], #{}),
 
@@ -30,10 +28,7 @@ query_a_non_existing_node_test() ->
 query_an_existing_node_with_no_value_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo], #{}),
 
@@ -46,10 +41,7 @@ query_an_existing_node_with_no_value_test() ->
 query_an_existing_node_with_value_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo, bar], #{}),
 
@@ -63,10 +55,7 @@ query_an_existing_node_with_value_test() ->
 query_a_node_with_matching_condition_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -84,10 +73,7 @@ query_a_node_with_matching_condition_test() ->
 query_a_node_with_non_matching_condition_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -104,10 +90,7 @@ query_child_nodes_of_a_specific_node_test() ->
                      payload = khepri_payload:data(bar_value)},
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -132,10 +115,7 @@ query_child_nodes_of_a_specific_node_with_condition_on_leaf_test() ->
                      payload = khepri_payload:data(bar_value)},
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -158,10 +138,7 @@ query_many_nodes_with_condition_on_parent_test() ->
                      payload = khepri_payload:data(baz_value)},
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -189,10 +166,7 @@ query_many_nodes_recursively_test() ->
                      payload = khepri_payload:data(baz_value)},
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret1 = khepri_machine:find_matching_nodes(
              Root,
@@ -239,10 +213,7 @@ query_many_nodes_recursively_using_regex_test() ->
                      payload = khepri_payload:data(baz_value)},
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -272,10 +243,7 @@ query_many_nodes_recursively_with_condition_on_leaf_test() ->
                      payload = khepri_payload:data(baz_value)},
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -302,10 +270,7 @@ query_many_nodes_recursively_with_condition_on_self_test() ->
                      payload = khepri_payload:data(baz_value)},
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -341,10 +306,7 @@ query_many_nodes_recursively_with_several_star_star_test() ->
                      payload = khepri_payload:data(baz_value)},
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -363,10 +325,7 @@ query_many_nodes_recursively_with_several_star_star_test() ->
 query_a_node_using_relative_path_components_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root, [?THIS_NODE, foo, ?PARENT_NODE, foo, bar], #{}),
@@ -383,10 +342,7 @@ include_child_names_in_query_response_test() ->
                      payload = khepri_payload:data(bar_value)},
                 #put{path = [foo, quux],
                      payload = khepri_payload:data(quux_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,

--- a/test/queries.erl
+++ b/test/queries.erl
@@ -17,7 +17,9 @@
 -dialyzer(no_missing_calls).
 
 query_a_non_existing_node_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo], #{}),
 
@@ -29,6 +31,8 @@ query_an_existing_node_with_no_value_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo], #{}),
@@ -43,6 +47,8 @@ query_an_existing_node_with_value_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [foo, bar], #{}),
@@ -58,6 +64,8 @@ query_a_node_with_matching_condition_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -77,6 +85,8 @@ query_a_node_with_non_matching_condition_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -95,6 +105,8 @@ query_child_nodes_of_a_specific_node_test() ->
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -121,6 +133,8 @@ query_child_nodes_of_a_specific_node_with_condition_on_leaf_test() ->
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -145,6 +159,8 @@ query_many_nodes_with_condition_on_parent_test() ->
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -174,6 +190,8 @@ query_many_nodes_recursively_test() ->
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret1 = khepri_machine:find_matching_nodes(
@@ -222,6 +240,8 @@ query_many_nodes_recursively_using_regex_test() ->
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -253,6 +273,8 @@ query_many_nodes_recursively_with_condition_on_leaf_test() ->
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -281,6 +303,8 @@ query_many_nodes_recursively_with_condition_on_self_test() ->
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -318,6 +342,8 @@ query_many_nodes_recursively_with_several_star_star_test() ->
                 #put{path = [baz, pouet],
                      payload = khepri_payload:data(pouet_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -338,6 +364,8 @@ query_a_node_using_relative_path_components_test() ->
     Commands = [#put{path = [foo, bar],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
@@ -356,6 +384,8 @@ include_child_names_in_query_response_test() ->
                 #put{path = [foo, quux],
                      payload = khepri_payload:data(quux_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(

--- a/test/root_node.erl
+++ b/test/root_node.erl
@@ -17,9 +17,7 @@
 -dialyzer(no_missing_calls).
 
 query_root_node_implicitly_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [], #{}),
 
@@ -30,9 +28,7 @@ query_root_node_implicitly_test() ->
        Ret).
 
 query_root_node_explicitly_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [?ROOT_NODE], #{}),
 
@@ -43,9 +39,7 @@ query_root_node_explicitly_test() ->
        Ret).
 
 query_root_node_using_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [?THIS_NODE], #{}),
 
@@ -58,10 +52,7 @@ query_root_node_using_dot_test() ->
 query_above_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Root = khepri_machine:get_root(S0),
 
     Ret = khepri_machine:find_matching_nodes(
@@ -88,9 +79,7 @@ query_above_root_node_using_dot_dot_test() ->
        Ret).
 
 query_root_node_with_conditions_true_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -105,9 +94,7 @@ query_root_node_with_conditions_true_test() ->
        Ret).
 
 query_root_node_with_conditions_false_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -120,9 +107,7 @@ query_root_node_with_conditions_false_test() ->
        Ret).
 
 store_data_in_root_node_using_empty_path_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -141,9 +126,7 @@ store_data_in_root_node_using_empty_path_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_using_root_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [?ROOT_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -162,9 +145,7 @@ store_data_in_root_node_using_root_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_using_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [?THIS_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -183,9 +164,7 @@ store_data_in_root_node_using_dot_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_using_dot_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #put{path = [?PARENT_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -204,9 +183,7 @@ store_data_in_root_node_using_dot_dot_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_with_condition_true_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #put{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
                    payload = khepri_payload:data(value)},
@@ -226,9 +203,7 @@ store_data_in_root_node_with_condition_true_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_with_condition_true_using_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #put{path = [#if_all{conditions = [?THIS_NODE, Compiled]}],
                    payload = khepri_payload:data(value)},
@@ -248,9 +223,7 @@ store_data_in_root_node_with_condition_true_using_dot_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_with_condition_false_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #put{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
                    payload = khepri_payload:data(value)},
@@ -275,9 +248,7 @@ store_data_in_root_node_with_condition_false_test() ->
     ?assertEqual([], SE).
 
 delete_empty_root_node_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node())}),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
     Command = #delete{path = []},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -296,10 +267,7 @@ delete_empty_root_node_test() ->
 delete_root_node_using_empty_path_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = []},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -319,10 +287,7 @@ delete_root_node_using_empty_path_test() ->
 delete_root_node_using_root_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [?ROOT_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -342,10 +307,7 @@ delete_root_node_using_root_test() ->
 delete_root_node_using_dot_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [?THIS_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -365,10 +327,7 @@ delete_root_node_using_dot_test() ->
 delete_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = [?PARENT_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -390,10 +349,7 @@ delete_root_node_with_child_nodes_test() ->
                      payload = khepri_payload:data(bar_value)},
                 #put{path = [baz, qux],
                      payload = khepri_payload:data(qux_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Command = #delete{path = []},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -412,10 +368,7 @@ delete_root_node_with_child_nodes_test() ->
 delete_root_node_with_condition_true_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -435,10 +388,7 @@ delete_root_node_with_condition_true_test() ->
 delete_root_node_with_condition_true_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #delete{path = [#if_all{conditions = [?THIS_NODE, Compiled]}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -458,10 +408,7 @@ delete_root_node_with_condition_true_using_dot_test() ->
 delete_root_node_with_condition_false_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
-                               member => khepri_cluster:node_to_member(
-                                           ?FUNCTION_NAME, node()),
-                               commands => Commands}),
+    S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),

--- a/test/root_node.erl
+++ b/test/root_node.erl
@@ -17,7 +17,9 @@
 -dialyzer(no_missing_calls).
 
 query_root_node_implicitly_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [], #{}),
 
@@ -28,7 +30,9 @@ query_root_node_implicitly_test() ->
        Ret).
 
 query_root_node_explicitly_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [?ROOT_NODE], #{}),
 
@@ -39,7 +43,9 @@ query_root_node_explicitly_test() ->
        Ret).
 
 query_root_node_using_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(Root, [?THIS_NODE], #{}),
 
@@ -53,6 +59,8 @@ query_above_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Root = khepri_machine:get_root(S0),
 
@@ -80,7 +88,9 @@ query_above_root_node_using_dot_dot_test() ->
        Ret).
 
 query_root_node_with_conditions_true_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -95,7 +105,9 @@ query_root_node_with_conditions_true_test() ->
        Ret).
 
 query_root_node_with_conditions_false_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Root = khepri_machine:get_root(S0),
     Ret = khepri_machine:find_matching_nodes(
             Root,
@@ -108,7 +120,9 @@ query_root_node_with_conditions_false_test() ->
        Ret).
 
 store_data_in_root_node_using_empty_path_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -127,7 +141,9 @@ store_data_in_root_node_using_empty_path_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_using_root_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [?ROOT_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -146,7 +162,9 @@ store_data_in_root_node_using_root_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_using_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [?THIS_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -165,7 +183,9 @@ store_data_in_root_node_using_dot_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_using_dot_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #put{path = [?PARENT_NODE],
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -184,7 +204,9 @@ store_data_in_root_node_using_dot_dot_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_with_condition_true_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #put{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
                    payload = khepri_payload:data(value)},
@@ -204,7 +226,9 @@ store_data_in_root_node_with_condition_true_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_with_condition_true_using_dot_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #put{path = [#if_all{conditions = [?THIS_NODE, Compiled]}],
                    payload = khepri_payload:data(value)},
@@ -224,7 +248,9 @@ store_data_in_root_node_with_condition_true_using_dot_test() ->
     ?assertEqual([], SE).
 
 store_data_in_root_node_with_condition_false_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #put{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
                    payload = khepri_payload:data(value)},
@@ -249,7 +275,9 @@ store_data_in_root_node_with_condition_false_test() ->
     ?assertEqual([], SE).
 
 delete_empty_root_node_test() ->
-    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME}),
+    S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node())}),
     Command = #delete{path = []},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -269,6 +297,8 @@ delete_root_node_using_empty_path_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = []},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -290,6 +320,8 @@ delete_root_node_using_root_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [?ROOT_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -311,6 +343,8 @@ delete_root_node_using_dot_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [?THIS_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -332,6 +366,8 @@ delete_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = [?PARENT_NODE]},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -355,6 +391,8 @@ delete_root_node_with_child_nodes_test() ->
                 #put{path = [baz, qux],
                      payload = khepri_payload:data(qux_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Command = #delete{path = []},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
@@ -375,6 +413,8 @@ delete_root_node_with_condition_true_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},
@@ -396,6 +436,8 @@ delete_root_node_with_condition_true_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
     Command = #delete{path = [#if_all{conditions = [?THIS_NODE, Compiled]}]},
@@ -417,6 +459,8 @@ delete_root_node_with_condition_false_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(#{store_id => ?FUNCTION_NAME,
+                               member => khepri_cluster:node_to_member(
+                                           ?FUNCTION_NAME, node()),
                                commands => Commands}),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
     Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},

--- a/test/timeout.erl
+++ b/test/timeout.erl
@@ -1,0 +1,54 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(timeout).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/internal.hrl").
+-include("test/helpers.hrl").
+
+can_specify_timeout_in_milliseconds_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, #{[foo] => #{}}},
+         khepri:put(?FUNCTION_NAME, [foo], foo_value, #{timeout => 60000})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{data => foo_value,
+                           payload_version => 1,
+                           child_list_version => 1,
+                           child_list_length => 0}}},
+         khepri:get(?FUNCTION_NAME, [foo], #{timeout => 60000})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{data => foo_value,
+                           payload_version => 1,
+                           child_list_version => 1,
+                           child_list_length => 0}}},
+         khepri:delete(?FUNCTION_NAME, [foo], #{timeout => 60000}))]}.
+
+can_specify_infinity_timeout_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, #{[foo] => #{}}},
+         khepri:put(?FUNCTION_NAME, [foo], foo_value, #{timeout => infinity})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{data => foo_value,
+                           payload_version => 1,
+                           child_list_version => 1,
+                           child_list_length => 0}}},
+         khepri:get(?FUNCTION_NAME, [foo], #{timeout => infinity})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{data => foo_value,
+                           payload_version => 1,
+                           child_list_version => 1,
+                           child_list_length => 0}}},
+         khepri:delete(?FUNCTION_NAME, [foo], #{timeout => infinity}))]}.

--- a/test/transactions.erl
+++ b/test/transactions.erl
@@ -452,7 +452,7 @@ put_with_native_keep_while_cond_test_() ->
         ?_assertEqual(
            {ok, #{[foo] =>
                   #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
-           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))]}]}.
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{}))]}]}.
 
 put_with_unix_string_keep_while_cond_test_() ->
     KeepWhile = #{"." => #if_child_list_length{count = {gt, 0}}},
@@ -474,7 +474,7 @@ put_with_unix_string_keep_while_cond_test_() ->
         ?_assertEqual(
            {ok, #{[foo] =>
                   #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
-           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))]}]}.
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{}))]}]}.
 
 put_with_unix_binary_keep_while_cond_test_() ->
     KeepWhile = #{<<".">> => #if_child_list_length{count = {gt, 0}}},
@@ -496,7 +496,7 @@ put_with_unix_binary_keep_while_cond_test_() ->
         ?_assertEqual(
            {ok, #{[foo] =>
                   #{[foo] => #if_child_list_length{count = {gt, 0}}}}},
-           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME))]}]}.
+           khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{}))]}]}.
 
 create_in_ro_transaction_test_() ->
     {setup,

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -64,9 +64,13 @@ allowed_khepri_tx_api_test() ->
        end).
 
 denied_khepri_tx_run_3_test() ->
+    MachineState = #khepri_machine{
+                      config = #config{store_id = ?FUNCTION_NAME,
+                                       member = {?FUNCTION_NAME, node()}}
+                     },
     ?assertToFunThrow(
        {invalid_tx_fun, {call_denied, {khepri_tx, run, 3}}},
-       _ = khepri_tx:run(#khepri_machine{}, fun() -> ok end, true)).
+       _ = khepri_tx:run(MachineState, fun() -> ok end, true)).
 
 allowed_erlang_expressions_add_test() ->
     One = mask(1),

--- a/test/utils.erl
+++ b/test/utils.erl
@@ -1,0 +1,75 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(utils).
+
+-include_lib("eunit/include/eunit.hrl").
+
+sleep_with_no_timeout_test() ->
+    Sleep = 50,
+    Timeout = infinity,
+    T0 = erlang:monotonic_time(),
+    ?assertEqual(Timeout, khepri_utils:sleep(Sleep, Timeout)),
+    T1 = erlang:monotonic_time(),
+    TDiff = erlang:convert_time_unit(T1 - T0, native, millisecond),
+    ?assert(TDiff >= Sleep).
+
+sleep_with_zero_timeout_test() ->
+    Sleep = 50,
+    Timeout = 0,
+    T0 = erlang:monotonic_time(),
+    NewTimeout = khepri_utils:sleep(Sleep, Timeout),
+    ?assertEqual(0, NewTimeout),
+    T1 = erlang:monotonic_time(),
+    TDiff = erlang:convert_time_unit(T1 - T0, native, millisecond),
+    ?assert(TDiff =< Sleep),
+    ?assert(TDiff >= Timeout).
+
+sleep_with_low_timeout_test() ->
+    Sleep = 50,
+    Timeout = 10,
+    T0 = erlang:monotonic_time(),
+    NewTimeout = khepri_utils:sleep(Sleep, Timeout),
+    ?assertEqual(0, NewTimeout),
+    T1 = erlang:monotonic_time(),
+    TDiff = erlang:convert_time_unit(T1 - T0, native, millisecond),
+    ?assert(TDiff =< Sleep),
+    ?assert(TDiff >= Timeout).
+
+sleep_with_high_timeout_test() ->
+    Sleep = 50,
+    Timeout = 1000,
+    T0 = erlang:monotonic_time(),
+    NewTimeout = khepri_utils:sleep(Sleep, Timeout),
+    ?assert(NewTimeout =< Timeout - Sleep),
+    T1 = erlang:monotonic_time(),
+    TDiff = erlang:convert_time_unit(T1 - T0, native, millisecond),
+    ?assert(TDiff >= Sleep).
+
+timeout_window_with_no_timeout_test() ->
+    Sleep = 50,
+    Timeout = infinity,
+    Window = khepri_utils:start_timeout_window(Timeout),
+    timer:sleep(Sleep),
+    NewTimeout = khepri_utils:end_timeout_window(Timeout, Window),
+    ?assertEqual(Timeout, NewTimeout).
+
+timeout_window_with_low_timeout_test() ->
+    Sleep = 50,
+    Timeout = 10,
+    Window = khepri_utils:start_timeout_window(Timeout),
+    timer:sleep(Sleep),
+    NewTimeout = khepri_utils:end_timeout_window(Timeout, Window),
+    ?assertEqual(0, NewTimeout).
+
+timeout_window_with_high_timeout_test() ->
+    Sleep = 50,
+    Timeout = 1000,
+    Window = khepri_utils:start_timeout_window(Timeout),
+    timer:sleep(Sleep),
+    NewTimeout = khepri_utils:end_timeout_window(Timeout, Window),
+    ?assert(NewTimeout =< Timeout - Sleep).


### PR DESCRIPTION
The previous clustering code calling Ra was copy-pasted from RabbitMQ and was not really adapted to Khepri.

The major behavioral change is that `khepri_cluster` only takes care of the local Ra server, not remote ones anymore. In particular it doesn't take a list of initial members to create a cluster. In the same spirit, the `add_member()` function is replaced by a `join()` function: the local Ra server joins a remote running Ra cluster.

The clustering API should also be way more user-friendly:

1.  The `start()` family of functions still takes the name of a running Ra system, but a data directory is also accepted: in this case, Khepri will configure a Ra system and store files in this given directory.

    The default is to start a new Ra system using `khepri#$NODENAME` as the data directory in the current working directory.

2.  The `start()` family of functions also accepts either the name of a Khepri store (i.e. a Ra cluster name as an atom) or a complete Ra server configuration (which contains the cluster name).

3.  The default Ra system name or data directory, and the default Khepri store name can be configured using application environment variables:

    * `default_ra_system` (which can be a Ra system name or a directory)
    * `default_ra_cluster_name`

4.  A `stop()` series of functions is introduced. They will stop the local Ra server but won't touch the Ra system, even if Khepri started it.

5.  The `remove_member()` function is gone for now. It will be replaced with a function to forcefully evict a member in the future. To remove a Ra server from a cluster, you have to use `reset()` locally to the node to remove.

The last important change is that Khepri will now take care of waiting if the local Ra server is not ready to process commands and queries. For instance if the Ra cluster is still in the process of electing a leader. All functions take a timeout argument to limit this wait.

As part of this API change, we should now be consistent with the use of "Store ID" and "Ra cluster name". "Store ID" is used everywhere. The notion of "cluster" is only mentionned when we talk about multiple nodes working together. This allows us to abstract the concept of the Ra cluster below Khepri. It also makes it clearer that a store ID must be an atom and not any other types which could be valid as a Ra cluster name.