### PR TITLE
Adapt to latest `codecov` uploader

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,6 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: _build/test/covertool/khepri.covertool.xml
-          flags: erlang:${{ matrix.otp_version }},os:${{ matrix.os }}
+          flags: erlang-${{ matrix.otp_version }},os-${{ matrix.os }}
           name: Erlang/OTP ${{ matrix.otp_version }} on ${{ matrix.os }}
           verbose: true # optional (default = false)

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1051,7 +1051,7 @@ gather_node_props(#node{stat = #{payload_version := DVersion,
     case Payload of
         #p_data{data = Data}  -> Result1#{data => Data};
         #p_sproc{sproc = Fun} -> Result1#{sproc => Fun};
-        _                            -> Result1
+        _                     -> Result1
     end.
 
 -spec to_absolute_keep_while(BasePath, KeepWhile) -> KeepWhile when


### PR DESCRIPTION
The `:` character was apparently already denied in flags, but the `codecov` uploader never reported that as an error. Since version 0.2.5, it does and the upload of Khepri's coverage reports broke.

Use `-` instead. This character is already used in the OS name, but that should be ok.

References codecov/uploader#831.