### PR TITLE
Support stored procedures as transaction functions

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -2309,13 +2309,13 @@ transaction(Fun, ReadWriteOrOptions) when is_function(Fun) ->
 %%
 %% This function accepts the following three forms:
 %% <ul>
-%% <li>`transaction(StoreId, PathPattern, ReadWrite)'. Calling it is the same
-%% as calling `transaction(StoreId, PathPattern, ReadWrite, #{})'.</li>
-%% <li>`transaction(StoreId, PathPattern, Options)'. Calling it is the same
-%% as calling `transaction(StoreId, PathPattern, auto, Options)'.</li>
-%% <li>`transaction(PathPattern, ReadWrite, Options)'. Calling it is the same
-%% as calling `transaction(StoreId, PathPattern, ReadWrite, Options)' with the
-%% default store ID.</li>
+%% <li>`transaction(StoreId, Fun, ReadWrite)'. Calling it is the same as
+%% calling `transaction(StoreId, Fun, ReadWrite, #{})'.</li>
+%% <li>`transaction(StoreId, Fun, Options)'. Calling it is the same as calling
+%% `transaction(StoreId, Fun, auto, Options)'.</li>
+%% <li>`transaction(Fun, ReadWrite, Options)'. Calling it is the same as
+%% calling `transaction(StoreId, Fun, ReadWrite, Options)' with the default
+%% store ID.</li>
 %% </ul>
 %%
 %% @see transaction/4.

--- a/src/khepri_error.hrl
+++ b/src/khepri_error.hrl
@@ -20,3 +20,7 @@
 -define(
    khepri_misuse(Name, Props),
    ?khepri_misuse(?khepri_exception(Name, Props))).
+
+-define(
+   khepri_raise_misuse(Name, Props, Stacktrace),
+   erlang:raise(error, ?khepri_exception(Name, Props), Stacktrace)).

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -2404,7 +2404,11 @@ replace_label(
             NewLabel = maps:get({Module, OldLabel}, LabelMap),
             setelement(Pos, Instruction, {f, NewLabel});
         nofail ->
-            Instruction
+            %% `beam_disasm' decodes the label of an instruction which can't
+            %% fail as `nofail'. The compiler never emits such a "label" and
+            %% crashes with that incorrect label. Instead the compiler seems to
+            %% use `{f,0}' to signify that the instruction can't/must not fail.
+            setelement(Pos, Instruction, {f, 0})
     end.
 
 -spec gen_module_name(State) -> Module when

--- a/src/khepri_fun.hrl
+++ b/src/khepri_fun.hrl
@@ -12,3 +12,7 @@
                          arity :: arity(),
                          literal_funs :: [khepri_fun:standalone_fun()],
                          env :: list()}).
+
+-define(IS_STANDALONE_FUN(StandaloneFun),
+        (is_record(StandaloneFun, standalone_fun) orelse
+         is_function(StandaloneFun))).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -314,10 +314,7 @@ transaction(StoreId, Fun, _ReadWrite, _Options)
     {arity, Arity} = erlang:fun_info(Fun, arity),
     ?khepri_misuse(
        denied_tx_fun_with_arguments,
-       #{'fun' => Fun, arity => Arity});
-transaction(StoreId, Term, _ReadWrite, _Options)
-  when ?IS_STORE_ID(StoreId) ->
-    ?khepri_misuse(non_fun_term_used_as_tx_fun, #{term => Term}).
+       #{'fun' => Fun, arity => Arity}).
 
 -spec readonly_transaction(StoreId, Fun, Options) -> Ret when
       StoreId :: khepri:store_id(),

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -52,7 +52,7 @@
 -record(delete, {path :: khepri_path:native_pattern(),
                  options  = #{} :: khepri:tree_options()}).
 
--record(tx, {'fun' :: khepri_fun:standalone_fun(),
+-record(tx, {'fun' :: khepri_fun:standalone_fun() | khepri_path:pattern(),
              args = [] :: list()}).
 
 -record(register_trigger, {id :: khepri:trigger_id(),

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -52,7 +52,8 @@
 -record(delete, {path :: khepri_path:native_pattern(),
                  options  = #{} :: khepri:tree_options()}).
 
--record(tx, {'fun' :: khepri_fun:standalone_fun()}).
+-record(tx, {'fun' :: khepri_fun:standalone_fun(),
+             args = [] :: list()}).
 
 -record(register_trigger, {id :: khepri:trigger_id(),
                            event_filter :: khepri_evf:event_filter(),

--- a/src/khepri_payload.hrl
+++ b/src/khepri_payload.hrl
@@ -7,7 +7,8 @@
 
 -define(NO_PAYLOAD, '$__NO_PAYLOAD__').
 -record(p_data, {data :: khepri:data()}).
--record(p_sproc, {sproc :: khepri_fun:standalone_fun()}).
+-record(p_sproc, {sproc :: khepri_fun:standalone_fun(),
+                  is_valid_as_tx_fun :: ro | rw | false}).
 
 -define(IS_KHEPRI_PAYLOAD(Payload), (Payload =:= ?NO_PAYLOAD orelse
                                      is_record(Payload, p_data) orelse

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -750,7 +750,7 @@ delete_many_payloads(PathPattern, Options) ->
 %% @param Reason term to return to caller of the transaction.
 
 abort(Reason) ->
-    throw({aborted, Reason}).
+    throw(?TX_ABORT(Reason)).
 
 %% -------------------------------------------------------------------
 %% is_transaction().

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -92,7 +92,7 @@
 -type tx_fun_result() :: any() | no_return().
 %% Return value of a transaction function.
 
--type tx_fun() :: fun(() -> khepri_tx:tx_fun_result()).
+-type tx_fun() :: fun().
 %% Transaction function signature.
 
 -type tx_abort() :: khepri:error(any()).

--- a/src/khepri_tx.hrl
+++ b/src/khepri_tx.hrl
@@ -7,3 +7,5 @@
 
 -define(TX_STATE_KEY, khepri_tx_machine_state).
 -define(TX_PROPS, khepri_tx_properties).
+
+-define(TX_ABORT(Reason), {'$__ABORTED_KHEPRI_TX__', Reason}).

--- a/test/simple_tx_misc.erl
+++ b/test/simple_tx_misc.erl
@@ -252,7 +252,7 @@ not_a_function_as_ro_transaction_test_() ->
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertError(
-         ?khepri_exception(non_fun_term_used_as_tx_fun, #{term := Term}),
+         function_clause,
          khepri:transaction(?FUNCTION_NAME, Term, ro))]}.
 
 not_a_function_as_rw_transaction_test_() ->
@@ -261,7 +261,7 @@ not_a_function_as_rw_transaction_test_() ->
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertError(
-         ?khepri_exception(non_fun_term_used_as_tx_fun, #{term := Term}),
+         function_clause,
          khepri:transaction(?FUNCTION_NAME, Term, rw))]}.
 
 exception_in_ro_transaction_test_() ->

--- a/test/stored_procs.erl
+++ b/test/stored_procs.erl
@@ -144,7 +144,8 @@ execute_crashing_sproc_test_() ->
 crashing_sproc_stacktrace_test_() ->
     {ok, Cwd} = file:get_cwd(),
     File1 = filename:join([Cwd, "test/mod_used_for_transactions.erl"]),
-    File2 = filename:join([Cwd, "test/stored_procs.erl"]),
+    File2 = filename:join([Cwd, "src/khepri_sproc.erl"]),
+    File3 = filename:join([Cwd, "test/stored_procs.erl"]),
     StoredProcPath = [sproc],
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
@@ -162,7 +163,8 @@ crashing_sproc_stacktrace_test_() ->
             {throw,
              "Expected crash",
              [{_GeneratedModuleName, run,0, [{file, File1}, {line, _}]},
-              {stored_procs, _, _, [{file, File2}, {line, _}]}
+              {khepri_sproc, _, _, [{file, File2}, {line, _}]},
+              {stored_procs, _, _, [{file, File3}, {line, _}]}
               | _]},
             try
                 khepri:run_sproc(

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -64,7 +64,7 @@ allowed_khepri_tx_api_test() ->
            _ = khepri_tx:is_transaction()
        end).
 
-denied_khepri_tx_adv_run_3_test() ->
+denied_khepri_tx_adv_run_4_test() ->
     MachineState = #khepri_machine{
                       config = #config{store_id = ?FUNCTION_NAME,
                                        member = {?FUNCTION_NAME, node()}}
@@ -72,8 +72,8 @@ denied_khepri_tx_adv_run_3_test() ->
     ?assertToFunError(
        ?khepri_exception(
           failed_to_prepare_tx_fun,
-          #{error := {call_denied, {khepri_tx_adv, run, 3}}}),
-       _ = khepri_tx_adv:run(MachineState, fun() -> ok end, true)).
+          #{error := {call_denied, {khepri_tx_adv, run, 4}}}),
+       _ = khepri_tx_adv:run(MachineState, fun() -> ok end, [], true)).
 
 allowed_erlang_expressions_add_test() ->
     One = mask(1),

--- a/test/tx_sprocs.erl
+++ b/test/tx_sprocs.erl
@@ -1,0 +1,154 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(tx_sprocs).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/khepri_error.hrl").
+-include("src/khepri_payload.hrl").
+-include("test/helpers.hrl").
+
+use_valid_sproc_as_tx_function_test_() ->
+    Fun = fun() -> ok end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [tx], Fun)),
+      ?_assertEqual(
+         ok,
+         khepri:run_sproc(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {ok, ok},
+         khepri:transaction(?FUNCTION_NAME, [tx], []))]}.
+
+call_ro_sproc_test_() ->
+    Fun = fun() -> khepri_tx:get([]) end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [tx], Fun)),
+      ?_assertError(
+         ?khepri_exception(invalid_use_of_khepri_tx_outside_transaction, #{}),
+         khepri:run_sproc(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {ok, {ok, undefined}},
+         khepri:transaction(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {ok, {ok, undefined}},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], auto)),
+      ?_assertEqual(
+         {ok, {ok, undefined}},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], ro)),
+      ?_assertEqual(
+         {ok, {ok, undefined}},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], rw))]}.
+
+call_rw_sproc_test_() ->
+    Fun = fun() -> khepri_tx:put([foo], value) end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [tx], Fun)),
+      ?_assertError(
+         ?khepri_exception(invalid_use_of_khepri_tx_outside_transaction, #{}),
+         khepri:run_sproc(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {ok, ok},
+         khepri:transaction(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {ok, ok},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], auto)),
+      ?_assertEqual(
+         {error, ?khepri_error(sproc_invalid_as_tx_fun, #{path => [tx]})},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], ro)),
+      ?_assertEqual(
+         {ok, ok},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], rw))]}.
+
+abort_tx_sproc_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [tx], fun abort_tx/0)),
+      ?_assertError(
+         ?khepri_exception(invalid_use_of_khepri_tx_outside_transaction, #{}),
+         khepri:run_sproc(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {error, abort_transaction},
+         khepri:transaction(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {error, abort_transaction},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], auto)),
+      ?_assertEqual(
+         {error, abort_transaction},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], ro)),
+      ?_assertEqual(
+         {error, abort_transaction},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], rw))]}.
+
+-spec abort_tx() -> no_return().
+
+abort_tx() ->
+    khepri_tx:abort(abort_transaction).
+
+forbidden_tx_sproc_test_() ->
+    Fun = fun() -> node() end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [tx], Fun)),
+      ?_assertEqual(
+         node(),
+         khepri:run_sproc(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {error, ?khepri_error(sproc_invalid_as_tx_fun, #{path => [tx]})},
+         khepri:transaction(?FUNCTION_NAME, [tx], [])),
+      ?_assertEqual(
+         {error, ?khepri_error(sproc_invalid_as_tx_fun, #{path => [tx]})},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], auto)),
+      ?_assertEqual(
+         {error, ?khepri_error(sproc_invalid_as_tx_fun, #{path => [tx]})},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], ro)),
+      ?_assertEqual(
+         {error, ?khepri_error(sproc_invalid_as_tx_fun, #{path => [tx]})},
+         khepri:transaction(?FUNCTION_NAME, [tx], [], rw))]}.
+
+crashing_tx_sproc_test_() ->
+    Fun = fun() -> erlang:throw("Expected crash") end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [tx], Fun)),
+      ?_assertThrow(
+         "Expected crash",
+         khepri:run_sproc(?FUNCTION_NAME, [tx], [])),
+      ?_assertThrow(
+         "Expected crash",
+         khepri:transaction(?FUNCTION_NAME, [tx], [])),
+      ?_assertThrow(
+         "Expected crash",
+         khepri:transaction(?FUNCTION_NAME, [tx], [], auto)),
+      ?_assertThrow(
+         "Expected crash",
+         khepri:transaction(?FUNCTION_NAME, [tx], [], ro)),
+      ?_assertThrow(
+         "Expected crash",
+         khepri:transaction(?FUNCTION_NAME, [tx], [], rw))]}.


### PR DESCRIPTION
This patch brings two improvements:

1.  A **transaction function can take arguments**. Arguments are passed as a list of terms to `khepri:transaction()`.

    Here is an example:

    ```erlang
    generic_tx(Wood, Increase) ->
        Path = [stock, Wood],
        {ok, Stock} = khepri_tx:get(Path),
        NewStock = erlang:min(?MAX_STOCK, Stock + Increase),
        ok = khepri_tx:put(Path, NewStock).

    increase_wood_stock(Wood, Increase) ->
        khepri:transaction(
          ?STORE_ID, fun generic_tx/2, [Wood, Increase]).
    ```

    This way, one can write a more generic transaction function which doesn't rely on variables in its environment, and pass arguments to `khepri:transaction()` instead.

4.  **Stored procedures can be used as transaction functions**. This allows to extract and store a transaction function once and use it many times. This saves the extraction time and reduce the size of the transaction Ra command.

    Here is an example:

    ```erlang
    generic_tx(Wood, Increase) ->
        Path = [stock, Wood],
        {ok, Stock} = khepri_tx:get(Path),
        NewStock = erlang:min(?MAX_STOCK, Stock + Increase),
        ok = khepri_tx:put(Path, NewStock).

    store_wood_stock_tx() ->
        khepri:put(?STORE_ID, [tx, wood_stock], fun generic_tx/2).

    increase_wood_stock(Wood, Increase) ->
        khepri:transaction(
          ?STORE_ID, [tx, wood_stock], [Wood, Increase]).
    ```

    The constraints for transaction functions remain the same: they can't have side effects. So now, everytime a function is stored in Khepri, we verify during extraction if it can be used as a transaction function and store the result with the extracted function. When the stored procedure is executed as a transaction function, we check the result of that verification and possibly deny the execution.

Fixes #141.