### PR TITLE
Cache query results

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,11 @@
 %% vim:ft=erlang:
 {minimum_otp_vsn, "23.0"}.
 
-{deps, [{ra, "2.1.0"}]}.
+%% TODO: use a version of Ra published to Hex
+{deps,
+ [{ra,
+   {git, "https://github.com/rabbitmq/ra.git",
+    {ref, "773aa85e8ba79c2aed2f4eb766c97ff525d3e2ce"}}}]}.
 
 {project_plugins, [rebar3_proper,
                    covertool,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,17 +1,18 @@
 {"1.2.0",
 [{<<"aten">>,{pkg,<<"aten">>,<<"0.5.8">>},1},
  {<<"gen_batch_server">>,{pkg,<<"gen_batch_server">>,<<"0.8.8">>},1},
- {<<"ra">>,{pkg,<<"ra">>,<<"2.1.0">>},0},
+ {<<"ra">>,
+  {git,"https://github.com/rabbitmq/ra.git",
+       {ref,"773aa85e8ba79c2aed2f4eb766c97ff525d3e2ce"}},
+  0},
  {<<"seshat">>,{pkg,<<"seshat">>,<<"0.3.2">>},1}]}.
 [
 {pkg_hash,[
  {<<"aten">>, <<"B5C97F48517C4F37F26A519AA57A00A31FF1B8EA4324EC1CAE27F818ED5C0DB2">>},
  {<<"gen_batch_server">>, <<"7840A1FA63EE1EFFC83E8A91D22664847A2BA1192D30EAFFFD914ACB51578068">>},
- {<<"ra">>, <<"A58527F480CCC8AF68B5041B76DD6CF46B3202759D3D63567720212416BF744C">>},
  {<<"seshat">>, <<"16CF14E92AECB927D8840387B97A362D0781997A906D0F3BBB274EB0EC3D74D9">>}]},
 {pkg_hash_ext,[
  {<<"aten">>, <<"64D40A8CF0DDFEA4E13AF00B7327F0925147F83612D0627D9506CBFFE90C13EF">>},
  {<<"gen_batch_server">>, <<"C3E6A1A2A0FB62AEE631A98CFA0FD8903E9562422CBF72043953E2FB1D203017">>},
- {<<"ra">>, <<"24001B370C23690AF3FE42DDCA353C71C45D1EDC1A0E56F9C1BF30BD4C37D14E">>},
  {<<"seshat">>, <<"20D820ACBEEF9D07298EE863D0C9D06F8E620ACBA100939EBB2925E4D6B0DFC7">>}]}
 ].

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -260,7 +260,8 @@
 -type query_options() :: #{timeout => timeout(),
                            expect_specific_node => boolean(),
                            include_child_names => boolean(),
-                           favor => favor_option()}.
+                           favor => favor_option(),
+                           use_cache => boolean()}.
 %% Options used in queries.
 %%
 %% <ul>
@@ -271,6 +272,10 @@
 %% the returned node properties map.</li>
 %% <li>`favor' indicates where to put the cursor between freshness of the
 %% returned data and low latency of queries; see {@link favor_option()}.</li>
+%% <li>`use_cache' may be used to control whether the query cache should be
+%% used for the query. When `true', the query cache is checked for the queried
+%% path and the result is cached. When `false', the query cache is not checked
+%% or updated. `true' is the default.</li>
 %% </ul>
 
 -type ok(Type) :: {ok, Type}.

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -275,7 +275,7 @@
 %% <li>`use_cache' may be used to control whether the query cache should be
 %% used for the query. When `true', the query cache is checked for the queried
 %% path and the result is cached. When `false', the query cache is not checked
