### PR TITLE
khepri_condition: Document path components within conditions

### DIFF
--- a/src/khepri_condition.erl
+++ b/src/khepri_condition.erl
@@ -14,6 +14,18 @@
 %% A condition is an Erlang record defining a specific property. Some of them
 %% have arguments to further define the condition.
 %%
+%% Path components (atoms and binaries) also act as conditions which check
+%% equality with the path of the tested node. This can be useful for
+%% conditions which compose other conditions: {@link if_not()},
+%% {@link if_all()} and {@link if_any()}.
+%%
+%% Example:
+%%
+%% ```
+%% %% Matches `[stock, wood, <<"birch">>]' but not `[stock, wood, <<"oak">>]'
+%% [stock, wood, #if_not{condition = <<"oak">>}]
+%% '''
+%%
 %% All supported conditions are described in the <a href="#types">Data Types
 %% section</a>.
 


### PR DESCRIPTION
Path components are valid conditions and may be used within conditions like `if_not`/`if_all`/`if_any`. This change adds a small note on that to the `khepri_condition` module-docs.