### PR TITLE
Use actual copyright character in headers

### DIFF
--- a/include/khepri.hrl
+++ b/include/khepri.hrl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -define(IS_NODE_ID(PathComponent),

--- a/src/internal.hrl
+++ b/src/internal.hrl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -define(DEFAULT_RA_SYSTEM_NAME, khepri).

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Khepri database API.

--- a/src/khepri_app.erl
+++ b/src/khepri_app.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @hidden

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Khepri service and cluster management API.

--- a/src/khepri_condition.erl
+++ b/src/khepri_condition.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Condition support.

--- a/src/khepri_event_handler.erl
+++ b/src/khepri_event_handler.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @hidden

--- a/src/khepri_evf.erl
+++ b/src/khepri_evf.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Khepri event filters.

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Anonymous function extraction private API.

--- a/src/khepri_fun.hrl
+++ b/src/khepri_fun.hrl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% Structure representing an anonymous function "extracted" as a compiled

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% TODO: Query this value from Ra itself.

--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Khepri path API.

--- a/src/khepri_payload.erl
+++ b/src/khepri_payload.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Khepri payloads.

--- a/src/khepri_sproc.erl
+++ b/src/khepri_sproc.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Khepri support code for stored procedures.

--- a/src/khepri_sup.erl
+++ b/src/khepri_sup.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @hidden

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @doc Khepri API for transactional queries and updates.

--- a/src/khepri_utils.erl
+++ b/src/khepri_utils.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 %% @hidden

--- a/test/app.erl
+++ b/test/app.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(app).

--- a/test/async_option.erl
+++ b/test/async_option.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(async_option).

--- a/test/conditions.erl
+++ b/test/conditions.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(conditions).

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(db_info).

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(delete_command).

--- a/test/display_tree.erl
+++ b/test/display_tree.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(display_tree).

--- a/test/favor_option.erl
+++ b/test/favor_option.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(favor_option).

--- a/test/helpers.hrl
+++ b/test/helpers.hrl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -define(META, #{index => ?LINE,

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(keep_while_conditions).

--- a/test/line_chunk.erl
+++ b/test/line_chunk.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(line_chunk).

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(machine_code_called_from_ra).

--- a/test/mod_used_for_transactions.erl
+++ b/test/mod_used_for_transactions.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(mod_used_for_transactions).

--- a/test/path_operations.erl
+++ b/test/path_operations.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(path_operations).

--- a/test/prop_path_operations.erl
+++ b/test/prop_path_operations.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(prop_path_operations).

--- a/test/prop_state_machine.erl
+++ b/test/prop_state_machine.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(prop_state_machine).

--- a/test/put_command.erl
+++ b/test/put_command.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(put_command).

--- a/test/queries.erl
+++ b/test/queries.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(queries).

--- a/test/root_node.erl
+++ b/test/root_node.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(root_node).

--- a/test/sf_cache.erl
+++ b/test/sf_cache.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(sf_cache).

--- a/test/simple_delete.erl
+++ b/test/simple_delete.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(simple_delete).

--- a/test/simple_get.erl
+++ b/test/simple_get.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(simple_get).

--- a/test/simple_put.erl
+++ b/test/simple_put.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(simple_put).

--- a/test/stored_procs.erl
+++ b/test/stored_procs.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(stored_procs).

--- a/test/test_ra_server_helpers.erl
+++ b/test/test_ra_server_helpers.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(test_ra_server_helpers).

--- a/test/transactions.erl
+++ b/test/transactions.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(transactions).

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(triggers).

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -2,7 +2,7 @@
 %% License, v. 2.0. If a copy of the MPL was not distributed with this
 %% file, You can obtain one at https://mozilla.org/MPL/2.0/.
 %%
-%% Copyright (c) 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
 -module(tx_funs).


### PR DESCRIPTION
Therefore "(c)" is replaced by "©".