### PR TITLE
Acknowledge trigger executions asynchronously

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -474,7 +474,7 @@ register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options)
 ack_triggers_execution(StoreId, TriggeredStoredProcs)
   when ?IS_STORE_ID(StoreId) ->
     Command = #ack_triggered{triggered = TriggeredStoredProcs},
-    process_command(StoreId, Command, #{}).
+    process_command(StoreId, Command, #{async => true}).
 
 -spec get_keep_while_conds_state(StoreId, Options) -> Ret when
       StoreId :: khepri:store_id(),


### PR DESCRIPTION
`khepri_machine:ack_triggers_execution/2` currently uses a synchronous command to trigger executions but this is unnecessary: triggers are executed asynchronously (via `gen_server:cast/2`) and there aren't any timing concerns that would require a blocking call.

Synchronous commands may fail and crash the `khepri_event_handler` process. In the `triggers` EUnit suite, calls to `khepri_machine:ack_triggers_execution/2` may race with `test_ra_server_helpers:cleanup/1` and the synchronous command might cause an exit within `khepri_event_handler` because the machine is shutting down. This can cause flaky tests in that suite on hardware that is fast enough to lose the race.

In this change, we switch to an asynchronous Ra command for acknowledging trigger executions. Asynchronous Ra commands wil not fail when the machine is shutting down, so they will not crash the `khepri_event_handler` process.