### PR TITLE
Implement ra_machine:overview/1 for khepri_machine

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -64,6 +64,7 @@
 
 -export([to_standalone_fun/1,
          to_standalone_fun/2,
+         to_fun/1,
          exec/2]).
 
 -ifdef(TEST).
@@ -936,6 +937,17 @@ load_standalone_fun(#standalone_fun{module = Module, beam = Beam}) ->
     end;
 load_standalone_fun(Fun) when is_function(Fun) ->
     ok.
+
+-spec to_fun(StandaloneFun) -> Fun when
+      StandaloneFun :: standalone_fun(),
+      Fun :: fun().
+%% @private
+
+to_fun(#standalone_fun{module = Module, arity = Arity} = StandaloneFun) ->
+    load_standalone_fun(StandaloneFun),
+    erlang:make_fun(Module, run, Arity);
+to_fun(Fun) when is_function(Fun) ->
+    Fun.
 
 %% -------------------------------------------------------------------
 %% Code processing [Pass 1]


### PR DESCRIPTION
The overview callback formats the state of the machine for functions like `sys:get_status/1`. The actual state of the machine is still accessible with `sys:get_state/1`.

The status output was not very readable because of the beam code binaries in `standalone_fun` records and the use of records for nodes in the internal representation of the tree. This `overview/1` implementation uses the map representation of the tree from `khepri_utils:flat_struct_to_tree/1` and converts compiled standalone functions into regular functions with `erlang:make_fun/3` (which are printed with a more concise and readable format).