### PR TITLE
Capture and assert on log contents in EUnit tests

### DIFF
--- a/test/app.erl
+++ b/test/app.erl
@@ -69,11 +69,16 @@ get_default_timeout_with_neg_integer_app_env_test() ->
     Timeout = -5000,
     application:set_env(
       khepri, default_timeout, Timeout, [{persistent, true}]),
-    ?assertError(
-       ?khepri_exception(
-          invalid_default_timeout_value,
-          #{default_timeout := Timeout}),
-       khepri_app:get_default_timeout()),
+    Log = helpers:capture_log(
+            fun() ->
+                    ?assertError(
+                       ?khepri_exception(
+                          invalid_default_timeout_value,
+                          #{default_timeout := Timeout}),
+                       khepri_app:get_default_timeout())
+            end),
+    ?assertSubString(
+      <<"Invalid timeout set in `default_timeout`">>, Log),
     application:unset_env(
       khepri, default_timeout, [{persistent, true}]).
 
@@ -137,11 +142,17 @@ get_default_ra_system_or_data_dir_with_invalid_app_env_test() ->
     Invalid = {invalid},
     application:set_env(
       khepri, default_ra_system, Invalid, [{persistent, true}]),
-    ?assertError(
-       ?khepri_exception(
-          invalid_default_ra_system_value,
-          #{default_ra_system := Invalid}),
-       khepri_cluster:get_default_ra_system_or_data_dir()),
+    Log = helpers:capture_log(
+            fun() ->
+                    ?assertError(
+                       ?khepri_exception(
+                          invalid_default_ra_system_value,
+                          #{default_ra_system := Invalid}),
+                       khepri_cluster:get_default_ra_system_or_data_dir())
+            end),
+    ?assertSubString(
+      <<"Invalid Ra system or data directory set in `default_ra_system`">>,
+      Log),
     application:unset_env(
       khepri, default_ra_system, [{persistent, true}]).
 
@@ -164,11 +175,16 @@ get_default_store_id_with_invalid_app_env_test() ->
     Invalid = {invalid},
     application:set_env(
       khepri, default_store_id, Invalid, [{persistent, true}]),
-    ?assertError(
-       ?khepri_exception(
-          invalid_default_store_id_value,
-          #{default_store_id := Invalid}),
-       khepri_cluster:get_default_store_id()),
+    Log = helpers:capture_log(
+            fun() ->
+                    ?assertError(
+                       ?khepri_exception(
+                          invalid_default_store_id_value,
+                          #{default_store_id := Invalid}),
+                       khepri_cluster:get_default_store_id())
+            end),
+    ?assertSubString(
+      <<"Invalid store ID set in `default_store_id`">>, Log),
     application:unset_env(
       khepri, default_store_id, [{persistent, true}]).
 

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -68,7 +68,13 @@ get_store_info_on_non_existing_store_test_() ->
          "\033[1;32m== CLUSTER MEMBERS ==\033[0m\n"
          "\n",
          begin
-             khepri:info(non_existing_store, #{timeout => 1000}),
+             Log = helpers:capture_log(
+                     fun() ->
+                             khepri:info(
+                               non_existing_store, #{timeout => 1000})
+                     end),
+             ?assertSubString(<<"Failed to query members in store">>, Log),
+             ?assertSubString(<<"{error,noproc}">>, Log),
              ?capturedOutput
          end)]}.
 

--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -16,6 +16,8 @@
          remove_store_dir/1,
          with_log/1,
          capture_log/1,
+         silence_default_logger/0,
+         restore_default_logger/1,
          %% For internal use only.
          log/2,
          format/2]).
@@ -78,6 +80,15 @@ remove_store_dir(StoreDir) ->
         Error ->
             throw(Error)
     end.
+
+silence_default_logger() ->
+    {ok, #{level := OldDefaultLoggerLevel}} =
+      logger:get_handler_config(default),
+    ok = logger:set_handler_config(default, level, none),
+    OldDefaultLoggerLevel.
+
+restore_default_logger(OldDefaultLoggerLevel) ->
+    ok = logger:set_handler_config(default, level, OldDefaultLoggerLevel).
 
 -spec with_log(Fun) -> {Result, Log}
     when

--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -13,7 +13,14 @@
          start_ra_system/1,
          stop_ra_system/1,
          store_dir_name/1,
-         remove_store_dir/1]).
+         remove_store_dir/1,
+         with_log/1,
+         capture_log/1,
+         %% For internal use only.
+         log/2,
+         format/2]).
+
+-define(CAPTURE_LOGGER_ID, capture_logger).
 
 init_list_of_modules_to_skip() ->
     _ = application:load(khepri),
