### PR TITLE
GitHub Actions: Test against 25.0, not the latest 25.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25]
+        otp_version: [24, '25.0']
         os: [ubuntu-latest, windows-latest]
         exclude:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.


### PR DESCRIPTION
There is a regression in EUnit shipped with Erlang 25.1. This regression makes `rebar3 eunit` to fail when it loads testsuites. See erlang/otp#6320.

While we wait for a fix to be committed and a new version of Erlang 25.x to be published, let's pin Erlang 25.0 explicitly.