### PR TITLE
khepri_fun: Work around bad decoding of `{test, is_tuple, ...}` arguments

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1112,6 +1112,16 @@ pass1_process_instructions(
                    Fail, [Ctx, Stride, {string, String}]},
     pass1_process_instructions([Instruction | Rest], State, Result);
 pass1_process_instructions(
+  [{test, IsTuple, _Fail, Args} = Instruction | Rest],
+  State,
+  Result)
+  when IsTuple =:= is_tuple orelse IsTuple =:= is_tagged_tuple ->
+    State1 = ensure_instruction_is_permitted(Instruction, State),
+    Args1 = [fix_type_tagged_beam_register(I)
+             || I <- Args],
+    Instruction1 = setelement(4, Instruction, Args1),
+    pass1_process_instructions(Rest, State1, [Instruction1 | Result]);
+pass1_process_instructions(
   [{raise, Fail, Args, Dst} | Rest],
   State,
   Result) ->

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -1237,3 +1237,21 @@ get_map_elements_arguments_are_correctly_disassembled_test() ->
     %% disassembled instruction arguments (they may not be validated at
     %% compile time apparently).
     ?assertEqual(undefined, khepri_fun:exec(StandaloneFun, [])).
+
+is_tuple_arguments_are_correctly_disassembled_test() ->
+    helpers:init_list_of_modules_to_skip(),
+    Path = [node()],
+    Result = khepri:put(store_id, Path, value, #{async => true}),
+    Fun = fun() ->
+                  case Result of
+                      ok         -> atom;
+                      {error, _} -> tuple
+                  end
+          end,
+    StandaloneFun = khepri_tx:to_standalone_fun(Fun, rw),
+    ?assertMatch(#standalone_fun{}, StandaloneFun),
+    %% Here, we don't really care about the transaction result. We mostly want
+    %% to make sure the function is loaded to detect any incorrectly
+    %% disassembled instruction arguments (they may not be validated at
+    %% compile time apparently).
+    ?assertEqual(atom, khepri_fun:exec(StandaloneFun, [])).


### PR DESCRIPTION
Likewise for `{test, is_tagged_tuple, ...}`.

The last argument is a list of (possibly tagged) registers. The tagged registers are incorrectly decoded by `beam_disasm` and we must patch them like we do it already in other places.

This fixes an error where a standalone function is successfully compiled but fails to load.