### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Ret = khepri:get("/:emails/alice"),
 "alice@example.org" = khepri:get_data_or("/:emails/alice", undefined).
 ```
 
-The `khepri:get/0` function and many other ones accept a "path pattern".
+The `khepri:get/1` function and many other ones accept a "path pattern".
 Therefore it is possible to get several nodes in a single call. The result is a
 map where keys are the path to each node which matched the path pattern, and
 the values are a map of properties. The data payload of the node is one of
@@ -174,8 +174,8 @@ the database itself and automatically execute it after some event occurs.
     StoredProcPath = [path, to, stored_procedure],
 
     Fun = fun(Props) ->
-              #{path := Path},
-                on_action => Action} = Props
+              #{path := Path,
+                on_action := Action} = Props
           end,
 
     khepri:put(StoreId, StoredProcPath, Fun).

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -42,7 +42,7 @@ the primary reason why the RabbitMQ team started to explore other options.
 
 Because RabbitMQ already uses an implementation of the Raft consensus algorithm
 for its quorum queues, it was decided to leverage that library for all
-metadata. That's how Khepri was borned.
+metadata. That's how Khepri was borne.
 
 Thanks to Ra and Raft, it is <strong>clear how Khepri will behave during a
 network partition and recover from it</strong>. This makes it more comfortable
@@ -59,7 +59,7 @@ work in progress.
 === Tree nodes ===
 
 Data in Khepri are organized as <em>tree nodes</em> ({@link
-khepri_machine:tree_node()}) in a tree structure. Every tree nodes have:
+khepri_machine:tree_node()}) in a tree structure. Every tree node has:
 <ul>
 <li>a <a href="#Node_ID">node ID</a></li>
 <li>a <a href="#Payload">payload</a> (optional)</li>
@@ -117,7 +117,7 @@ The equivalent of a <em>key</em> in a key/value store is a <em>path</em>
 A path is a list of node IDs, from the root (unnamed) tree node to the target
 ({@link khepri_path:path()}). For instance:
 ```
-%% Points to "/:stock/:wood/oak" in the tree showed above:
+%% Points to "/:stock/:wood/oak" in the tree shown above:
 Path = [stock, wood, <<"oak">>].
 '''
 
@@ -158,9 +158,9 @@ Relative paths are useful when putting conditions on
 
 === Tree node lifetime ===
 
-A tree node's lifetime starts when it is inserted the first time, until it is
-removed from the tree. However, intermediary tree nodes created on the way
-remain in the tree long after the leaf node was removed.
+A tree node's lifetime starts when it is inserted the first time and ends when
+it is removed from the tree. However, intermediary tree nodes created on the
+way remain in the tree long after the leaf node was removed.
 
 For instance, when `[stock, wood, <<"walnut">>]' was inserted, the intermediary
 tree nodes `stock' and `wood' were created if they were missing. After
@@ -218,7 +218,7 @@ true = khepri:exists([stock, wood, <<"lime tree">>]),
 {ok, _} = khepri:delete([stock, wood, <<"lime tree">>]).
 '''
 
-Inside transaction funtions, {@link khepri_tx} must be used instead of {@link
+Inside transaction functions, {@link khepri_tx} must be used instead of {@link
 khepri}. The former provides the same API, except for functions which don't
 make sense in the context of a transaction function.
 
@@ -418,9 +418,9 @@ EventFilter = khepri_evf:tree([stock, wood, <<"oak">>], %% Required
                               #{on_actions => [delete], %% Optional
                                 priority => 10}),       %% Optional
 
-%% For ease of use, some terms can be automatically converted to an event %
-%filter. Here, a Unix-like path could be used as a tree event % filter, though
-%it would have default properties unlike the previous line:
+%% For ease of use, some terms can be automatically converted to an event
+%% filter. Here, a Unix-like path could be used as a tree event filter, though
+%% it would have default properties unlike the previous line:
 EventFilter = "/:stock/:wood/oak".
 
 ok = khepri:register_trigger(
@@ -453,8 +453,8 @@ containing properties of the emitted event:
 
 ```
 my_stored_procedure(Props) ->
-    #{path := Path},
-      on_action => Action} = Props.
+    #{path := Path,
+      on_action := Action} = Props.
 '''
 
 `Path' is the path to the tree node created, updated or deleted.
@@ -464,7 +464,7 @@ my_stored_procedure(Props) ->
 The return value of this stored procedure is ignored in the context of a
 trigger.
 
-=== Execution guaranties ===
+=== Execution guarantees ===
 
 The stored procedure associated with a trigger (event filter) is executed on
 the Ra leader node.

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -508,7 +508,7 @@ put(StoreId, PathPattern, Data, Options) ->
 %%
 %% The payload must be one of the following form:
 %% <ul>
-%% <li>An explicit absense of payload ({@link khepri_payload:no_payload()}),
+%% <li>An explicit absence of payload ({@link khepri_payload:no_payload()}),
 %% using the marker returned by {@link khepri_payload:none/0}, meaning there
 %% will be no payload attached to the node and the existing payload will be
 %% discarded if any</li>

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -31,7 +31,7 @@
 %% <pre>ok = application:set_env(
 %%        khepri, default_store_id, my_store, [{persistent, true}]),
 %%
-%% {ok, my_store} = khepri:start("/var/lib/khepri", my_store).</pre></li>
+%% {ok, my_store} = khepri:start().</pre></li>
 %% </ul>
 %%
 %% == The data directory and the Ra system ==
@@ -75,7 +75,7 @@
 %% == Managing Ra cluster members ==
 %%
 %% A Khepri/Ra cluster can be expanded by telling a node to join a remote
-%% cluster. Node that the Khepri store/Ra server to add to the cluster must run
+%% cluster. Note that the Khepri store/Ra server to add to the cluster must run
 %% before it can join.
 %%
 %% ```
@@ -143,7 +143,7 @@
 %%
 %% This configuration map can lack the required parameters, Khepri will fill
 %% them if necessary. Important parameters for Khepri (e.g. `machine') will be
-%% overriden anyway.
+%% overridden anyway.
 %%
 %% @see ra_server:ra_server_config/0.
 

--- a/src/khepri_evf.erl
+++ b/src/khepri_evf.erl
@@ -32,7 +32,7 @@
 %% <li>`priority': a {@link priority()}</li>
 %% </ul>
 %%
-%% A Khepri path, wether it is a native path or a Unix-like path, can be used
+%% A Khepri path, whether it is a native path or a Unix-like path, can be used
 %% as a tree event filter. It will be automatically converted to a tree event
 %% filter with default properties.
 

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -73,6 +73,7 @@
 %% Commands specific to this Ra machine.
 
 -type machine_init_args() :: #{store_id := khepri:store_id(),
+                               member := ra:server_id(),
                                snapshot_interval => non_neg_integer(),
                                commands => [command()],
                                atom() => any()}.


### PR DESCRIPTION
I had a branch of typo fixes from reading through the docs and some of the code a while back and I totally forgot to PR it 🙃

I found a few spelling/grammar typos and I think also a spec missing a field.