-%% or updated. `true' is the default.</li>
+%% or updated. `false' is the default.</li>
 %% </ul>
 
 -type ok(Type) :: {ok, Type}.

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -210,11 +210,10 @@ get(StoreId, PathPattern, Options) ->
     QueryFun = fun(#?MODULE{root = Root}) ->
                        find_matching_nodes(Root, PathPattern1, Options)
                end,
-    IsPath = lists:all(fun(C) -> ?IS_PATH_COMPONENT(C) end, PathPattern1),
     UseCache = maps:get(use_cache, Options, false),
     IsLowLatency = maps:get(favor, Options, undefined) == low_latency,
     if
-        IsPath andalso UseCache andalso IsLowLatency ->
+        UseCache andalso IsLowLatency ->
             Cache = khepri_query_cache:from_store_id(StoreId),
             T0 = khepri_utils:start_timeout_window(Timeout),
             case khepri_query_cache:lookup(Cache, PathPattern1) of

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -214,7 +214,7 @@ get(StoreId, PathPattern, Options) ->
                        find_matching_nodes(Root, PathPattern1, Options)
                end,
     IsPath = lists:all(fun(C) -> ?IS_PATH_COMPONENT(C) end, PathPattern1),
-    UseCache = maps:get(use_cache, Options, true),
+    UseCache = maps:get(use_cache, Options, false),
     if
         IsPath andalso UseCache ->
             CachedOptions = maps:without([timeout, favor, use_cache], Options),

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -25,3 +25,5 @@
                event_filter := khepri_evf:event_filter()}},
          emitted_triggers = [] :: [khepri_machine:triggered()],
          metrics = #{} :: #{applied_command_count => non_neg_integer()}}).
+
+-record(khepri_machine_aux, {query_cache :: khepri_query_cache:cache()}).

--- a/src/khepri_query_cache.erl
+++ b/src/khepri_query_cache.erl
@@ -14,15 +14,14 @@
 -opaque cache() :: atom().
 %% An identifier for a query cache.
 
--type key() :: {khepri_path:native_path(), khepri:query_options()}.
+-type key() :: khepri_path:native_path().
+%% TODO: allow patterns
 
 -export_type([cache/0, key/0]).
 
 -export([init/1,
          lookup/2,
-         lookup_remote/3,
          store/3,
-         store_remote/4,
          evict/2,
          from_store_id/1]).
 
@@ -52,40 +51,11 @@ lookup(Cache, Key) ->
             error
     end.
 
--spec lookup_remote(ra:server_id(), key(), timeout()) ->
-    khepri:ok(term()) | error.
-%% @doc Looks up the value for `PathPattern' in the {@link cache()} on
-%% `ServerId''s node.
-
-lookup_remote({StoreId, Node}, Key, _Timeout) when Node =:= node() ->
-    lookup(from_store_id(StoreId), Key);
-lookup_remote({StoreId, Node}, Key, Timeout) ->
-    Cache = from_store_id(StoreId),
-    case rpc:call(Node, ?MODULE, lookup, [Cache, Key], Timeout) of
-        {badrpc, _Reason} ->
-            error;
-        Value ->
-            Value
-    end.
-
 -spec store(cache(), key(), term()) -> ok.
 %% @doc Stores `Value' in the given `Cache' for the given `PathPattern'.
 
 store(Cache, Key, Value) ->
     ets:insert(Cache, {Key, Value}),
-    ok.
-
--spec store_remote(RaServer, Key, Value, timeout()) -> ok when
-    RaServer :: ra:server_id(),
-    Key :: key(),
-    Value :: term().
-%% @doc Stores `Value' in `RaServer''s {@link cache()}.
-
-store_remote({StoreId, Node}, Key, Value, _Timeout) when Node =:= node() ->
-    store(from_store_id(StoreId), Key, Value);
-store_remote({StoreId, Node}, Key, Value, Timeout) ->
-    Cache = from_store_id(StoreId),
-    rpc:call(Node, ?MODULE, store, [Cache, Key, Value], Timeout),
     ok.
 
 -spec evict(cache(), key()) -> ok.

