### PR TITLE
khepri_fun: Resolve label inside `{call_fun2, {u,Idx}, ...}` instruction

### DIFF
--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -571,6 +571,8 @@ ensure_instruction_is_permitted({call_fun, _}) ->
     ok;
 ensure_instruction_is_permitted({call_fun2, {atom, safe}, _, _}) ->
     ok;
+ensure_instruction_is_permitted({call_fun2, {f, _}, _, _}) ->
+    ok;
 ensure_instruction_is_permitted({case_end, _}) ->
     ok;
 ensure_instruction_is_permitted({'catch', _, _}) ->


### PR DESCRIPTION
In pull request #134, the `{u,Idx}` argument was discarded and replaced by `{atom, safe}` because the module was already compiled successfully and the register used in the instruction must point to a valid function.

`Idx` is an offset in the Lambda table ("FunT" in the beam chunks). In this patch, we decode this table. This allows us to resolve the label used by `call_fun2` and replace `{u,Idx}` by a valid `{f,Label}`.

This is probably a small optimization of the resulting code, but it closer to what the Erlang compiler would do.

The testcase is expanded to execute the extracted function to make sure it still works.