### PR TITLE
Work around badly disassembled `get_map_elements` arguments

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1279,18 +1279,21 @@ pass1_process_instructions(
     Comment = {'%', VarInfo},
     pass1_process_instructions(Rest, State1, [Instruction1, Comment | Result]);
 pass1_process_instructions(
-  [{get_map_elements, _Fail, Src, {list, _}} = Instruction | Rest],
+  [{get_map_elements, _Fail, Src, {list, List}} = Instruction | Rest],
   State,
   Result) ->
     State1 = ensure_instruction_is_permitted(Instruction, State),
     Src1 = fix_type_tagged_beam_register(Src),
+    List1 = [fix_type_tagged_beam_register(I)
+             || I <- List],
     Instruction1 = setelement(3, Instruction, Src1),
+    Instruction2 = setelement(4, Instruction1, {list, List1}),
 
     Reg = get_reg_from_type_tagged_beam_register(Src1),
     Type = {t_map, any, any},
     VarInfo = {var_info, Reg, [{type, Type}]},
     Comment = {'%', VarInfo},
-    pass1_process_instructions(Rest, State1, [Instruction1, Comment | Result]);
+    pass1_process_instructions(Rest, State1, [Instruction2, Comment | Result]);
 pass1_process_instructions(
   [{put_map_assoc, _Fail, Src, _Dst, _Live, {list, _}} = Instruction | Rest],
   State,

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -2147,7 +2147,9 @@ replace_label(
             Instruction;
         {f, OldLabel} ->
             NewLabel = maps:get({Module, OldLabel}, LabelMap),
-            setelement(Pos, Instruction, {f, NewLabel})
+            setelement(Pos, Instruction, {f, NewLabel});
+        nofail ->
+            Instruction
     end.
 
 -spec gen_module_name(State) -> Module when

--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -16,7 +16,7 @@
          remove_store_dir/1]).
 
 init_list_of_modules_to_skip() ->
-    application:load(khepri),
+    _ = application:load(khepri),
     khepri_utils:init_list_of_modules_to_skip().
 
 start_ra_system(RaSystem) ->

--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -9,10 +9,15 @@
 
 -include_lib("stdlib/include/assert.hrl").
 
--export([start_ra_system/1,
+-export([init_list_of_modules_to_skip/0,
+         start_ra_system/1,
          stop_ra_system/1,
          store_dir_name/1,
          remove_store_dir/1]).
+
+init_list_of_modules_to_skip() ->
+    application:load(khepri),
+    khepri_utils:init_list_of_modules_to_skip().
 
 start_ra_system(RaSystem) ->
     {ok, _} = application:ensure_all_started(ra),

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -27,6 +27,7 @@
 
 -define(make_standalone_fun(Expression),
         begin
+            helpers:init_list_of_modules_to_skip(),
             __Fun = fun() -> Expression end,
             khepri_tx:to_standalone_fun(__Fun, rw)
         end).
@@ -838,6 +839,7 @@ denied_re_version_test() ->
        end).
 
 when_readwrite_mode_is_true_test() ->
+    helpers:init_list_of_modules_to_skip(),
     ?assert(
        is_record(khepri_tx:to_standalone_fun(
                    fun() ->
@@ -887,6 +889,7 @@ when_readwrite_mode_is_true_test() ->
                  standalone_fun)).
 
 when_readwrite_mode_is_false_test() ->
+    helpers:init_list_of_modules_to_skip(),
     ?assert(
        is_function(khepri_tx:to_standalone_fun(
                      fun() ->
@@ -942,6 +945,7 @@ when_readwrite_mode_is_false_test() ->
                    0)).
 
 when_readwrite_mode_is_auto_test() ->
+    helpers:init_list_of_modules_to_skip(),
     ?assert(
        is_function(khepri_tx:to_standalone_fun(
                      fun() ->
@@ -1008,6 +1012,7 @@ make_fun(9)  -> fun(_, _, _, _, _, _, _, _, _) -> result end;
 make_fun(10) -> fun(_, _, _, _, _, _, _, _, _, _) -> result end.
 
 list_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     List = make_list(),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> List end,
@@ -1017,6 +1022,7 @@ list_in_fun_env_test() ->
     ?assertEqual(List, khepri_fun:exec(StandaloneFun, [])).
 
 map_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Map = make_map(),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Map end,
@@ -1026,6 +1032,7 @@ map_in_fun_env_test() ->
     ?assertEqual(Map, khepri_fun:exec(StandaloneFun, [])).
 
 tuple_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Tuple = make_tuple(),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Tuple end,
@@ -1035,6 +1042,7 @@ tuple_in_fun_env_test() ->
     ?assertEqual(Tuple, khepri_fun:exec(StandaloneFun, [])).
 
 binary_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Binary = make_binary(),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Binary end,
@@ -1044,6 +1052,7 @@ binary_in_fun_env_test() ->
     ?assertEqual(Binary, khepri_fun:exec(StandaloneFun, [])).
 
 fun0_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(0),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun() end,
@@ -1053,6 +1062,7 @@ fun0_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun1_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(1),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1) end,
@@ -1062,6 +1072,7 @@ fun1_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun2_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(2),
     self() ! Fun,
     receive Fun -> ok end,
@@ -1073,6 +1084,7 @@ fun2_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun3_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(3),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3) end,
@@ -1082,6 +1094,7 @@ fun3_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun4_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(4),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3, 4) end,
@@ -1091,6 +1104,7 @@ fun4_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun5_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(5),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3, 4, 5) end,
@@ -1100,6 +1114,7 @@ fun5_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun6_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(6),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3, 4, 5, 6) end,
@@ -1109,6 +1124,7 @@ fun6_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun7_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(7),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3, 4, 5, 6, 7) end,
@@ -1118,6 +1134,7 @@ fun7_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun8_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(8),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3, 4, 5, 6, 7, 8) end,
@@ -1127,6 +1144,7 @@ fun8_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun9_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(9),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3, 4, 5, 6, 7, 8, 9) end,
@@ -1136,6 +1154,7 @@ fun9_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 fun10_in_fun_env_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = make_fun(10),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> Fun(1, 2, 3, 4, 5, 6, 7, 8, 9, 10) end,
@@ -1145,6 +1164,7 @@ fun10_in_fun_env_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 exec_with_regular_fun_test() ->
+    helpers:init_list_of_modules_to_skip(),
     Fun = khepri_tx:to_standalone_fun(
             fun() -> result end,
             ro),
