### PR TITLE
Infer typing for get_list/3, get_hd/2

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1316,6 +1316,15 @@ pass1_process_instructions(
     Instruction1 = setelement(4, Instruction, Args1),
     pass1_process_instructions(Rest, State1, [Instruction1 | Result]);
 pass1_process_instructions(
+  [{get_hd, Src, _Dst} = Instruction | Rest],
+  State,
+  Result) ->
+    State1 = ensure_instruction_is_permitted(Instruction, State),
+    Type = {t_cons, any, any},
+    VarInfo = {var_info, Src, [{type, Type}]},
+    Comment = {'%', VarInfo},
+    pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
+pass1_process_instructions(
   [{get_list, Src, _HeadDst, _TailDst} = Instruction | Rest],
   State,
   Result) ->

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1316,6 +1316,15 @@ pass1_process_instructions(
     Instruction1 = setelement(4, Instruction, Args1),
     pass1_process_instructions(Rest, State1, [Instruction1 | Result]);
 pass1_process_instructions(
+  [{get_list, Src, _HeadDst, _TailDst} = Instruction | Rest],
+  State,
+  Result) ->
+    State1 = ensure_instruction_is_permitted(Instruction, State),
+    Type = {t_cons, any, any},
+    VarInfo = {var_info, Src, [{type, Type}]},
+    Comment = {'%', VarInfo},
+    pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
+pass1_process_instructions(
   [{get_tuple_element, Src, Element, _Dest} = Instruction | Rest],
   State,
   Result) ->

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -26,11 +26,11 @@
              allowed_bs_match_accepts_match_context_test/0]}]).
 
 -define(make_standalone_fun(Expression),
-        begin
+        fun() ->
             helpers:init_list_of_modules_to_skip(),
             __Fun = fun() -> Expression end,
             khepri_tx:to_standalone_fun(__Fun, rw)
-        end).
+        end()).
 
 -define(assertStandaloneFun(Expression),
         ?assertMatch(#standalone_fun{}, ?make_standalone_fun(Expression))).

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -527,6 +527,20 @@ allowed_multiple_nested_higher_order_functions_test() ->
     ?assertMatch(#standalone_fun{}, StandaloneFun),
     ?assert(is_function(khepri_fun:exec(StandaloneFun, []), 3)).
 
+reverse(List) ->
+    reverse(List, []).
+
+reverse([Head | Tail], Acc) ->
+    reverse(Tail, [Head | Acc]);
+reverse([], Acc) ->
+    Acc.
+
+allowed_list_pattern_matching_test() ->
+    %% Tests the get_list/3 instruction.
+    List = mask([a, b, c]),
+    Reverse = ?make_standalone_fun(reverse(List)),
+    ?assertMatch(#standalone_fun{}, Reverse),
+    ?assertEqual([c, b, a], khepri_fun:exec(Reverse, [])).
 denied_receive_block_test() ->
     ?assertToFunThrow(
        {invalid_tx_fun, receiving_message_denied},

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -540,7 +540,17 @@ allowed_list_pattern_matching_test() ->
     List = mask([a, b, c]),
     Reverse = ?make_standalone_fun(reverse(List)),
     ?assertMatch(#standalone_fun{}, Reverse),
-    ?assertEqual([c, b, a], khepri_fun:exec(Reverse, [])).
+    ?assertEqual([c, b, a], khepri_fun:exec(Reverse, [])),
+
+    %% Tests the get_hd/2 instruction.
+    ReverseHead = ?make_standalone_fun(
+                        begin
+                            [Head | _] = reverse(List),
+                            Head
+                        end),
+    ?assertMatch(#standalone_fun{}, ReverseHead),
+    ?assertEqual(c, khepri_fun:exec(ReverseHead, [])).
+
 denied_receive_block_test() ->
     ?assertToFunThrow(
        {invalid_tx_fun, receiving_message_denied},


### PR DESCRIPTION
`get_list/3` and `get_hd/2` need type comments that specify the source register as at least a cons-cell: `{t_cons, any, any}` or else the newly compiled code will fail the `beam_validator` checks.