### PR TITLE
GitHub Actions: Stop pinning Erlang 25 version to 25.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, '25.0']
+        otp_version: [24, 25]
         os: [ubuntu-latest, windows-latest]
         exclude:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.


### PR DESCRIPTION
We had to do that because EUnit in Erlang 25.1 had a bug which made the Khepri testsuite crash; see erlang/otp#6320.

The bug was fixed in Erlang 25.1.1.