### PR TITLE
Fix `call_fun2` instruction jump label support

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1158,15 +1158,16 @@ pass1_process_instructions(
     pass1_process_instructions([Instruction | Rest], State, Result);
 pass1_process_instructions(
   [{call_fun2,
-    {atom, safe},
+    {atom, SafeOrNot},
     Arity,
     {tr, FunReg, {{t_fun, _Arity, _Domain, _Range} = Type, _, _}}} | Rest],
   State,
-  Result) ->
+  Result)
+  when SafeOrNot =:= safe orelse SafeOrNot =:= unsafe ->
     %% `beam_disasm' did not decode this instruction correctly. The
     %% type in the type-tagged record is wrapped with extra information
     %% we discard.
-    Instruction = {call_fun2, {atom, safe}, Arity, {tr, FunReg, Type}},
+    Instruction = {call_fun2, {atom, SafeOrNot}, Arity, {tr, FunReg, Type}},
     pass1_process_instructions([Instruction | Rest], State, Result);
 pass1_process_instructions(
   [{call_fun2,

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -572,6 +572,8 @@ ensure_instruction_is_permitted({call_fun, _}) ->
     ok;
 ensure_instruction_is_permitted({call_fun2, {atom, safe}, _, _}) ->
     ok;
+ensure_instruction_is_permitted({call_fun2, {atom, unsafe}, _, _}) ->
+    ok;
 ensure_instruction_is_permitted({call_fun2, {f, _}, _, _}) ->
     ok;
 ensure_instruction_is_permitted({case_end, _}) ->

--- a/test/mod_used_for_transactions.erl
+++ b/test/mod_used_for_transactions.erl
@@ -7,6 +7,10 @@
 
 -module(mod_used_for_transactions).
 
+-include_lib("stdlib/include/assert.hrl").
+
+-include("src/khepri_fun.hrl").
+
 -export([exported/0,
          get_lambda/0,
          %% We export this one just to try to prevent inlining.
@@ -14,7 +18,8 @@
          crashing_fun/0,
          make_record/1,
          outer_function/2,
-         min/2]).
+         min/2,
+         call_inner_function/2]).
 
 exported() -> unexported().
 unexported() -> ok.
@@ -49,3 +54,6 @@ inner_function(_, _) ->
 
 min(A, B) ->
     erlang:min(A, B).
+
+call_inner_function(InnerFun, Options) when is_map(Options) ->
+    InnerFun(Options).

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -16,7 +16,10 @@
 
 -dialyzer([{no_return, [allowed_khepri_tx_api_test/0,
                         allowed_erlang_module_api_test/0,
-                        allowed_bs_match_accepts_match_context_test/0]},
+                        allowed_bs_match_accepts_match_context_test/0,
+                        call_fun2_instruction_with_atom_unsafe_test/0,
+                        call_outer_function_external/3]},
+           {no_fail_call, [call_outer_function_external/3]},
            {no_missing_calls,
             [extracting_unexported_external_function_test/0]},
            {no_match,
@@ -536,6 +539,29 @@ allowed_multiple_nested_higher_order_functions_test() ->
     Ret2 = Ret1(Sets, path, change),
     ?assertEqual([{change, {path, a}}, {change, {path, b}}], Ret2).
 
+call_fun2_instruction_with_atom_unsafe_test() ->
+    OuterFun = fun(Ret) -> {outer, Ret} end,
+    InnerFun = fun inner_function/1,
+
+    StandaloneFun = ?make_standalone_fun(
+                        begin
+                            R = call_outer_function_external(
+                                  OuterFun, InnerFun, #{}),
+                            {ok, R}
+                        end),
+    ?assertMatch(#standalone_fun{}, StandaloneFun),
+    ?assertError(
+       {badarity, {_, [#{}]}},
+       khepri_fun:exec(StandaloneFun, [])).
+
+-spec call_outer_function_external(fun(), fun(), map()) -> no_return().
+
+call_outer_function_external(OuterFun, InnerFun, Options) ->
+    OuterFun(
+      mod_used_for_transactions:call_inner_function(
+        fun() -> InnerFun() end,
+        Options)).
+
 call_fun2_instruction_with_jump_label_test() ->
     OuterFun = fun(Ret) -> {outer, Ret} end,
     InnerInnerFun = fun inner_function/1,
@@ -556,9 +582,6 @@ call_fun2_instruction_with_jump_label_test() ->
     Ret = khepri_fun:exec(StandaloneFun, []),
     ?assertEqual({ok, {outer, inner}}, Ret).
 
-inner_function(_) ->
-    inner.
-
 call_outer_function_local(OuterFun, InnerFun, Options) ->
     OuterFun(
       call_inner_function(
@@ -567,6 +590,9 @@ call_outer_function_local(OuterFun, InnerFun, Options) ->
 
 call_inner_function(InnerFun, Options) when is_map(Options) ->
     InnerFun().
+
+inner_function(_) ->
+    inner.
 
 reverse(List) ->
     reverse(List, []).


### PR DESCRIPTION
Since #149, we resolve and adjust the jump label inside the `call_fun2` instruction. This way we are as close as possible to the code originally produced by the compiler and benefit from its optimizations.

However, there is one situation where we can't keep the jump label: it is when the called local function is not local anymore after extraction.

To avoid many almost identical copies of the same anonymous function where only the environment changes, `khepri_fun` will extract the function in a dedicated module and keep the environment separate. If there is another anonymous function inside this environment, it will become its own module.

Therefore, it's possible that in the original Beam code, the two anonymous functions were inside the same module. If the compiler emitted a `call_fun2` instruction, it could use a jump label in the outer function to call the inner function passed in the environment.

After extraction by `khepri_fun`, this is no longer possible because the inner function will be in another module. `call_fun2` must use the `{atom, safe}` argument instead.

While here, add support for the `{atom, unsafe}` argument as well because I found a testcase for it while searching for the testcase for the jump label version.