@@ -1152,6 +1172,7 @@ exec_with_regular_fun_test() ->
     ?assertEqual(result, khepri_fun:exec(Fun, [])).
 
 exec_standalone_fun_multiple_times_test() ->
+    helpers:init_list_of_modules_to_skip(),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> result end,
                       rw),
@@ -1159,6 +1180,7 @@ exec_standalone_fun_multiple_times_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 exec_with_standalone_fun_test() ->
+    helpers:init_list_of_modules_to_skip(),
     StandaloneFun = khepri_tx:to_standalone_fun(
                       fun() -> result end,
                       rw),
@@ -1170,6 +1192,7 @@ exec_with_standalone_fun_test() ->
     ?assertEqual(result, khepri_fun:exec(StandaloneFun, [])).
 
 record_matching_fun_clause_test() ->
+    helpers:init_list_of_modules_to_skip(),
     StandaloneFun = khepri_fun:to_standalone_fun(
                       fun mod_used_for_transactions:outer_function/2,
                       #{}),

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -237,7 +237,7 @@ allowed_case_block_test() ->
 allowed_case_block_with_different_tuple_arities_test() ->
     ?assertStandaloneFun(
        begin
-           case {a, b, c} of
+           case khepri_tx:get([foo]) of
                {_, _, _} -> three;
                {_, _} ->    two;
                {_} ->       one


### PR DESCRIPTION
The last argument of `get_map_elements` is a list of (possibly tagged) registers. The tagged registers are incorrectly decoded by `beam_disasm` and we must patch them like we do it already in other places. This fixes an error where a standalone function is successfully compiled but fails to load.

While here, we also now handle the absence of `fail` label. Some instructions, which take a label as an argument to jump to if the instruction fails, also accept `nofail` instead of a label. Our patching of fail labels was not taking this case into account. This caused a crash in the function extraction code. This problem was discovered while writing the testcase in this pull request.