--- a/src/khepri_query_cache.erl
+++ b/src/khepri_query_cache.erl
@@ -1,0 +1,91 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2021-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% @doc An `ets' based cache for query results.
+%%
+%% @hidden
+
+-module(khepri_query_cache).
+
+-opaque cache() :: atom().
+%% An identifier for a query cache.
+
+-export_type([cache/0]).
+
+-export([init/1,
+         lookup/2,
+         lookup_remote/3,
+         evict/2,
+         reset/1,
+         from_store_id/1]).
+
+-spec init(khepri:store_id()) -> cache().
+%% @doc Creates a new ETS table to act as a query cache for the store.
+%% If the cache already exists, it is not recreated.
+
+init(StoreId) ->
+    Name = from_store_id(StoreId),
+    _ = case ets:info(Name) of
+            undefined ->
+                ets:new(Name, [public, named_table, {read_concurrency, true}]);
+            _ ->
+                ok
+        end,
+    Name.
+
+-spec lookup(cache(), khepri_path:native_pattern()) ->
+    khepri:ok(term()) | error.
+%% @doc Looks up the value of `PathPattern' in the `Cache', returning
+%% `error' if not present in the cache.
+
+lookup(Cache, PathPattern) ->
+    case ets:lookup(Cache, PathPattern) of
+        [{PathPattern, Value}] ->
+            {ok, Value};
+        _ ->
+            error
+    end.
+
+-spec lookup_remote(ra:server_id(), khepri_path:native_pattern(), timeout()) ->
+    khepri:ok(term()) | error.
+%% @doc Looks up the value for `PathPattern' in the {@link cache()} on
+%% `ServerId''s node.
+
+lookup_remote({StoreId, Node}, PathPattern, _Timeout) when Node =:= node() ->
+    lookup(from_store_id(StoreId), PathPattern);
+lookup_remote({StoreId, Node}, PathPattern, Timeout) ->
+    Cache = from_store_id(StoreId),
+    case rpc:call(Node, ?MODULE, lookup, [Cache, PathPattern], Timeout) of
+        {badrpc, _Reason} ->
+            error;
+        Value ->
+            Value
+    end.
+
+-spec evict(cache(), khepri_path:native_pattern()) -> ok.
+%% @doc Removes the `PathPattern' entry from the `Cache'.
+
+evict(Cache, PathPattern) ->
+    ets:delete(Cache, PathPattern),
+    ok.
+
+-spec reset(cache()) -> ok.
+%% @doc Resets the `Cache' by deleting all objects.
+
+reset(Cache) ->
+    ets:delete_all_objects(Cache),
+    ok.
+
+from_store_id(StoreId) ->
+    case persistent_term:get({?MODULE, StoreId}, undefined) of
+        undefined ->
+            Name = list_to_atom(io_lib:format("~s_~s", [?MODULE, StoreId])),
+            persistent_term:put({?MODULE, StoreId}, Name),
+            Name;
+        Name ->
+            Name
+    end.

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -424,7 +424,8 @@ can_start_a_three_node_cluster(Config) ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(Node, khepri, get, [StoreId, [foo],
+                                              #{use_cache => false}]))
       end, RunningNodes1),
 
     LeaderId2 = get_leader_in_store(StoreId, RunningNodes1),
@@ -519,7 +520,8 @@ can_join_several_times_a_three_node_cluster(Config) ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(Node, khepri, get, [StoreId, [foo],
+                                              #{use_cache => false}]))
       end, Nodes),
 
     ok.
@@ -657,7 +659,8 @@ can_restart_nodes_in_a_three_node_cluster(Config) ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(Node, khepri, get, [StoreId, [foo],
+                                              #{use_cache => false}]))
       end, RunningNodes3),
 
     ok.

--- a/test/prop_state_machine.erl
+++ b/test/prop_state_machine.erl
@@ -52,7 +52,7 @@ initial_state() ->
 
 command(_State) ->
     elements([{call, khepri, put, [?STORE_ID, path(), payload()]},
-              {call, khepri, get, [?STORE_ID, path()]},
+              {call, khepri, get, [?STORE_ID, path(), #{use_cache => false}]},
               {call, khepri, delete, [?STORE_ID, path()]}]).
 
 precondition(_State, _Command) ->
@@ -61,7 +61,7 @@ precondition(_State, _Command) ->
 next_state(
   #state{} = State,
   _Result,
-  {call, khepri, get, [_StoreId, _Path]}) ->
+  {call, khepri, get, [_StoreId, _Path, _Options]}) ->
     State;
 next_state(
   #state{entries = Entries} = State,
@@ -80,7 +80,7 @@ next_state(
 
 postcondition(
   #state{entries = Entries},
-  {call, khepri, get, [_StoreId, Path]},
+  {call, khepri, get, [_StoreId, Path, _Options]},
   Result) ->
     result_is_ok(Result, Entries, Path, {ok, #{}});
 postcondition(

--- a/test/root_node.erl
+++ b/test/root_node.erl
@@ -108,7 +108,8 @@ query_root_node_with_conditions_false_test() ->
 
 store_data_in_root_node_using_empty_path_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
-    Command = #put{path = [],
+    Path = [],
+    Command = #put{path = Path,
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -123,11 +124,12 @@ store_data_in_root_node_using_empty_path_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 store_data_in_root_node_using_root_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
-    Command = #put{path = [?ROOT_NODE],
+    Path = [?ROOT_NODE],
+    Command = #put{path = Path,
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -142,11 +144,12 @@ store_data_in_root_node_using_root_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 store_data_in_root_node_using_dot_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
-    Command = #put{path = [?THIS_NODE],
+    Path = [?THIS_NODE],
+    Command = #put{path = Path,
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -161,11 +164,12 @@ store_data_in_root_node_using_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 store_data_in_root_node_using_dot_dot_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
-    Command = #put{path = [?PARENT_NODE],
+    Path = [?PARENT_NODE],
+    Command = #put{path = Path,
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -180,12 +184,13 @@ store_data_in_root_node_using_dot_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 store_data_in_root_node_with_condition_true_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
-    Command = #put{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
+    Path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
+    Command = #put{path = Path,
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -200,12 +205,13 @@ store_data_in_root_node_with_condition_true_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 store_data_in_root_node_with_condition_true_using_dot_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
-    Command = #put{path = [#if_all{conditions = [?THIS_NODE, Compiled]}],
+    Path = [#if_all{conditions = [?THIS_NODE, Compiled]}],
+    Command = #put{path = Path,
                    payload = khepri_payload:data(value)},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
@@ -220,7 +226,7 @@ store_data_in_root_node_with_condition_true_using_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 store_data_in_root_node_with_condition_false_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -245,11 +251,12 @@ store_data_in_root_node_with_condition_false_test() ->
                                          child_list_version => 1,
                                          child_list_length => 0},
                      condition => Compiled}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertMatch([], SE).
 
 delete_empty_root_node_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
-    Command = #delete{path = []},
+    Path = [],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -262,13 +269,14 @@ delete_empty_root_node_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_using_empty_path_test() ->
-    Commands = [#put{path = [],
+    Path = [],
+    Commands = [#put{path = Path,
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
-    Command = #delete{path = []},
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -282,13 +290,14 @@ delete_root_node_using_empty_path_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_using_root_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
-    Command = #delete{path = [?ROOT_NODE]},
+    Path = [?ROOT_NODE],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -302,13 +311,14 @@ delete_root_node_using_root_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_using_dot_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
-    Command = #delete{path = [?THIS_NODE]},
+    Path = [?THIS_NODE],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -322,13 +332,14 @@ delete_root_node_using_dot_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [],
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
-    Command = #delete{path = [?PARENT_NODE]},
+    Path = [?PARENT_NODE],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -342,7 +353,7 @@ delete_root_node_using_dot_dot_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_with_child_nodes_test() ->
     Commands = [#put{path = [foo, bar],
@@ -350,7 +361,8 @@ delete_root_node_with_child_nodes_test() ->
                 #put{path = [baz, qux],
                      payload = khepri_payload:data(qux_value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
-    Command = #delete{path = []},
+    Path = [],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -363,14 +375,15 @@ delete_root_node_with_child_nodes_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 3,
                                 child_list_length => 2}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_with_condition_true_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
-    Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},
+    Path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -383,14 +396,15 @@ delete_root_node_with_condition_true_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 2,
                                 child_list_length => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_with_condition_true_using_dot_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 1}),
-    Command = #delete{path = [#if_all{conditions = [?THIS_NODE, Compiled]}]},
+    Path = [#if_all{conditions = [?THIS_NODE, Compiled]}],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -403,14 +417,15 @@ delete_root_node_with_condition_true_using_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 2,
                                 child_list_length => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).
 
 delete_root_node_with_condition_false_test() ->
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
     Compiled = khepri_condition:compile(#if_child_list_length{count = 0}),
-    Command = #delete{path = [#if_all{conditions = [?ROOT_NODE, Compiled]}]},
+    Path = [#if_all{conditions = [?ROOT_NODE, Compiled]}],
+    Command = #delete{path = Path},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -425,4 +440,4 @@ delete_root_node_with_condition_false_test() ->
                   payload = khepri_payload:data(foo_value)}}},
        Root),
     ?assertEqual({ok, #{}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, {evict, Path}}], SE).


### PR DESCRIPTION
From the discussion in https://github.com/rabbitmq/khepri/discussions/33

This adds an ETS-based cache for each server in the khepri cluster. Local caches are immediately consistent - Ra auxiliary commands evict stale items from each cache as a node is changed in the store. Reading from remote caches (like a leader query) is eventually consistent: it's possible to read from the other node's cache faster than the aux commands can evict stale entries. Paths are added to the cache when queried.

Still TODO:

* use a cache replacement strategy
* split the current cache into a behaviour plus default implementation
* unit tests