### PR TITLE
Work around more badly disassembled instruction arguments

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1255,6 +1255,14 @@ pass1_process_instructions(
 %% Third group.
 
 pass1_process_instructions(
+  [{bif, _Operation, _Fail, Args, _Dst} = Instruction | Rest],
+  State,
+  Result) ->
+    State1 = ensure_instruction_is_permitted(Instruction, State),
+    Args1 = [fix_type_tagged_beam_register(I) || I <- Args],
+    Instruction1 = setelement(4, Instruction, Args1),
+    pass1_process_instructions(Rest, State1, [Instruction1 | Result]);
+pass1_process_instructions(
   [{get_tuple_element, Src, Element, _Dest} = Instruction | Rest],
   State,
   Result) ->

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1332,13 +1332,11 @@ pass1_process_instructions(
     Comment = {'%', VarInfo},
     pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
 pass1_process_instructions(
-  [{test, IsTuple, _Fail, Args} = Instruction | Rest],
+  [{test, _Test, _Fail, Args} = Instruction | Rest],
   State,
-  Result)
-  when IsTuple =:= is_tuple orelse IsTuple =:= is_tagged_tuple ->
+  Result) ->
     State1 = ensure_instruction_is_permitted(Instruction, State),
-    Args1 = [fix_type_tagged_beam_register(I)
-             || I <- Args],
+    Args1 = [fix_type_tagged_beam_register(I) || I <- Args],
     Instruction1 = setelement(4, Instruction, Args1),
     pass1_process_instructions(Rest, State1, [Instruction1 | Result]);
 


### PR DESCRIPTION
In this patch, we fix badly decoded arguments of `{test, ...}` (all of them, not just the ones we saw in the field) and `{bif, ...}`.