### PR TITLE
GitHub Actions: New workflow to publish to Hex.pm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Publish release
+
+on:
+  push:
+    tags:
+      - v0*
+      - v1*
+      - v2*
+      - v3*
+      - v4*
+      - v5*
+      - v6*
+      - v7*
+      - v8*
+      - v9*
+
+jobs:
+  Publish:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v3
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
The workflow is triggered by pushing a tag to GitHub.