### PR TITLE
Populate the list of skipped modules (in function extraction) during app startup

### DIFF
--- a/src/khepri_app.erl
+++ b/src/khepri_app.erl
@@ -22,6 +22,7 @@
          config_change/3]).
 
 start(normal, []) ->
+    ok = khepri_utils:init_list_of_modules_to_skip(),
     khepri_sup:start_link().
 
 stop(_) ->
@@ -29,6 +30,7 @@ stop(_) ->
     lists:foreach(
       fun(StoreId) -> _ = khepri_cluster:stop(StoreId) end,
       StoreIds),
+    khepri_utils:clear_list_of_modules_to_skip(),
     ok.
 
 config_change(_Changed, _New, _Removed) ->

--- a/test/app.erl
+++ b/test/app.erl
@@ -19,6 +19,8 @@ app_starts_workers_test_() ->
        [?_assertMatch({ok, _}, application:ensure_all_started(khepri)),
         ?_assert(is_process_alive(whereis(khepri_event_handler))),
         ?_assertEqual([?FUNCTION_NAME], khepri:get_store_ids()),
+        ?_assert(khepri_utils:should_collect_code_for_module(some_mod)),
+        ?_assertNot(khepri_utils:should_collect_code_for_module(khepri_tx)),
         ?_assertEqual(ok, application:stop(khepri)),
         ?_assertEqual(undefined, whereis(khepri_event_handler)),
         ?_assertEqual([], khepri:get_store_ids()),


### PR DESCRIPTION
So far, we were doing it on the first transaction call and the result was cached. The code is using `application:load/1` to make sure the list of modules for an application was available. The problem is that it is a sync call to the application controller with an infinite timeout.

Therefore, if the transaction is executed as part of the start or the stop of an application, the application controller might be busy and this `application:load/1` will block indefinitely.

Now, the same code is executed as part of Khepri's application start. Also, we use the list of already loaded application returned by `application:loaded_applications/0` to skip the load of already loaded applications.

Thanks to this, we reduced, perhaps even eliminated the situation where we call the application controller and cause a dead lock.

The cached list of modules is removed on Khepri's application stop.