### PR TITLE
khepri_tx: Allow `badrecord` instruction

### DIFF
--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -507,6 +507,8 @@ ensure_instruction_is_permitted({arithfbif, _, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({badmatch, _}) ->
     ok;
+ensure_instruction_is_permitted({badrecord, _}) ->
+    ok;
 ensure_instruction_is_permitted({bif, Bif, _, Args, _}) ->
     Arity = length(Args),
     ensure_bif_is_valid(Bif, Arity);

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -542,7 +542,7 @@ denied_module_info_1_test() ->
            _ = lists:module_info(compile)
        end).
 
--record(record, {}).
+-record(record, {field}).
 
 allowed_erlang_module_api_test() ->
     %% The compiler optimization will replace many of the following calls
@@ -643,6 +643,10 @@ allowed_erlang_module_api_test() ->
            _ = erlang:size(Binary),
            _ = erlang:throw(Term)
        end).
+
+allowed_record_test() ->
+    Record = persistent_term:get(record, undefined),
+    ?assertStandaloneFun(Record#record.field).
 
 denied_builtin_make_ref_0_test() ->
     ?assertToFunThrow(


### PR DESCRIPTION
This instruction is generated to throw an exception if for instance the variable in `Variable#myrecord.field` is not a record.