### PR TITLE
mix: Add application definition

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,13 @@ defmodule Khepri.MixProject do
     ]
   end
 
+  def application do
+    {:ok, [app]} = :file.consult("src/khepri.app.src")
+    {:application, _app_name, props} = app
+
+    Keyword.take(props, [:applications, :env, :mod, :registered])
+  end
+
   defp deps() do
     # To avoid duplication, we query rebar.config to get the list of
     # dependencies and their version pinning.


### PR DESCRIPTION
Prior to this change, Mix would not invoke `khepri_app:start/2` when starting the Khepri application (for example in `iex -S mix`). Transaction functions created within IEx would fail since the persistent term `{khepri,skipped_modules_in_code_collection}` was undefined.

This change adds the `application/0` function suggested in the [`mix compile.app`](https://hexdocs.pm/mix/1.14.0/Mix.Tasks.Compile.App.html) documentation. The Erlang `app.src` file already provides the `applications`, `mod`, `env`, and `registered` options necessary to configure the Khepri application, so we inherit the values directly from `src/khepri.app.src`.