### PR TITLE
Add an erlang_ls configuration file

### DIFF
--- a/erlang_ls.config
+++ b/erlang_ls.config
@@ -1,0 +1,9 @@
+# vim: ft=yaml
+# https://erlang-ls.github.io/configuration/
+apps_dirs:
+  - "."
+deps_dirs:
+  - "_build/default/lib/*"
+include_dirs:
+  - "_build/default/lib/*/include"
+  - "include"


### PR DESCRIPTION
This file is picked up by erlang_ls when running through an editor.
Without it, erlang_ls is functional but it will mistakenly jump to
`_build/default/lib/khepri/src/` when jumping to definitions or
references within the source.