### PR TITLE
khepri_machine: Fix handling of `khepri:delete_many("**")`

### DIFF
--- a/test/simple_delete.erl
+++ b/test/simple_delete.erl
@@ -90,6 +90,42 @@ delete_many_on_existing_node_with_condition_false_test_() ->
          {ok, foo_value},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
+delete_many_recursively_1_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar, baz], baz_value)),
+      ?_assertEqual(
+         ok,
+         khepri:delete_many(
+           ?FUNCTION_NAME, [#if_path_matches{regex = any}])),
+      ?_assertEqual(
+         {ok, #{}},
+         khepri:get_many(?FUNCTION_NAME, [#if_path_matches{regex = any}]))]}.
+
+delete_many_recursively_2_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar, baz], baz_value)),
+      ?_assertEqual(
+         ok,
+         khepri:delete_many(
+           ?FUNCTION_NAME, [foo, #if_path_matches{regex = any}])),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined}},
+         khepri:get_many(?FUNCTION_NAME, [#if_path_matches{regex = any}]))]}.
+
 delete_payload_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,

--- a/test/simple_tx_delete.erl
+++ b/test/simple_tx_delete.erl
@@ -137,6 +137,52 @@ delete_many_on_existing_node_with_condition_false_test_() ->
          {ok, foo_value},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
+delete_many_recursively_1_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar, baz], baz_value)),
+      ?_assertEqual(
+         {ok, ok},
+         begin
+             Fun = fun() ->
+                           khepri_tx:delete_many(
+                             [#if_path_matches{regex = any}])
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end),
+      ?_assertEqual(
+         {ok, #{}},
+         khepri:get_many(?FUNCTION_NAME, [#if_path_matches{regex = any}]))]}.
+
+delete_many_recursively_2_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo, bar, baz], baz_value)),
+      ?_assertEqual(
+         {ok, ok},
+         begin
+             Fun = fun() ->
+                           khepri_tx:delete_many(
+                             [foo, #if_path_matches{regex = any}])
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end),
+      ?_assertEqual(
+         {ok, #{[foo] => undefined}},
+         khepri:get_many(?FUNCTION_NAME, [#if_path_matches{regex = any}]))]}.
+
 delete_payload_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,


### PR DESCRIPTION
Before this fix, `handle_branch()` would correctly handle a condition (such as `#if_path_matches{}`) which applied to the current tree node and its child nodes. The given `Fun()` would be called correctly for each child node, unlike what a stalled comment said (it is removed in this commit as well).

However, if `Fun()` deleted a child, `handle_branch()` still recursed for this child node, effectively adding it back to the tree if it had child nodes itself.

This bug fix verifies after handling the current child that it is still present before it recurses to handle its own child nodes.

Now, calling `khepri:delete_many("**")` will correctly remove all tree nodes, not just leaf nodes.