### PR TITLE
khepri_fun: Allow external funs in options

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -579,11 +579,16 @@ cache_standalone_fun(
     %% We include the options in the cached value. This is useful when the
     %% callbacks change for the same anonymous function.
     Checksums1 = maps:fold(
-                   fun
-                       (_Key, Fun, Acc) when is_function(Fun) ->
+                   fun (_Key, Fun, Acc) when is_function(Fun) ->
                            Info = maps:from_list(erlang:fun_info(Fun)),
-                           #{module := Module,
-                             new_uniq := Checksum} = Info,
+                           #{module := Module} = Info,
+                           Checksum = case Info of
+                                          #{type := local,
+                                            new_uniq := Checksum0} ->
+                                              Checksum0;
+                                          #{type := external} ->
+                                              Module:module_info(md5)
+                                      end,
                            case Acc of
                                #{Module := KnownChecksum} ->
                                    ?assertEqual(KnownChecksum, Checksum),

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -38,6 +38,8 @@
 -define(assertToFunThrow(Expected, Expression),
         ?assertThrow(Expected, ?make_standalone_fun(Expression))).
 
+-export([true/1, true/4]).
+
 %% The compiler is smart enough to optimize away many instructions by
 %% inspecting types and values. `mask/1' confuses the compiler by sending
 %% and receiving the value.
@@ -1025,6 +1027,18 @@ when_readwrite_mode_is_auto_test() ->
                    fun() -> Fun() end,
                    auto),
                  standalone_fun)).
+
+true(_) -> true.
+true(_, _, _, _) -> true.
+
+transaction_fun_options_as_external_functions_test() ->
+    Fun = fun() -> ok end,
+    Options = #{ensure_instruction_is_permitted => fun ?MODULE:true/1,
+                should_process_function => fun ?MODULE:true/4,
+                is_standalone_fun_still_needed => fun ?MODULE:true/1},
+    ?assertMatch(
+      #standalone_fun{},
+      khepri_fun:to_standalone_fun(Fun, Options)).
 
 make_list() -> [a, b].
 make_map() -> #{a => b}.


### PR DESCRIPTION
Previously, the checksum calculation in `khepri_fun:to_standalone_fun3/2` assumed that function options were local functions. It's possible to pass external functions as fully qualified captures, for example:

    fun khepri_tx:ensure_instruction_is_permitted/1

This change fixes a match error that is raised when passing in external functions as options. When an external function is passed, that function's md5 is used as the checksum.