### PR TITLE
Add import/export feature

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,6 +11,7 @@
 {erl_opts, [debug_info,
             warn_export_vars,
             warnings_as_errors]}.
+{erl_first_files, ["src/khepri_import_export.erl"]}.
 
 {dialyzer, [{warnings, [underspecs,
                         unknown,

--- a/src/khepri_export_erlang.erl
+++ b/src/khepri_export_erlang.erl
@@ -1,0 +1,257 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% @doc Khepri import/export callback module using Erlang terms formatted as
+%% plain text as its external format.
+%%
+%% The exported file could be read using {@link file:consult/1} to get back
+%% the list of backup items.
+%%
+%% This callback module takes a filename or an opened file descriptor as its
+%% private data passed to {@link khepri:export/4} and {@link khepri:import/3}.
+%%
+%% Example:
+%% ```
+%% ok = khepri:put(StoreId, "/:stock/:wood/Oak", 100).
+%% ok = khepri:put(StoreId, "/:stock/:wood/Mapple", 55).
+%% ok = khepri:export(StoreId, khepri_export_erlang, "export.erl").
+%% '''
+%%
+%% Content of `export.erl':
+%% ```
+%% {put,[stock,wood,<<"Mapple">>],{p_data,55},#{},#{}}.
+%% {put,[stock,wood,<<"Oak">>],{p_data,100},#{},#{}}.
+%% '''
+
+-module(khepri_export_erlang).
+
+-behavior(khepri_import_export).
+
+-include_lib("kernel/include/logger.hrl").
+
+%% How many bytes to read from the file descriptor before `read/1' returns a
+%% list of backup items. `khepri_import_export' will call this module again to
+%% read the next batch.
+-define(IMPORT_APPROX_LIMIT_PER_CALL, 100 * 1024). %% In bytes.
+
+-export([open_write/1,
+         write/2,
+         commit_write/1,
+         abort_write/1,
+
+         open_read/1,
+         read/1,
+         close_read/1]).
+
+-type write_state() :: #{fd := file:io_device(),
+                         filename => file:name_all()}.
+
+-type read_state() :: #{fd := file:io_device(),
+                        max_chunk := non_neg_integer(),
+                        location := erl_anno:location(),
+                        start_pos => integer(),
+                        filename => file:name_all()}.
+
+-spec open_write(Filename | Fd) -> Ret when
+      Filename :: file:name_all(),
+      Fd :: file:io_device(),
+      Ret :: {ok, WriteState} | {error, any()},
+      WriteState :: write_state().
+%% @private
+
+open_write(Filename) when is_list(Filename) ->
+    ?LOG_DEBUG(
+       "~s: opening file \"~ts\" for export",
+       [?MODULE, Filename],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    case file:open(Filename, [write]) of
+        {ok, Fd} ->
+            State = #{fd => Fd,
+                      filename => Filename},
+            {ok, State};
+        {error, _} = Error ->
+            Error
+    end;
+open_write(Fd) ->
+    ?LOG_DEBUG(
+       "~s: using existing file descriptor ~p",
+       [?MODULE, Fd],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    State = #{fd => Fd},
+    {ok, State}.
+
+-spec write(WriteState, BackupItems) -> Ret when
+      WriteState :: write_state(),
+      BackupItems :: [khepri_import_export:backup_item()],
+      Ret :: {ok, WriteState} | {error, any()}.
+%% @private
+
+write(#{fd := Fd} = State, [BackupItem | Rest]) ->
+    ?LOG_DEBUG(
+       "~s: exporting: ~p",
+       [?MODULE, BackupItem],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    Binary = io_lib:format("~0p.~n", [BackupItem]),
+    case file:write(Fd, Binary) of
+        ok                 -> write(State, Rest);
+        {error, _} = Error -> Error
+    end;
+write(State, []) ->
+    ?LOG_DEBUG(
+       "~s: finished exporting",
+       [?MODULE],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    {ok, State}.
+
+-spec commit_write(WriteState) -> Ret when
+      WriteState :: write_state(),
+      Ret :: ok | {error, any()}.
+%% @private
+
+commit_write(#{fd := Fd, filename := Filename}) ->
+    ?LOG_DEBUG(
+       "~s: closing file \"~ts\" after export",
+       [?MODULE, Filename],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    case file:close(Fd) of
+        ok                 -> ok;
+        {error, _} = Error -> Error
+    end;
+commit_write(_State) ->
+    ?LOG_DEBUG(
+       "~s: used existing file descriptor; nothing to close after export",
+       [?MODULE],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    ok.
+
+-spec abort_write(WriteState) -> Ret when
+      WriteState :: write_state(),
+      Ret :: ok.
+%% @private
+
+abort_write(#{fd := Fd, filename := Filename}) ->
+    ?LOG_DEBUG(
+       "~s: aborting export to file \"~ts\"",
+       [?MODULE, Filename],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    _ = file:close(Fd),
+    _ = file:delete(Filename),
+    ok;
+abort_write(#{fd := Fd}) ->
+    ?LOG_DEBUG(
+       "~s: aborting export to existing file descriptor ~p",
+       [?MODULE, Fd],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    ok.
+
+-spec open_read(Filename | Fd) -> Ret when
+      Filename :: file:name_all(),
+      Fd :: file:io_device(),
+      Ret :: {ok, ReadState} | {error, any()},
+      ReadState :: read_state().
+%% @private
+
+open_read(Filename) when is_list(Filename) ->
+    ?LOG_DEBUG(
+       "~s: opening file \"~ts\" for import",
+       [?MODULE, Filename],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    case file:open(Filename, [read]) of
+        {ok, Fd} ->
+            _ = epp:set_encoding(Fd),
+            State = #{fd => Fd,
+                      max_chunk => ?IMPORT_APPROX_LIMIT_PER_CALL,
+                      location => 1,
+                      filename => Filename},
+            {ok, State};
+        {error, _} = Error ->
+            Error
+    end;
+open_read(Fd) ->
+    ?LOG_DEBUG(
+       "~s: using existing file descriptor ~p for import",
+       [?MODULE, Fd],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    State = #{fd => Fd,
+              max_chunk => ?IMPORT_APPROX_LIMIT_PER_CALL,
+              location => 1},
+    {ok, State}.
+
+-spec read(ReadState) -> Ret when
+      ReadState :: read_state(),
+      Ret :: {ok, BackupItems, ReadState} | {error, any()},
+      BackupItems :: [khepri_import_export:backup_item()].
+%% @private
+
+read(#{fd := Fd} = State) ->
+    StartPos = case file:position(Fd, cur) of
+                   {ok, Pos} -> Pos;
+                   _         -> undefined
+               end,
+    State1 = State#{start_pos => StartPos},
+    do_read(State1, []).
+
+-spec do_read(ReadState, BackupItems) -> Ret when
+      ReadState :: read_state(),
+      BackupItems :: [khepri_import_export:backup_item()],
+      Ret :: {ok, BackupItems, ReadState} | {error, any()}.
+%% @private
+
+do_read(
+  #{fd := Fd,
+    location := Location,
+    start_pos := StartPos,
+    max_chunk := MaxChunk} = State,
+  BackupItems) ->
+    case io:read(Fd, <<>>, Location) of
+        {ok, BackupItem, EndLocation} ->
+            ?LOG_DEBUG(
+               "~s: importing: ~p",
+               [?MODULE, BackupItem],
+               #{domain => [khepri, import_export, ?MODULE]}),
+            BackupItems1 = [BackupItem | BackupItems],
+            State1 = State#{location => EndLocation},
+
+            CurPos = case file:position(Fd, cur) of
+                         {ok, Pos} -> Pos;
+                         _         -> undefined
+                     end,
+            MustStop = (StartPos =:= undefined orelse
+                        CurPos =:= undefined orelse
+                        CurPos - StartPos >= MaxChunk),
+            case MustStop of
+                false -> do_read(State1, BackupItems1);
+                true  -> {ok, lists:reverse(BackupItems1), State1}
+            end;
+        {eof, EndLocation} ->
+            ?LOG_DEBUG(
+               "~s: finished importing",
+               [?MODULE],
+               #{domain => [khepri, import_export, ?MODULE]}),
+            State1 = State#{location => EndLocation},
+            {ok, lists:reverse(BackupItems), State1};
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec close_read(ReadState) -> Ret when
+      ReadState :: read_state(),
+      Ret :: ok | {error, any()}.
+%% @private
+
+close_read(#{fd := Fd, filename := Filename}) ->
+    ?LOG_DEBUG(
+       "~s: closing file \"~ts\" after import",
+       [?MODULE, Filename],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    file:close(Fd);
+close_read(_State) ->
+    ?LOG_DEBUG(
+       "~s: used existing file descriptor; nothing to close after import",
+       [?MODULE],
+       #{domain => [khepri, import_export, ?MODULE]}),
+    ok.

--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -1,0 +1,442 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% @doc Wrapper around Mnesia Backup &amp; Restore callback modules.
+%%
+%% Khepri uses the same callback module as Mnesia to implement its import and
+%% export feature. The <a
+%% href="https://www.erlang.org/doc/apps/mnesia/mnesia_app_a">Mnesia Backup
+%% &amp; Restore API is described in the Mnesia documentation</a>.
+%%
+%% Mnesia doesn't provide an Erlang behavior module to ease development. This
+%% module can be used as the behavior instead. For example:
+%% ```
+%% -module(my_export_module).
+%% -behavior(khepri_import_export).
+%%
+%% -export([open_write/1,
+%%          write/2,
+%%          commit_write/1,
+%%          abort_write/1,
+%% 
+%%          open_read/1,
+%%          read/1,
+%%          close_read/1]).
+%% '''
+%%
+%% There are two sets of callback functions to implement: one used during
+%% export (or "backup" in Mnesia terms), one used during import (or "restore"
+%% in Mnesia terms).
+%%
+%% == Export callback API ==
+%%
+%% <ol>
+%% <li>
+%% <p>`Module:open_write(Args)'</p>
+%% <p>This function is called at the beginning of an export. It is responsible
+%% for any initialization and must return an `{ok, ModulePriv}' tuple.
+%% `ModulePriv' is a private state passed to the following functions.</p>
+%% </li>
+%% <li>
+%% <p>`Module:write(ModulePriv, BackupItems)'</p>
+%% <p>This function is called for each subset of the items to export.</p>
+%% <p>`BackupItems' is a list of opaque Erlang terms. The callback module
+%% can't depend on the structure of these Erlang terms. Only the fact that it
+%% is a list is guarantied.</p>
+%% <p>An empty list of `BackupItems' means this is the last call to
+%% `Module:write/2'. Otherwise, the way all items to export are split into
+%% several subsets and thus several calls to `Module:write/2' is
+%% undefined.</p>
+%% <p>At the end of each call, the function must return `{ok, NewModulePriv}'.
+%% This new private state is passed to the subsequent calls.</p>
+%% </li>
+%% <li>
+%% <p>`Module:commit_write(ModulePriv)'</p>
+%% <p>This function is called after successful calls to `Module:write/2'. It
+%% is responsible for doing any cleanup.</p>
+%% <p>This function can return `ok' or `{ok, Ret}' if it wants to return some
+%% Erlang terms to the caller.</p>
+%% </li>
+%% <li>
+%% <p>`Module:abort_write(ModulePriv)'</p>
+%% <p>This function is called after failed call to `Module:write/2', or if
+%% reading from the Khepri store fails. It is responsible for doing any
+%% cleanup.</p>
+%% <p>This function can return `ok' or `{ok, Ret}' if it wants to return some
+%% Erlang terms to the caller.</p>
+%% </li>
+%% </ol>
+%%
+%% == Import callback API ==
+%%
+%% <ol>
+%% <li>
+%% <p>`Module:open_read(Args)'</p>
+%% <p>This function is called at the beginning of an import. It is responsible
+%% for any initialization and must return an `{ok, ModulePriv}' tuple.
+%% `ModulePriv' is a private state passed to the following functions.</p>
+%% </li>
+%% <li>
+%% <p>`Module:read(ModulePriv)'</p>
+%% <p>This function is one or more times until there is nothing left to
+%% import.</p>
+%% <p>The function must return `{ok, BackupItems, NewModulePriv}'. This new
+%% private state is passed to the subsequent calls.</p>
+%% <p>`BackupItems' is a list of opaque Erlang terms. The callback module
+%% can't depend on the structure of these Erlang terms. The backup items must
+%% be returned exactly as they were at the time of the export and in the same
+%% order.</p>
+%% <p>An empty list of `BackupItems' means this is the last batch.
+%% `Module:read/1' won't be called anymore. `Module:close_read/1' will be
+%% called next instead.</p>
+%% </li>
+%% <li>
+%% <p>`Module:close_read(ModulePriv)'</p>
+%% <p>This function is called after the last call to `Module:read/1',
+%% successful or not, or if the actual import into the Khepri store fails. It
+%% is responsible for doing any cleanup.</p>
+%% <p>This function can return `ok' or `{ok, Ret}' if it wants to return some
+%% Erlang terms to the caller.</p>
+%% </li>
+%% </ol>
+%%
+%% == Available callback modules ==
+%%
+%% Khepri comes with {@link khepri_export_erlang}. This module offers to
+%% export Khepri tree nodes in a plain text file where backup items are
+%% formatted as Erlang terms.
+
+-module(khepri_import_export).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("src/khepri_cluster.hrl").
+-include("src/khepri_machine.hrl").
+
+-export([export/4,
+         import/3]).
+
+-type module_priv() :: any().
+%% Private data passed to `Module:open_write/1' or `Module:open_read/1'
+%% initially.
+%%
+%% The actual term is specific to the callback module implementation. The
+%% callback can use this term however it wants. It is returned from most
+%% callback functions and passed to the next one.
+
+-type backup_item() :: term().
+%% An opaque term passed in a list to `Module:write/2' and returned by
+%% `Module:read/1'.
+%%
+%% The callback module must not depend on the content of this term.
+
+-export_type([module_priv/0,
+              backup_item/0]).
+
+-callback open_write(ModulePriv) -> Ret when
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: {ok, ModulePriv} | {error, any()}.
+
+-callback write(ModulePriv, BackupItems) -> Ret when
+      ModulePriv :: khepri_import_export:module_priv(),
+      BackupItems :: [khepri_import_export:backup_item()],
+      Ret :: {ok, ModulePriv} | {error, any()}.
+
+-callback commit_write(ModulePriv) -> Ret when
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+
+-callback abort_write(ModulePriv) -> Ret when
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {error, any()}.
+
+-callback open_read(ModulePriv) -> Ret when
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: {ok, ModulePriv} | {error, any()}.
+
+-callback read(ModulePriv) -> Ret when
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: {ok, BackupItems, ModulePriv} | {error, any()},
+      BackupItems :: [khepri_import_export:backup_item()].
+
+-callback close_read(ModulePriv) -> Ret when
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+
+%% -------------------------------------------------------------------
+%% Export (backup).
+%% -------------------------------------------------------------------
+
+-spec export(StoreId, PathPattern, Module, ModulePriv) -> Ret when
+      StoreId :: khepri:store_id(),
+      PathPattern :: khepri_path:pattern(),
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+%% @private
+
+export(StoreId, PathPattern, Module, ModulePriv)
+  when ?IS_STORE_ID(StoreId) andalso is_atom(Module) ->
+    PathPattern1 = khepri_path:from_string(PathPattern),
+    khepri_path:ensure_is_valid(PathPattern1),
+    Query = fun(State) ->
+                    try
+                        do_export(State, PathPattern, Module, ModulePriv)
+                    catch
+                        Class:Exception:Stacktrace ->
+                            {error, {exception, Class, Exception, Stacktrace}}
+                    end
+            end,
+    Ret = khepri_machine:process_query(StoreId, Query, #{}),
+    case Ret of
+        {error, {exception, Class, Exception, Stacktrace}} ->
+            erlang:raise(Class, Exception, Stacktrace);
+        _ ->
+            Ret
+    end.
+
+-spec do_export(MachineState, PathPattern, Module, ModulePriv) -> Ret when
+      MachineState :: khepri_machine:state(),
+      PathPattern :: khepri_path:native_pattern(),
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+%% @private
+
+do_export(
+  #khepri_machine{root = Root} = State,
+  PathPattern, Module, ModulePriv) ->
+    %% Initialize export using the callback module.
+    case open_write(Module, ModulePriv) of
+        {ok, ModulePriv1} ->
+            %% Prepare the traversal.
+            Fun =
+            fun(Path, Node, ModulePriv2) ->
+                    Ret =
+                    try
+                        write(State, Path, Node, Module, ModulePriv2)
+                    catch
+                        Class:Exception:Stacktrace ->
+                            _ = catch abort_write(Module, ModulePriv2),
+                            erlang:raise(Class, Exception, Stacktrace)
+                    end,
+                    case Ret of
+                        {ok, ModulePriv3} ->
+                            {ok, keep, ModulePriv3};
+                        {error, _} = Error ->
+                            _ = abort_write(Module, ModulePriv2),
+                            Error
+                    end
+            end,
+            TreeOptions = #{expect_specific_node => false,
+                            include_root_props => true},
+            Ret1 = khepri_machine:walk_down_the_tree(
+                     Root, PathPattern, TreeOptions, #{}, Fun, ModulePriv1),
+            case Ret1 of
+                {ok, NewRoot, _, FinalModulePriv} ->
+                    ?assertEqual(Root, NewRoot),
+                    commit_write(Module, FinalModulePriv);
+                {error, _} = Error ->
+                    Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec open_write(Module, ModulePriv) -> Ret when
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: {ok, ModulePriv} | {error, any()}.
+%% @private
+
+open_write(Module, ModulePriv) ->
+    ?LOG_DEBUG(
+       "Khepri export: calling ~s:open_write/1:~n"
+       "  opaque data: ~p",
+       [Module, ModulePriv],
+       #{domain => [khepri, import_export]}),
+    case Module:open_write(ModulePriv) of
+        {ok, _} = Ret      -> Ret;
+        {error, _} = Error -> Error
+    end.
+
+-spec write(MachineState, Path, Node, Module, ModulePriv) -> Ret when
+      MachineState :: khepri_machine:state(),
+      Path :: khepri_path:native_path(),
+      Node :: khepri_machine:tree_node(),
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: {ok, ModulePriv} | {error, any()}.
+%% @private
+
+write(
+  #khepri_machine{keep_while_conds = KeepWhileConds},
+  Path, #node{payload = Payload},
+  Module, ModulePriv) ->
+    Extra = case KeepWhileConds of
+                #{Path := KeepWhile} -> #{keep_while => KeepWhile};
+                _                    -> #{}
+            end,
+    HasPayload = Payload =/= ?NO_PAYLOAD,
+    HasExtra = Extra =/= #{},
+    case HasPayload orelse HasExtra of
+        true ->
+            Command = #put{path = Path,
+                           payload = Payload,
+                           extra = Extra},
+            ?LOG_DEBUG(
+               "Khepri export: calling ~s:write/2:~n"
+               "  opaque data: ~p~n"
+               "  backup items: ~p",
+               [Module, ModulePriv, [Command]],
+               #{domain => [khepri, import_export]}),
+            case Module:write(ModulePriv, [Command]) of
+                {ok, _} = Ret      -> Ret;
+                {error, _} = Error -> Error
+            end;
+        false ->
+            {ok, ModulePriv}
+    end;
+write(_State, _Path, {interrupted, _, _}, _Module, ModulePriv) ->
+    {ok, ModulePriv}.
+
+-spec commit_write(Module, ModulePriv) -> Ret when
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+%% @private
+
+commit_write(Module, ModulePriv) ->
+    ?LOG_DEBUG(
+       "Khepri export: calling ~s:commit_write/1:~n"
+       "  opaque data: ~p",
+       [Module, ModulePriv],
+       #{domain => [khepri, import_export]}),
+    case Module:commit_write(ModulePriv) of
+        ok = Ret           -> Ret;
+        {ok, _} = Ret      -> Ret;
+        {error, _} = Error -> Error
+    end.
+
+-spec abort_write(Module, ModulePriv) -> Ret when
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {error, any()}.
+%% @private
+
+abort_write(Module, ModulePriv) ->
+    ?LOG_DEBUG(
+       "Khepri export: calling ~s:abort_write/1:~n"
+       "  opaque data: ~p",
+       [Module, ModulePriv],
+       #{domain => [khepri, import_export]}),
+    Module:abort_write(ModulePriv).
+
+%% -------------------------------------------------------------------
+%% Import (restore).
+%% -------------------------------------------------------------------
+
+-spec import(StoreId, Module, ModulePriv) -> Ret when
+      StoreId :: khepri:store_id(),
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+%% @private
+
+import(StoreId, Module, ModulePriv)
+  when ?IS_STORE_ID(StoreId) andalso is_atom(Module) ->
+    case open_read(Module, ModulePriv) of
+        {ok, ModulePriv1}  -> do_import(StoreId, Module, ModulePriv1);
+        {error, _} = Error -> Error
+    end.
+
+-spec do_import(StoreId, Module, ModulePriv) -> Ret when
+      StoreId :: khepri:store_id(),
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+%% @private
+
+do_import(StoreId, Module, ModulePriv) ->
+    Ret = try
+              read(Module, ModulePriv)
+          catch
+              Class:Exception:Stacktrace ->
+                  _ = catch close_read(Module, ModulePriv),
+                  erlang:raise(Class, Exception, Stacktrace)
+          end,
+    case Ret of
+        {ok, BackupItems, ModulePriv1} when BackupItems =/= [] ->
+            case handle_backup_items(StoreId, BackupItems) of
+                ok ->
+                    do_import(StoreId, Module, ModulePriv1);
+                {error, _} = Error ->
+                    _ = close_read(Module, ModulePriv1),
+                    Error
+            end;
+        {ok, [], ModulePriv1} ->
+            close_read(Module, ModulePriv1);
+        {error, _} = Error ->
+            _ = close_read(Module, ModulePriv),
+            Error
+    end.
+
+-spec handle_backup_items(StoreId, BackupItems) -> Ret when
+      StoreId :: khepri:store_id(),
+      BackupItems :: [khepri_import_export:backup_item()],
+      Ret :: ok | {error, any()}.
+%% @private
+
+handle_backup_items(StoreId, [Command | Rest]) ->
+    Options = #{},
+    case khepri_machine:process_command(StoreId, Command, Options) of
+        {ok, _}            -> handle_backup_items(StoreId, Rest);
+        {error, _} = Error -> Error
+    end;
+handle_backup_items(_StoreId, []) ->
+    ok.
+
+-spec open_read(Module, ModulePriv) -> Ret when
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: {ok, ModulePriv} | {error, any()}.
+%% @private
+
+open_read(Module, ModulePriv) ->
+    case Module:open_read(ModulePriv) of
+        {ok, _} = Ret      -> Ret;
+        {error, _} = Error -> Error
+    end.
+
+-spec read(Module, ModulePriv) -> Ret when
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: {ok, BackupItems, ModulePriv} | {error, any()},
+      BackupItems :: [khepri_import_export:backup_item()].
+%% @private
+
+read(Module, ModulePriv) ->
+    case Module:read(ModulePriv) of
+        {ok, BackupItems, _ModulePriv1} = Ret when is_list(BackupItems) ->
+            Ret;
+        {error, _Reason} = Error ->
+            Error
+    end.
+
+-spec close_read(Module, ModulePriv) -> Ret when
+      Module :: module(),
+      ModulePriv :: khepri_import_export:module_priv(),
+      Ret :: ok | {ok, ModulePriv} | {error, any()}.
+%% @private
+
+close_read(Module, ModulePriv) ->
+    case Module:close_read(ModulePriv) of
+        ok = Ret                 -> Ret;
+        {ok, _ModulePriv1} = Ret -> Ret;
+        {error, _Reason} = Error -> Error
+    end.

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -56,7 +56,10 @@
          count_matching_nodes/3,
          insert_or_update_node/5,
          delete_matching_nodes/3,
-         handle_tx_exception/1]).
+         handle_tx_exception/1,
+         process_query/3,
+         process_command/3,
+         walk_down_the_tree/6]).
 
 -ifdef(TEST).
 -export([are_keep_while_conditions_met/2,

--- a/test/export.erl
+++ b/test/export.erl
@@ -1,0 +1,436 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(export).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/khepri_fun.hrl").
+-include("src/khepri_machine.hrl").
+
+export_empty_store_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, []},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+export_full_store_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    Cond = #if_any{conditions =
+                   [#if_child_list_length{count = {gt, 0}},
+                    #if_has_payload{has_payload = true}]},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         {ok, [#put{path = [foo],
+                    extra = #{keep_while => #{[foo] => Cond}}},
+               #put{path = [foo, bar],
+                    payload = khepri_payload:data(bar_value)}]},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+export_standalone_function_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    Fun = fun() -> "It works!" end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [sproc], Fun)),
+      ?_assertEqual(
+         {ok, [#put{path = [sproc],
+                    payload =
+                    khepri_payload:prepare(khepri_payload:sproc(Fun))}]},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+export_function_ref_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    Fun = fun lists:last/1,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [sproc], Fun)),
+      ?_assertEqual(
+         {ok, [#put{path = [sproc],
+                    payload =
+                    khepri_payload:prepare(khepri_payload:sproc(Fun))}]},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+export_root_tree_node_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [], root_value)),
+      ?_assertEqual(
+         {ok, [#put{path = [],
+                    payload = khepri_payload:data(root_value)}]},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+export_non_existing_node_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, []},
+         khepri:export(?FUNCTION_NAME, [non_existing], Module, ModulePriv))]}.
+
+export_keep_while_conds_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    Cond1 = #if_any{conditions =
+                    [#if_child_list_length{count = {gt, 0}},
+                     #if_has_payload{has_payload = true}]},
+    Cond2 = #if_child_list_length{count = 0},
+    KeepWhile = #{[?THIS_KHEPRI_NODE] => Cond2},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [foo, bar], ?NO_PAYLOAD,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, [#put{path = [foo],
+                    extra = #{keep_while => #{[foo] => Cond1}}},
+               #put{path = [foo, bar],
+                    payload = ?NO_PAYLOAD,
+                    extra = #{keep_while => #{[foo, bar] => Cond2}}}]},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+error_to_export_during_open_write_test_() ->
+    Module = export_helper,
+    ModulePriv = error_during_open_write,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         {error, open_write},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+throw_to_export_during_open_write_test_() ->
+    Module = export_helper,
+    ModulePriv = throw_during_open_write,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertThrow(
+         open_write,
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+error_to_export_during_write_test_() ->
+    Module = export_helper,
+    ModulePriv = error_during_write,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         {error, write},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+throw_to_export_during_write_test_() ->
+    Module = export_helper,
+    ModulePriv = throw_during_write,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertThrow(
+         write,
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+error_to_export_during_commit_write_test_() ->
+    Module = export_helper,
+    ModulePriv = error_during_commit_write,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         {error, commit_write},
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+throw_to_export_during_commit_write_test_() ->
+    Module = export_helper,
+    ModulePriv = throw_during_commit_write,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertThrow(
+         commit_write,
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+throw_to_export_during_abort_write_test_() ->
+    Module = export_helper,
+    ModulePriv = throw_during_abort_write,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertThrow(
+         abort_write,
+         khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+import_empty_store_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         begin
+             {ok, ModulePriv1} = khepri:export(
+                                   ?FUNCTION_NAME, Module, ModulePriv),
+             khepri:import(?FUNCTION_NAME, Module, ModulePriv1)
+         end),
+      ?_assertEqual(
+         {ok, #{}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR]))]}.
+
+import_full_store_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => bar_value}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR])),
+      ?_assertEqual(
+         ok,
+         begin
+             {ok, ModulePriv1} = khepri:export(
+                                   ?FUNCTION_NAME, Module, ModulePriv),
+             ok = khepri:delete_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR]),
+             khepri:import(?FUNCTION_NAME, Module, ModulePriv1)
+         end),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => bar_value}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR]))]}.
+
+import_standalone_function_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    Fun = fun() -> "It works!" end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [sproc], Fun)),
+      ?_assertMatch(
+         {ok, #{[sproc] := #standalone_fun{}}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR])),
+      ?_assertEqual(
+         ok,
+         begin
+             {ok, ModulePriv1} = khepri:export(
+                                   ?FUNCTION_NAME, Module, ModulePriv),
+             ok = khepri:delete_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR]),
+             khepri:import(?FUNCTION_NAME, Module, ModulePriv1)
+         end),
+      ?_assertMatch(
+         {ok, #{[sproc] := #standalone_fun{}}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR]))]}.
+
+import_function_ref_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    Fun = fun lists:last/1,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [sproc], Fun)),
+      ?_assertMatch(
+         {ok, #{[sproc] := Fun}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR])),
+      ?_assertEqual(
+         ok,
+         begin
+             {ok, ModulePriv1} = khepri:export(
+                                   ?FUNCTION_NAME, Module, ModulePriv),
+             ok = khepri:delete_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR]),
+             khepri:import(?FUNCTION_NAME, Module, ModulePriv1)
+         end),
+      ?_assertMatch(
+         {ok, #{[sproc] := Fun}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR]))]}.
+
+import_root_tree_node_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:put(?FUNCTION_NAME, [], root_value)),
+      ?_assertMatch(
+         {ok, #{[] := root_value}},
+         khepri:get_many(
+           ?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR],
+           #{include_root_props => true})),
+      ?_assertEqual(
+         ok,
+         begin
+             {ok, ModulePriv1} = khepri:export(
+                                   ?FUNCTION_NAME, Module, ModulePriv),
+             ok = khepri:delete_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR]),
+             khepri:import(?FUNCTION_NAME, Module, ModulePriv1)
+         end),
+      ?_assertMatch(
+         {ok, #{[] := root_value}},
+         khepri:get_many(
+           ?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR],
+           #{include_root_props => true}))]}.
+
+import_keep_while_conds_test_() ->
+    Module = export_helper,
+    ModulePriv = [],
+    Cond1 = #if_any{conditions =
+                    [#if_child_list_length{count = {gt, 0}},
+                     #if_has_payload{has_payload = true}]},
+    Cond2 = #if_child_list_length{count = 0},
+    KeepWhile = #{[?THIS_KHEPRI_NODE] => Cond2},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [foo, bar], ?NO_PAYLOAD,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => undefined}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR])),
+      ?_assertEqual(
+         {ok, #{[foo] => #{[foo] => Cond1},
+                [foo, bar] => #{[foo, bar] => Cond2}}},
+         khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{})),
+      ?_assertEqual(
+         ok,
+         begin
+             {ok, ModulePriv1} = khepri:export(
+                                   ?FUNCTION_NAME, Module, ModulePriv),
+             ok = khepri:delete_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR]),
+             khepri:import(?FUNCTION_NAME, Module, ModulePriv1)
+         end),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => undefined}},
+         khepri:get_many(?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR])),
+      ?_assertEqual(
+         {ok, #{[foo] => #{[foo] => Cond1},
+                [foo, bar] => #{[foo, bar] => Cond2}}},
+         khepri_machine:get_keep_while_conds_state(?FUNCTION_NAME, #{}))]}.
+
+error_to_import_during_open_read_test_() ->
+    Module = export_helper,
+    ModulePriv = error_during_open_read,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {error, open_read},
+         khepri:import(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+throw_to_import_during_open_read_test_() ->
+    Module = export_helper,
+    ModulePriv = throw_during_open_read,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertThrow(
+         open_read,
+         khepri:import(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+error_to_import_during_read_test_() ->
+    Module = export_helper,
+    ModulePriv = error_during_read,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {error, read},
+         khepri:import(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+throw_to_import_during_read_test_() ->
+    Module = export_helper,
+    ModulePriv = throw_during_read,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertThrow(
+         read,
+         khepri:import(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+error_to_import_during_close_read_test_() ->
+    Module = export_helper,
+    ModulePriv = error_during_close_read,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {error, close_read},
+         khepri:import(?FUNCTION_NAME, Module, ModulePriv))]}.
+
+throw_to_import_during_close_read_test_() ->
+    Module = export_helper,
+    ModulePriv = throw_during_close_read,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertThrow(
+         close_read,
+         khepri:import(?FUNCTION_NAME, Module, ModulePriv))]}.

--- a/test/export_erlang.erl
+++ b/test/export_erlang.erl
@@ -1,0 +1,247 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(export_erlang).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/khepri_fun.hrl").
+-include("src/khepri_machine.hrl").
+
+-define(
+   FILENAME,
+   lists:flatten(io_lib:format("test-export-~s.erl", [?FUNCTION_NAME]))).
+
+export_import_empty_store_to_file_test_() ->
+    Module = khepri_export_erlang,
+    Filename = ?FILENAME,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual({ok, []}, file:consult(Filename)),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**"))]}.
+
+export_import_full_store_to_file_test_() ->
+    Module = khepri_export_erlang,
+    Filename = ?FILENAME,
+    Cond = #if_any{conditions =
+                   [#if_child_list_length{count = {gt, 0}},
+                    #if_has_payload{has_payload = true}]},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar, baz], baz_value)),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => bar_value,
+                [foo, bar, baz] => baz_value}},
+         khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual(
+         {ok, [#put{path = [foo],
+                    extra = #{keep_while => #{[foo] => Cond}}},
+               #put{path = [foo, bar],
+                    payload = khepri_payload:data(bar_value)},
+               #put{path = [foo, bar, baz],
+                    payload = khepri_payload:data(baz_value)}]},
+         file:consult(Filename)),
+
+      ?_assertEqual(ok, khepri:delete_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => bar_value,
+                [foo, bar, baz] => baz_value}},
+         khepri:get_many(?FUNCTION_NAME, "**"))]}.
+
+fail_to_open_file_test_() ->
+    Module = khepri_export_erlang,
+    Filename = "/",
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv)
+     end,
+     [?_assertEqual(
+         {error, eisdir},
+         khepri:export(?FUNCTION_NAME, Module, Filename))]}.
+
+fail_to_write_test_() ->
+    Module = khepri_export_erlang,
+    Filename = ?FILENAME,
+    {ok, Fd1} = file:open(Filename, [write]),
+    ok = file:close(Fd1),
+    {ok, Fd2} = file:open(Filename, [read]),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:close(Fd2),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar, baz], baz_value)),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => bar_value,
+                [foo, bar, baz] => baz_value}},
+         khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertMatch(
+         {error, _},
+         khepri:export(?FUNCTION_NAME, Module, Fd2))]}.
+
+export_import_empty_store_to_fd_test_() ->
+    Module = khepri_export_erlang,
+    Filename = ?FILENAME,
+    {ok, Fd} = file:open(Filename, [read, write]),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:close(Fd),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Fd)),
+      ?_assertEqual({ok, []}, file:consult(Filename)),
+
+      ?_assertEqual({ok, 0}, file:position(Fd, 0)),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Fd)),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**"))]}.
+
+export_import_full_store_to_fd_test_() ->
+    Module = khepri_export_erlang,
+    Filename = ?FILENAME,
+    {ok, Fd} = file:open(Filename, [read, write]),
+    Cond = #if_any{conditions =
+                   [#if_child_list_length{count = {gt, 0}},
+                    #if_has_payload{has_payload = true}]},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:close(Fd),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar, baz], baz_value)),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => bar_value,
+                [foo, bar, baz] => baz_value}},
+         khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Fd)),
+      ?_assertEqual(
+         {ok, [#put{path = [foo],
+                    extra = #{keep_while => #{[foo] => Cond}}},
+               #put{path = [foo, bar],
+                    payload = khepri_payload:data(bar_value)},
+               #put{path = [foo, bar, baz],
+                    payload = khepri_payload:data(baz_value)}]},
+         file:consult(Filename)),
+
+      ?_assertEqual(ok, khepri:delete_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+
+      ?_assertEqual({ok, 0}, file:position(Fd, 0)),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Fd)),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined,
+                [foo, bar] => bar_value,
+                [foo, bar, baz] => baz_value}},
+         khepri:get_many(?FUNCTION_NAME, "**"))]}.
+
+export_import_standalone_function_test_() ->
+    Module = khepri_export_erlang,
+    Filename = ?FILENAME,
+    Fun = fun() -> "It works!" end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual(ok, khepri:create(?FUNCTION_NAME, [sproc], Fun)),
+      ?_assertMatch(
+         {ok, #{[sproc] := #standalone_fun{}}},
+         khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual(
+         {ok, [#put{path = [sproc],
+                    payload =
+                    khepri_payload:prepare(khepri_payload:sproc(Fun))}]},
+         file:consult(Filename)),
+
+      ?_assertEqual(ok, khepri:delete_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Filename)),
+      ?_assertMatch(
+         {ok, #{[sproc] := #standalone_fun{}}},
+         khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(Fun(), khepri:run_sproc(?FUNCTION_NAME, [sproc], []))]}.
+
+export_import_function_ref_test_() ->
+    Module = khepri_export_erlang,
+    Filename = ?FILENAME,
+    Fun = fun lists:last/1,
+    List = [a, b],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual(ok, khepri:create(?FUNCTION_NAME, [sproc], Fun)),
+      ?_assertMatch(
+         {ok, #{[sproc] := Fun}},
+         khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual(
+         {ok, [#put{path = [sproc],
+                    payload =
+                    khepri_payload:prepare(khepri_payload:sproc(Fun))}]},
+         file:consult(Filename)),
+
+      ?_assertEqual(ok, khepri:delete_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Filename)),
+      ?_assertMatch(
+         {ok, #{[sproc] := Fun}},
+         khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(
+         Fun(List),
+         khepri:run_sproc(?FUNCTION_NAME, [sproc], [List]))]}.

--- a/test/export_helper.erl
+++ b/test/export_helper.erl
@@ -1,0 +1,104 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(export_helper).
+
+-export([open_write/1,
+         write/2,
+         commit_write/1,
+         abort_write/1,
+
+         open_read/1,
+         read/1,
+         close_read/1]).
+
+open_write(ModulePriv) when is_list(ModulePriv) ->
+    {ok, ModulePriv};
+open_write(error_during_open_write) ->
+    {error, ?FUNCTION_NAME};
+open_write(throw_during_open_write) ->
+    throw(?FUNCTION_NAME);
+open_write(error_during_write = ModulePriv) ->
+    {ok, ModulePriv};
+open_write(throw_during_write = ModulePriv) ->
+    {ok, ModulePriv};
+open_write(error_during_commit_write = ModulePriv) ->
+    {ok, ModulePriv};
+open_write(throw_during_commit_write = ModulePriv) ->
+    {ok, ModulePriv};
+open_write(throw_during_abort_write = ModulePriv) ->
+    {ok, ModulePriv}.
+
+write(ModulePriv, BackupItems)
+  when is_list(ModulePriv) andalso is_list(BackupItems) ->
+    ModulePriv1 = ModulePriv ++ BackupItems,
+    {ok, ModulePriv1};
+write(error_during_write, _BackupItems) ->
+    {error, ?FUNCTION_NAME};
+write(throw_during_write, _BackupItems) ->
+    throw(?FUNCTION_NAME);
+write(error_during_commit_write = ModulePriv, _BackupItems) ->
+    {ok, ModulePriv};
+write(throw_during_commit_write = ModulePriv, _BackupItems) ->
+    {ok, ModulePriv};
+write(throw_during_abort_write, _BackupItems) ->
+    {error, ?FUNCTION_NAME}.
+
+commit_write(ModulePriv) when is_list(ModulePriv) ->
+    {ok, ModulePriv};
+commit_write(error_during_commit_write) ->
+    {error, ?FUNCTION_NAME};
+commit_write(throw_during_commit_write) ->
+    throw(?FUNCTION_NAME).
+
+abort_write(ModulePriv) when is_list(ModulePriv) ->
+    ok;
+abort_write(error_during_write) ->
+    ok;
+abort_write(throw_during_write) ->
+    ok;
+abort_write(throw_during_abort_write) ->
+    throw(?FUNCTION_NAME).
+
+open_read(ModulePriv) when is_list(ModulePriv) ->
+    {ok, ModulePriv};
+open_read(error_during_open_read) ->
+    {error, ?FUNCTION_NAME};
+open_read(throw_during_open_read) ->
+    throw(?FUNCTION_NAME);
+open_read(error_during_read = ModulePriv) ->
+    {ok, ModulePriv};
+open_read(throw_during_read = ModulePriv) ->
+    {ok, ModulePriv};
+open_read(error_during_close_read = ModulePriv) ->
+    {ok, ModulePriv};
+open_read(throw_during_close_read = ModulePriv) ->
+    {ok, ModulePriv}.
+
+read([BackupItem | Rest]) ->
+    {ok, [BackupItem], Rest};
+read([]) ->
+    {ok, [], []};
+read(error_during_read) ->
+    {error, ?FUNCTION_NAME};
+read(throw_during_read) ->
+    throw(?FUNCTION_NAME);
+read(error_during_close_read = ModulePriv) ->
+    {ok, [], ModulePriv};
+read(throw_during_close_read = ModulePriv) ->
+    {ok, [], ModulePriv}.
+
+close_read(ModulePriv) when is_list(ModulePriv) ->
+    ok;
+close_read(error_during_read) ->
+    ok;
+close_read(throw_during_read) ->
+    ok;
+close_read(error_during_close_read) ->
+    {error, ?FUNCTION_NAME};
+close_read(throw_during_close_read) ->
+    throw(?FUNCTION_NAME).


### PR DESCRIPTION
With this patch, it is possible to export and import a Khepri store.

`khepri:export/{2,3,4}` uses a callback module and private data to export the content of the store. It is possible to specify a path pattern to filter what should be exported.

`khepri:import/{2,3}` uses a callback module and private data — of course the same used for export — to import what was previously exported. This function doesn't remove existing tree nodes. It is up to the caller to take care of this. There is no support for filtering on import.

The callback module API is the same as [Mnesia's "Backup and restore" API](https://www.erlang.org/doc/apps/mnesia/mnesia_app_a). The callback module itself doesn't know what is inside the list of "backup items" passed to it, it's completely opaque.

The implementation uses `khepri_machine` state machine commands as the export format: each tree node matching the export path pattern is converted to a `put` command. Tree nodes which don't have any payload or "keep while" conditions are skipped (i.e. not exported).

During import, the commands are processed one by one. In a future patch, we could process them in batches to speed things up.

Fixes #153.