### PR TITLE
GitHub Actions: Update actions/checkout and actions/cache to v3

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 25

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Publish release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Publish to Hex.pm
         uses: erlangpack/github-action@v3
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
       RUN_DIALYZER_ON_OTP_RELEASE: 25
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         id: install-erlang
         with:
@@ -30,7 +30,7 @@ jobs:
           rebar3-version: '3.18.0'
 
       - name: Restore Dialyzer PLT files from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         if: ${{ matrix.otp_version == env.RUN_DIALYZER_ON_OTP_RELEASE && matrix.os == 'ubuntu-latest' }}
         with:
           path: _build/*/rebar3_*_plt


### PR DESCRIPTION
This follows a warning reported by GitHub Actions:

    Node.js 12 actions are deprecated. For more information see:
    https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
    Please update the following actions to use Node.js 16:
    actions/checkout, actions/cache