### PR TITLE
Setup bazel build files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,50 @@
+build --experimental_enable_bzlmod
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/dev/
+
+build --incompatible_strict_action_env
+build --local_test_jobs=1
+
+build:buildbuddy --bes_results_url=https://app.buildbuddy.io/invocation/
+build:buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
+build:buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
+build:buildbuddy --remote_timeout=1200
+build:buildbuddy --grpc_keepalive_time=360s
+build:buildbuddy --grpc_keepalive_timeout=360s
+build:buildbuddy --remote_download_minimal
+build:buildbuddy --build_metadata=REPO_URL=https://github.com/rabbitmq/khepri.git
+
+build:rbe --config=buildbuddy
+
+build:rbe --remote_executor=grpcs://remote.buildbuddy.io
+
+build:rbe --spawn_strategy=remote
+build:rbe --test_strategy=""
+build:rbe --jobs=50
+
+build:rbe --crosstool_top=@rbe//cc:toolchain
+build:rbe --extra_toolchains=@rbe//config:cc-toolchain
+
+build:rbe --host_platform=@rbe//config:platform
+
+build:rbe --host_cpu=k8
+build:rbe --cpu=k8
+
+build:rbe-23 --config=rbe
+build:rbe-23 --platforms=//bzl/platforms:erlang_23_platform
+build:rbe-23 --extra_execution_platforms=//bzl/platforms:erlang_23_platform
+
+build:rbe-24 --config=rbe
+build:rbe-24 --platforms=//bzl/platforms:erlang_24_platform
+build:rbe-24 --extra_execution_platforms=//bzl/platforms:erlang_24_platform
+
+build:rbe-25 --config=rbe
+build:rbe-25 --platforms=//bzl/platforms:erlang_25_platform
+build:rbe-25 --extra_execution_platforms=//bzl/platforms:erlang_25_platform
+
+build:local --platforms=//bzl/platforms:erlang_external_platform
+build:local --extra_execution_platforms=//bzl/platforms:erlang_external_platform
+
+# Try importing a user specific .bazelrc
+# You can create your own by copying and editing the template-user.bazelrc template:
+# cp template-user.bazelrc user.bazelrc
+try-import %workspace%/user.bazelrc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,3 +63,19 @@ jobs:
           flags: erlang:${{ matrix.otp_version }},os:${{ matrix.os }}
           name: Erlang/OTP ${{ matrix.otp_version }} on ${{ matrix.os }}
           verbose: true # optional (default = false)
+
+  build-bazel:
+    name: Build Bazel
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        otp_major:
+        - "24"
+        - "25"
+    steps:
+    - name: CHECKOUT
+      uses: actions/checkout@v2
+    - name: TEST
+      run: |
+        bazelisk test //... --config=rbe-${{ matrix.otp_major }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ erl_crash.dump
 !/doc/stylesheet.css
 /mix.lock
 /nonode@nohost/