@@ -70,4 +77,69 @@ remove_store_dir(StoreDir) ->
             ok;
         Error ->
             throw(Error)
+    end.
+
+-spec with_log(Fun) -> {Result, Log}
+    when
+      Fun :: fun(() -> Result),
+      Result :: term(),
+      Log :: binary().
+
+%% @doc Returns the value of executing the given `Fun' and any log messages
+%% produced while executing it, concatenated into a binary.
+with_log(Fun) ->
+    FormatterConfig = #{},
+    HandlerConfig = #{config => self(),
+                      formatter => {?MODULE, FormatterConfig}},
+    {ok, #{level := OldDefaultLogLevel}} = logger:get_handler_config(default),
+    ok = logger:set_handler_config(default, level, none),
+    ok = logger:add_handler(?CAPTURE_LOGGER_ID, ?MODULE, HandlerConfig),
+    try
+        Result = Fun(),
+        Log = collect_logs(),
+        {Result, Log}
+    after
+        _ = logger:remove_handler(?CAPTURE_LOGGER_ID),
+        _ = logger:set_handler_config(default, level, OldDefaultLogLevel)
+    end.
+
+-spec capture_log(Fun) -> Log
+    when
+      Fun :: fun(() -> any()),
+      Log :: binary().
+
+%% @doc Returns the logger messages produced while executing the given `Fun'
+%% concatenated into a binary.
+capture_log(Fun) ->
+    {_Result, Log} = with_log(Fun),
+    Log.
+
+%% Implements the `log/2' callback for logger handlers
+log(LogEvent, Config) ->
+    #{config := TestPid} = Config,
+    Msg = case maps:get(msg, LogEvent) of
+              {report, Report} ->
+                  {Format, Args} = logger:format_report(Report),
+                  iolist_to_binary(io_lib:format(Format, Args));
+              {string, Chardata} ->
+                  unicode:characters_to_binary(Chardata);
+              {Format, Args} ->
+                  iolist_to_binary(io_lib:format(Format, Args))
+          end,
+    TestPid ! {?MODULE, Msg},
+    ok.
+
+%% Implements the `format/2' callback for logger formatters
+format(_LogEvent, _FormatConfig) ->
+    %% No-op: print nothing to the console.
+    ok.
+
+collect_logs() ->
+    collect_logs(<<>>).
+
+collect_logs(Acc) ->
+    receive
+        {?MODULE, Msg} -> collect_logs(<<Msg/binary, Acc/binary>>)
+    after
+        50 -> Acc
     end.

--- a/test/helpers.hrl
+++ b/test/helpers.hrl
@@ -16,3 +16,10 @@
         #{store_id => ?FUNCTION_NAME,
           member => khepri_cluster:this_member(?FUNCTION_NAME),
           commands => Commands}).
+
+%% Asserts that `SubString' is contained in `String'.
+%%
+%% `SubString' and `String' may either be lists or binaries but both must be
+%% the same type in any call.
+-define(assertSubString(SubString, String),
+        ?assertNotMatch(nomatch, string:find(String, SubString))).


### PR DESCRIPTION
Some cases in the EUnit suite emit log messages which interrupt the regular EUnit output and can fill up a terminal page. These changes silence all emitted logs, either by discarding logs or by capturing them and asserting on the contents. The latter is useful in cases like the buggy-sproc case in `triggers`: it's useful to be able to assert on the contents of the error message and ensure that it's counting the number of crashes within the 10 second period.

This will also be useful for a test case in #135