### PR TITLE
Remove OTP23 from CI workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [23, 24, 25]
+        otp_version: [24, 25]
         os: [ubuntu-latest, windows-latest]
         exclude:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.


### PR DESCRIPTION
From a Slack discussion: OTP23 is EOL for the server so we should be able to drop support here. There aren't any failures on OTP23 but we may be able to remove some compatibility code from `khepri_fun`. (I'm not sure of any off the top of my head but we should be able to figure it out with coverage reports between runs with OTP23-25)