+
+/user.bazelrc
+/bazel-*

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,7 @@ load("@rules_erlang//:erlang_app.bzl", "erlang_app", "test_erlang_app")
 load("@rules_erlang//:xref2.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "DEFAULT_PLT_APPS", "dialyze", "plt")
 load("@rules_erlang//:ct.bzl", "ct_suite")
+load("@rules_erlang//:erlang_bytecode.bzl", "erlang_bytecode")
 load(":eunit.bzl", "eunit")
 
 NAME = "khepri"
@@ -56,16 +57,42 @@ dialyze(
     plt = ":base_plt",
 )
 
+helpers = [
+    "test/cth_log_redirect_any_domains.erl",
+    "test/helpers.erl",
+]
+
+erlang_bytecode(
+    name = "test_helpers",
+    srcs = helpers,
+    hdrs = glob(["test/*.hrl"]),
+    deps = [
+        ":test_erlang_app",
+    ],
+    dest = "test",
+    testonly = True,
+)
+
 suites = glob(["test/*_SUITE.erl"])
 [ct_suite(
     name = f.replace("test/", "").replace(".erl", ""),
     deps = [
-        "@cth_readable//:erlang_app"
+        "@cth_readable//:erlang_app",
+    ],
+    additional_beam = [
+        ":test_helpers",
     ],
 ) for f in suites]
 
 eunit(
+    srcs = glob(
+        ["test/*.erl"],
+        exclude = suites + helpers,
+    ),
     deps = [
-        "@proper//:erlang_app"
+        "@proper//:erlang_app",
     ],
+    additional_beam = [
+        ":test_helpers",
+    ]
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,71 @@
+load("@rules_erlang//:erlang_app.bzl", "erlang_app", "test_erlang_app")
+load("@rules_erlang//:xref2.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "DEFAULT_PLT_APPS", "dialyze", "plt")
+load("@rules_erlang//:ct.bzl", "ct_suite")
+load(":eunit.bzl", "eunit")
+
+NAME = "khepri"
+
+VERSION = "0.4.3"
+
+EXTRA_APPS = [
+    "compiler",
+]
+
+DEPS = [
+    "@ra//:erlang_app",
+    "@gen_batch_server//:erlang_app",
+]
+
+RUNTIME_DEPS = [
+    "@aten//:erlang_app",
+    "@seshat//:erlang_app",
+]
+
+erlang_app(
+    app_name = NAME,
+    app_version = VERSION,
+    extra_apps = EXTRA_APPS,
+    runtime_deps = RUNTIME_DEPS,
+    deps = DEPS,
+)
+
+test_erlang_app(
+    app_name = NAME,
+    app_version = VERSION,
+    extra_apps = EXTRA_APPS,
+    runtime_deps = RUNTIME_DEPS,
+    deps = DEPS,
+)
+
+xref()
+
+plt(
+    name = "base_plt",
+    apps = DEFAULT_PLT_APPS + EXTRA_APPS,
+    deps = DEPS + RUNTIME_DEPS,
+)
+
+dialyze(
+    size = "small",
+    dialyzer_opts = [
+        "-Wunderspecs",
+        "-Wunknown",
+        "-Wunmatched_returns",
+    ],
+    plt = ":base_plt",
+)
+
+suites = glob(["test/*_SUITE.erl"])
+[ct_suite(
+    name = f.replace("test/", "").replace(".erl", ""),
+    deps = [
+        "@cth_readable//:erlang_app"
+    ],
+) for f in suites]
+
+eunit(
+    deps = [
+        "@proper//:erlang_app"
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,46 @@
+module(
+    name = "khepri",
+    version = "0.4.3",
+)
+
+bazel_dep(
+    name = "rules_erlang",
+    version = "3.3.0",
+)
+
+erlang_package = use_extension(
+    "@rules_erlang//bzlmod:extensions.bzl",
+    "erlang_package",
+)
+
+erlang_package.hex_package(
+    name = "aten",
+    version = "0.5.8",
+    sha256 = "64d40a8cf0ddfea4e13af00b7327f0925147f83612d0627d9506cbffe90c13ef",
+)
+
+erlang_package.hex_package(
+    name = "gen_batch_server",
+    sha256 = "c3e6a1a2a0fb62aee631a98cfa0fd8903e9562422cbf72043953e2fb1d203017",
+    version = "0.8.8",
+)
+
+erlang_package.hex_package(
+    name = "seshat",
+    sha256 = "20d820acbeef9d07298ee863d0c9d06f8e620acba100939ebb2925e4d6b0dfc7",
+    version = "0.3.2",
+)
+
+erlang_package.hex_package(
+    name = "ra",
+    version = "2.1.0",
+    sha256 = "24001b370c23690af3fe42ddca353c71c45d1edc1a0e56f9c1bf30bd4c37d14e",
+)
+
+use_repo(
+    erlang_package,
+    "aten",
+    "gen_batch_server",
+    "seshat",
+    "ra",
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -86,13 +86,18 @@ hex_pm_erlang_app(
 )
 
 hex_pm_erlang_app(
-    name = "proper",
-    sha256 = "18285842185bd33efbda97d134a5cb5a0884384db36119fee0e3cfa488568cbb",
-    version = "1.4.0",
-)
-
-hex_pm_erlang_app(
     name = "cth_readable",
     sha256 = "686541a22efe6ca5a41a047b39516c2dd28fb3cade5f24a2f19145b3967f9d80",
     version = "1.5.1",
+)
+
+load("@rules_erlang//:github.bzl", "github_erlang_app")
+
+# proper on git master addresses compilation warnings from OTP25
+github_erlang_app(
+    name = "proper",
+    org = "proper-testing",
+    ref = "bfd7d862dd5082eeca65c192a7021d0e4de5973e",
+    version = "bfd7d862dd5082eeca65c192a7021d0e4de5973e",
+    sha256 = "081a17c6bfce7203c53f64f0b2c43ed530dad3f0b1220c88b58f03674ab4d979"
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,98 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "af87959afe497dc8dfd4c6cb66e1279cb98ccc84284619ebfec27d9c09a903de",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.0/bazel-skylib-1.2.0.tar.gz",
+    ],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+http_archive(
+    name = "io_buildbuddy_buildbuddy_toolchain",
+    sha256 = "a2a5cccec251211e2221b1587af2ce43c36d32a42f5d881737db3b546a536510",
+    strip_prefix = "buildbuddy-toolchain-829c8a574f706de5c96c54ca310f139f4acda7dd",
+    urls = ["https://github.com/buildbuddy-io/buildbuddy-toolchain/archive/829c8a574f706de5c96c54ca310f139f4acda7dd.tar.gz"],
+)
+
+load("@io_buildbuddy_buildbuddy_toolchain//:deps.bzl", "buildbuddy_deps")
+
+buildbuddy_deps()
+
+load("@io_buildbuddy_buildbuddy_toolchain//:rules.bzl", "buildbuddy")
+
+buildbuddy(
+    name = "buildbuddy_toolchain",
+    llvm = True,
+)
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "rbe",
+    commit = "f68402af3e31018e8bbff1d24a5ccc43ca4ad4c6",  # linux-rbe branch
+    remote = "https://github.com/rabbitmq/rbe-erlang-platform.git",
+)
+
+git_repository(
+    name = "rules_erlang",
+    remote = "https://github.com/rabbitmq/rules_erlang.git",
+    tag = "3.3.0",
+)
+
+load(
+    "@rules_erlang//:rules_erlang.bzl",
+    "rules_erlang_dependencies",
+)
+
+rules_erlang_dependencies()
+
+register_toolchains(
+    "//bzl/toolchains:erlang_toolchain_external",
+    "//bzl/toolchains:erlang_toolchain_23",
+    "//bzl/toolchains:erlang_toolchain_24",
+    "//bzl/toolchains:erlang_toolchain_25",
+)
+
+load("@rules_erlang//:hex_pm.bzl", "hex_pm_erlang_app")
+
+hex_pm_erlang_app(
+    name = "ra",
+    sha256 = "24001b370c23690af3fe42ddca353c71c45d1edc1a0e56f9c1bf30bd4c37d14e",
+    version = "2.1.0",
+)
+
+hex_pm_erlang_app(
+    name = "seshat",
+    sha256 = "20d820acbeef9d07298ee863d0c9d06f8e620acba100939ebb2925e4d6b0dfc7",
+    version = "0.3.2",
+)
+
+hex_pm_erlang_app(
+    name = "aten",
+    sha256 = "64d40a8cf0ddfea4e13af00b7327f0925147f83612d0627d9506cbffe90c13ef",
+    version = "0.5.8",
+)
+
+hex_pm_erlang_app(
+    name = "gen_batch_server",
+    sha256 = "c3e6a1a2a0fb62aee631a98cfa0fd8903e9562422cbf72043953e2fb1d203017",
+    version = "0.8.8",
+)
+
+hex_pm_erlang_app(
+    name = "proper",
+    sha256 = "18285842185bd33efbda97d134a5cb5a0884384db36119fee0e3cfa488568cbb",
+    version = "1.4.0",
+)
+
+hex_pm_erlang_app(
+    name = "cth_readable",
+    sha256 = "686541a22efe6ca5a41a047b39516c2dd28fb3cade5f24a2f19145b3967f9d80",
+    version = "1.5.1",
+)

--- a/bzl/platforms/BUILD.bazel
+++ b/bzl/platforms/BUILD.bazel
@@ -1,0 +1,35 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "erlang_external_platform",
+    constraint_values = [
+        "@rules_erlang//platforms:erlang_external",
+    ],
+    parents = ["@local_config_platform//:host"],
+)
+
+platform(
+    name = "erlang_23_platform",
+    constraint_values = [
+        "@rules_erlang//platforms:erlang_23",
+    ],
+    parents = ["@rbe//config:platform"],
+)
+
+platform(
+    name = "erlang_24_platform",
+    constraint_values = [
+        "@rules_erlang//platforms:erlang_24",
+    ],
+    parents = ["@rbe//config:platform"],
+)
+
+platform(
+    name = "erlang_25_platform",
+    constraint_values = [
+        "@rules_erlang//platforms:erlang_25",
+    ],
+    parents = ["@rbe//config:platform"],
+)

--- a/bzl/toolchains/BUILD.bazel
+++ b/bzl/toolchains/BUILD.bazel
@@ -1,0 +1,25 @@
+load(
+    "@rules_erlang//tools:erlang.bzl",
+    "erlang_toolchain_external",
+    "erlang_toolchain_from_github_release",
+)
+
+erlang_toolchain_external()
+
+erlang_toolchain_from_github_release(
+    name_suffix = "_23",
+    sha256 = "35123f366ded534775a05db8ad6c06c20519ae228af1b5952132b10845621f21",
+    version = "23.3.4.14",
+)
+
+erlang_toolchain_from_github_release(
+    name_suffix = "_24",
+    sha256 = "76fcca5ba6f11eb9caac32bf053badc46b5d66f867150eef077f4f0d7944ecd7",
+    version = "24.3.4",
+)
+
+erlang_toolchain_from_github_release(
+    name_suffix = "_25",
+    sha256 = "2d7678c9bc6fcf3a1242c4d1c3864855d85e73ade792cd80adb8a9f379996711",
+    version = "25.0",
+)

--- a/eunit.bzl
+++ b/eunit.bzl
@@ -16,7 +16,7 @@ def eunit(
     srcs = native.glob(["test/**/*.erl"], exclude = native.glob(["test/*_SUITE.erl"])) if srcs == None else srcs
     erlang_bytecode(
         name = "test_case_beam_files",
-        hdrs = native.glob(["include/*.hrl", "src/*.hrl"]),
+        hdrs = native.glob(["include/*.hrl", "src/*.hrl", "test/*.hrl"]),
         srcs = srcs,
         erlc_opts = erlc_opts,
         dest = "test",

--- a/eunit.bzl
+++ b/eunit.bzl
@@ -1,0 +1,47 @@
+load("@rules_erlang//private:eunit.bzl", "eunit_test")
+load("@rules_erlang//:erlang_app.bzl", "DEFAULT_TEST_ERLC_OPTS")
+load("@rules_erlang//:erlang_bytecode.bzl", "erlang_bytecode")
+
+def _module_name(p):
+    return p.rpartition("/")[-1].replace(".erl", "")
+
+def eunit(
+        erlc_opts = DEFAULT_TEST_ERLC_OPTS,
+        srcs = None,
+        data = [],
+        deps = [],
+        runtime_deps = [],
+        additional_beam = [],
+        **kwargs):
+    srcs = native.glob(["test/**/*.erl"], exclude = native.glob(["test/*_SUITE.erl"])) if srcs == None else srcs
+    erlang_bytecode(
+        name = "test_case_beam_files",
+        hdrs = native.glob(["include/*.hrl", "src/*.hrl"]),
+        srcs = srcs,
+        erlc_opts = erlc_opts,
+        dest = "test",
+        deps = [":test_erlang_app"] + deps,
+        testonly = True,
+    )
+
+    # eunit_mods is the list of source modules, plus any test module which is
+    # not amoung the eunit_mods with a "_tests" suffix appended
+    eunit_ebin_mods = [_module_name(f) for f in native.glob(["src/**/*.erl"])]
+    eunit_test_mods = [_module_name(f) for f in srcs]
+    eunit_mods = eunit_ebin_mods
+    for tm in eunit_test_mods:
+        if tm not in [m + "_tests" for m in eunit_ebin_mods]:
+            eunit_mods.append(tm)
+
+    eunit_test(
+        name = "eunit",
+        is_windows = select({
+            "@bazel_tools//src/conditions:host_windows": True,
+            "//conditions:default": False,
+        }),
+        compiled_suites = [":test_case_beam_files"] + additional_beam,
+        eunit_mods = eunit_mods,
+        data = native.glob(["test/**/*"], exclude = srcs) + data,
+        deps = [":test_erlang_app"] + deps + runtime_deps,
+        **kwargs
+    )

--- a/user-template.bazelrc
+++ b/user-template.bazelrc
@@ -1,0 +1,12 @@
+build --@rules_erlang//:erlang_home=/Users/rabbitmq/kerl/24.3.2
+build --@rules_erlang//:erlang_version=24.3
+
+# rabbitmqctl wait shells out to 'ps', which is broken in the bazel macOS
+# sandbox (https://github.com/bazelbuild/bazel/issues/7448)
+# adding "--spawn_strategy=local" to the invocation is a workaround
+build --spawn_strategy=local
+
+# don't re-run flakes automatically on the local machine
+build --flaky_test_attempts=1
+
+build:buildbuddy --remote_header=x-buildbuddy-api-key=YOUR_API_KEY


### PR DESCRIPTION
_This is a draft pending changes in `rules_erlang`: https://github.com/rabbitmq/rules_erlang/pull/61_

This sets up bazel build files mostly influenced by osiris and ra.

There was an adjustment to make in the test cases since the stacktrace filenames differ between rebar3 and bazel.