### PR TITLE
Rename `delete_payload()` back to `clear_payload()`

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -105,9 +105,9 @@
 
          delete/1, delete/2, delete/3,
          delete_many/1, delete_many/2, delete_many/3,
-         delete_payload/1, delete_payload/2, delete_payload/3,
-         delete_many_payloads/1, delete_many_payloads/2,
-         delete_many_payloads/3,
+         clear_payload/1, clear_payload/2, clear_payload/3,
+         clear_many_payloads/1, clear_many_payloads/2,
+         clear_many_payloads/3,
 
          register_trigger/3, register_trigger/4, register_trigger/5,
 
@@ -134,9 +134,9 @@
          'compare_and_swap!'/3, 'compare_and_swap!'/4, 'compare_and_swap!'/5,
          'delete!'/1, 'delete!'/2, 'delete!'/3,
          'delete_many!'/1, 'delete_many!'/2, 'delete_many!'/3,
-         'delete_payload!'/1, 'delete_payload!'/2, 'delete_payload!'/3,
-         'delete_many_payloads!'/1, 'delete_many_payloads!'/2,
-         'delete_many_payloads!'/3,
+         'clear_payload!'/1, 'clear_payload!'/2, 'clear_payload!'/3,
+         'clear_many_payloads!'/1, 'clear_many_payloads!'/2,
+         'clear_many_payloads!'/3,
 
          export/2, export/3, export/4,
          import/2, import/3,
@@ -1994,42 +1994,42 @@ delete_many(StoreId, PathPattern, Options) ->
     ?result_ret_to_minimal_ret(Ret).
 
 %% -------------------------------------------------------------------
-%% delete_payload().
+%% clear_payload().
 %% -------------------------------------------------------------------
 
--spec delete_payload(PathPattern) -> Ret when
+-spec clear_payload(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% Calling this function is the same as calling `delete_payload(StoreId,
+%% Calling this function is the same as calling `clear_payload(StoreId,
 %% PathPattern)' with the default store ID (see {@link
 %% khepri_cluster:get_default_store_id/0}).
 %%
-%% @see delete_payload/2.
-%% @see delete_payload/3.
+%% @see clear_payload/2.
+%% @see clear_payload/3.
 
-delete_payload(PathPattern) ->
+clear_payload(PathPattern) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    delete_payload(StoreId, PathPattern).
+    clear_payload(StoreId, PathPattern).
 
--spec delete_payload(StoreId, PathPattern) -> Ret when
+-spec clear_payload(StoreId, PathPattern) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% Calling this function is the same as calling `delete_payload(StoreId,
+%% Calling this function is the same as calling `clear_payload(StoreId,
 %% PathPattern, #{})'.
 %%
-%% @see delete_payload/3.
+%% @see clear_payload/3.
 
-delete_payload(StoreId, PathPattern) ->
-    delete_payload(StoreId, PathPattern, #{}).
+clear_payload(StoreId, PathPattern) ->
+    clear_payload(StoreId, PathPattern, #{}).
 
--spec delete_payload(StoreId, PathPattern, Options) -> Ret when
+-spec clear_payload(StoreId, PathPattern, Options) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:command_options() |
@@ -2051,48 +2051,48 @@ delete_payload(StoreId, PathPattern) ->
 %% value may be sent by a message if a correlation ID was specified).
 %%
 %% @see put/4.
-%% @see khepri_adv:delete_payload/3.
+%% @see khepri_adv:clear_payload/3.
 
-delete_payload(StoreId, PathPattern, Options) ->
+clear_payload(StoreId, PathPattern, Options) ->
     Options1 = Options#{props_to_return => []},
-    Ret = khepri_adv:delete_payload(StoreId, PathPattern, Options1),
+    Ret = khepri_adv:clear_payload(StoreId, PathPattern, Options1),
     ?result_ret_to_minimal_ret(Ret).
 
 %% -------------------------------------------------------------------
-%% delete_many_payloads().
+%% clear_many_payloads().
 %% -------------------------------------------------------------------
 
--spec delete_many_payloads(PathPattern) -> Ret when
+-spec clear_many_payloads(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% Calling this function is the same as calling `delete_many_payloads(StoreId,
+%% Calling this function is the same as calling `clear_many_payloads(StoreId,
 %% PathPattern)' with the default store ID (see {@link
 %% khepri_cluster:get_default_store_id/0}).
 %%
-%% @see delete_many_payloads/2.
-%% @see delete_many_payloads/3.
+%% @see clear_many_payloads/2.
+%% @see clear_many_payloads/3.
 
-delete_many_payloads(PathPattern) ->
+clear_many_payloads(PathPattern) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    delete_many_payloads(StoreId, PathPattern).
+    clear_many_payloads(StoreId, PathPattern).
 
--spec delete_many_payloads(StoreId, PathPattern) -> Ret when
+-spec clear_many_payloads(StoreId, PathPattern) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% Calling this function is the same as calling `delete_many_payloads(StoreId,
+%% Calling this function is the same as calling `clear_many_payloads(StoreId,
 %% PathPattern, #{})'.
 %%
-%% @see delete_many_payloads/3.
+%% @see clear_many_payloads/3.
 
-delete_many_payloads(StoreId, PathPattern) ->
-    delete_many_payloads(StoreId, PathPattern, #{}).
+clear_many_payloads(StoreId, PathPattern) ->
+    clear_many_payloads(StoreId, PathPattern, #{}).
 
--spec delete_many_payloads(StoreId, PathPattern, Options) ->
+-spec clear_many_payloads(StoreId, PathPattern, Options) ->
     Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
@@ -2115,11 +2115,11 @@ delete_many_payloads(StoreId, PathPattern) ->
 %%
 %% @see delete_many/3.
 %% @see put/4.
-%% @see khepri_adv:delete_many_payloads/3.
+%% @see khepri_adv:clear_many_payloads/3.
 
-delete_many_payloads(StoreId, PathPattern, Options) ->
+clear_many_payloads(StoreId, PathPattern, Options) ->
     Options1 = Options#{props_to_return => []},
-    Ret = khepri_adv:delete_many_payloads(
+    Ret = khepri_adv:clear_many_payloads(
             StoreId, PathPattern, Options1),
     ?result_ret_to_minimal_ret(Ret).
 

--- a/src/khepri_adv.erl
+++ b/src/khepri_adv.erl
@@ -40,9 +40,9 @@
 
          delete/1, delete/2, delete/3,
          delete_many/1, delete_many/2, delete_many/3,
-         delete_payload/1, delete_payload/2, delete_payload/3,
-         delete_many_payloads/1, delete_many_payloads/2,
-         delete_many_payloads/3]).
+         clear_payload/1, clear_payload/2, clear_payload/3,
+         clear_many_payloads/1, clear_many_payloads/2,
+         clear_many_payloads/3]).
 
 -type node_props_map() :: #{khepri_path:native_path() => khepri:node_props()}.
 %% Structure used to return a map of nodes and their associated properties,
@@ -978,42 +978,42 @@ delete_many(StoreId, PathPattern, Options) ->
     khepri_machine:delete(StoreId, PathPattern, Options).
 
 %% -------------------------------------------------------------------
-%% delete_payload().
+%% clear_payload().
 %% -------------------------------------------------------------------
 
--spec delete_payload(PathPattern) -> Ret when
+-spec clear_payload(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri_adv:single_result().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% Calling this function is the same as calling `delete_payload(StoreId,
+%% Calling this function is the same as calling `clear_payload(StoreId,
 %% PathPattern)' with the default store ID (see {@link
 %% khepri_cluster:get_default_store_id/0}).
 %%
-%% @see delete_payload/2.
-%% @see delete_payload/3.
+%% @see clear_payload/2.
+%% @see clear_payload/3.
 
-delete_payload(PathPattern) ->
+clear_payload(PathPattern) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    delete_payload(StoreId, PathPattern).
+    clear_payload(StoreId, PathPattern).
 
--spec delete_payload(StoreId, PathPattern) -> Ret when
+-spec clear_payload(StoreId, PathPattern) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri_adv:single_result().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% Calling this function is the same as calling `delete_payload(StoreId,
+%% Calling this function is the same as calling `clear_payload(StoreId,
 %% PathPattern, #{})'.
 %%
-%% @see delete_payload/3.
+%% @see clear_payload/3.
 
-delete_payload(StoreId, PathPattern) ->
-    delete_payload(StoreId, PathPattern, #{}).
+clear_payload(StoreId, PathPattern) ->
+    clear_payload(StoreId, PathPattern, #{}).
 
--spec delete_payload(StoreId, PathPattern, Options) -> Ret when
+-spec clear_payload(StoreId, PathPattern, Options) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:command_options() |
@@ -1037,9 +1037,9 @@ delete_payload(StoreId, PathPattern) ->
 %% was specified).
 %%
 %% @see update/4.
-%% @see khepri:delete_payload/3.
+%% @see khepri:clear_payload/3.
 
-delete_payload(StoreId, PathPattern, Options) ->
+clear_payload(StoreId, PathPattern, Options) ->
     Ret = update(StoreId, PathPattern, khepri_payload:none(), Options),
     case Ret of
         {error, ?khepri_error(node_not_found, _)} -> {ok, #{}};
@@ -1047,40 +1047,40 @@ delete_payload(StoreId, PathPattern, Options) ->
     end.
 
 %% -------------------------------------------------------------------
-%% delete_many_payloads().
+%% clear_many_payloads().
 %% -------------------------------------------------------------------
 
--spec delete_many_payloads(PathPattern) -> Ret when
+-spec clear_many_payloads(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri_adv:many_results().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% Calling this function is the same as calling `delete_many_payloads(StoreId,
+%% Calling this function is the same as calling `clear_many_payloads(StoreId,
 %% PathPattern)' with the default store ID (see {@link
 %% khepri_cluster:get_default_store_id/0}).
 %%
-%% @see delete_many_payloads/2.
-%% @see delete_many_payloads/3.
+%% @see clear_many_payloads/2.
+%% @see clear_many_payloads/3.
 
-delete_many_payloads(PathPattern) ->
+clear_many_payloads(PathPattern) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    delete_many_payloads(StoreId, PathPattern).
+    clear_many_payloads(StoreId, PathPattern).
 
--spec delete_many_payloads(StoreId, PathPattern) -> Ret when
+-spec clear_many_payloads(StoreId, PathPattern) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri_adv:many_results().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% Calling this function is the same as calling `delete_many_payloads(StoreId,
+%% Calling this function is the same as calling `clear_many_payloads(StoreId,
 %% PathPattern, #{})'.
 %%
-%% @see delete_many_payloads/3.
+%% @see clear_many_payloads/3.
 
-delete_many_payloads(StoreId, PathPattern) ->
-    delete_many_payloads(StoreId, PathPattern, #{}).
+clear_many_payloads(StoreId, PathPattern) ->
+    clear_many_payloads(StoreId, PathPattern, #{}).
 
--spec delete_many_payloads(StoreId, PathPattern, Options) ->
+-spec clear_many_payloads(StoreId, PathPattern, Options) ->
     Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
@@ -1105,9 +1105,9 @@ delete_many_payloads(StoreId, PathPattern) ->
 %%
 %% @see delete_many/3.
 %% @see put/4.
-%% @see khepri:delete_many_payloads/3.
+%% @see khepri:clear_many_payloads/3.
 
-delete_many_payloads(StoreId, PathPattern, Options) ->
+clear_many_payloads(StoreId, PathPattern, Options) ->
     PathPattern1 = khepri_path:from_string(PathPattern),
     PathPattern2 = khepri_path:combine_with_conditions(
                      PathPattern1, [#if_node_exists{exists = true}]),

--- a/src/khepri_bang.hrl
+++ b/src/khepri_bang.hrl
@@ -931,43 +931,43 @@
     unwrap_result(Ret).
 
 %% -------------------------------------------------------------------
-%% delete_payload().
+%% clear_payload().
 %% -------------------------------------------------------------------
 
--spec 'delete_payload!'(PathPattern) -> Payload when
+-spec 'clear_payload!'(PathPattern) -> Payload when
       PathPattern :: khepri_path:pattern(),
       Payload :: khepri:unwrapped_minimal_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% Calling this function is the same as calling {@link delete_payload/1} but
+%% Calling this function is the same as calling {@link clear_payload/1} but
 %% the result is unwrapped (from the `{ok, Result}' tuple) and returned
 %% directly. If there is an error, an exception is thrown.
 %%
-%% @see delete_payload/1.
+%% @see clear_payload/1.
 
-'delete_payload!'(PathPattern) ->
-    Ret = delete_payload(PathPattern),
+'clear_payload!'(PathPattern) ->
+    Ret = clear_payload(PathPattern),
     unwrap_result(Ret).
 
--spec 'delete_payload!'(StoreId, PathPattern) -> Payload when
+-spec 'clear_payload!'(StoreId, PathPattern) -> Payload when
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Payload :: khepri:unwrapped_minimal_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% Calling this function is the same as calling {@link delete_payload/2} but
+%% Calling this function is the same as calling {@link clear_payload/2} but
 %% the result is unwrapped (from the `{ok, Result}' tuple) and returned
 %% directly. If there is an error, an exception is thrown.
 %%
-%% @see delete_payload/2.
+%% @see clear_payload/2.
 
-'delete_payload!'(StoreId, PathPattern) ->
-    Ret = delete_payload(StoreId, PathPattern),
+'clear_payload!'(StoreId, PathPattern) ->
+    Ret = clear_payload(StoreId, PathPattern),
     unwrap_result(Ret).
 
--spec 'delete_payload!'(StoreId, PathPattern, Options) -> Ret when
+-spec 'clear_payload!'(StoreId, PathPattern, Options) -> Ret when
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:command_options() |
@@ -978,52 +978,52 @@
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% Calling this function is the same as calling {@link delete_payload/3} but
+%% Calling this function is the same as calling {@link clear_payload/3} but
 %% the result is unwrapped (from the `{ok, Result}' tuple) and returned
 %% directly. If there is an error, an exception is thrown.
 %%
-%% @see delete_payload/3.
+%% @see clear_payload/3.
 
-'delete_payload!'(StoreId, PathPattern, Options) ->
-    Ret = delete_payload(StoreId, PathPattern, Options),
+'clear_payload!'(StoreId, PathPattern, Options) ->
+    Ret = clear_payload(StoreId, PathPattern, Options),
     unwrap_result(Ret).
 
 %% -------------------------------------------------------------------
-%% delete_many_payloads().
+%% clear_many_payloads().
 %% -------------------------------------------------------------------
 
--spec 'delete_many_payloads!'(PathPattern) -> Payload when
+-spec 'clear_many_payloads!'(PathPattern) -> Payload when
       PathPattern :: khepri_path:pattern(),
       Payload :: khepri:unwrapped_minimal_ret().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% Calling this function is the same as calling {@link delete_many_payloads/1}
+%% Calling this function is the same as calling {@link clear_many_payloads/1}
 %% but the result is unwrapped (from the `{ok, Result}' tuple) and returned
 %% directly. If there is an error, an exception is thrown.
 %%
-%% @see delete_many_payloads/1.
+%% @see clear_many_payloads/1.
 
-'delete_many_payloads!'(PathPattern) ->
-    Ret = delete_many_payloads(PathPattern),
+'clear_many_payloads!'(PathPattern) ->
+    Ret = clear_many_payloads(PathPattern),
     unwrap_result(Ret).
 
--spec 'delete_many_payloads!'(StoreId, PathPattern) -> Payload when
+-spec 'clear_many_payloads!'(StoreId, PathPattern) -> Payload when
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Payload :: khepri:unwrapped_minimal_ret().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% Calling this function is the same as calling {@link delete_many_payloads/2}
+%% Calling this function is the same as calling {@link clear_many_payloads/2}
 %% but the result is unwrapped (from the `{ok, Result}' tuple) and returned
 %% directly. If there is an error, an exception is thrown.
 %%
-%% @see delete_many_payloads/2.
+%% @see clear_many_payloads/2.
 
-'delete_many_payloads!'(StoreId, PathPattern) ->
-    Ret = delete_many_payloads(StoreId, PathPattern),
+'clear_many_payloads!'(StoreId, PathPattern) ->
+    Ret = clear_many_payloads(StoreId, PathPattern),
     unwrap_result(Ret).
 
--spec 'delete_many_payloads!'(StoreId, PathPattern, Options) -> Ret when
+-spec 'clear_many_payloads!'(StoreId, PathPattern, Options) -> Ret when
       StoreId :: store_id(),
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:command_options() |
@@ -1033,14 +1033,14 @@
              khepri_machine:async_ret().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% Calling this function is the same as calling {@link delete_many_payloads/3}
+%% Calling this function is the same as calling {@link clear_many_payloads/3}
 %% but the result is unwrapped (from the `{ok, Result}' tuple) and returned
 %% directly. If there is an error, an exception is thrown.
 %%
-%% @see delete_many_payloads/3.
+%% @see clear_many_payloads/3.
 
-'delete_many_payloads!'(StoreId, PathPattern, Options) ->
-    Ret = delete_many_payloads(StoreId, PathPattern, Options),
+'clear_many_payloads!'(StoreId, PathPattern, Options) ->
+    Ret = clear_many_payloads(StoreId, PathPattern, Options),
     unwrap_result(Ret).
 
 %% -------------------------------------------------------------------

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -74,8 +74,8 @@
 
          delete/1, delete/2,
          delete_many/1, delete_many/2,
-         delete_payload/1, delete_payload/2,
-         delete_many_payloads/1, delete_many_payloads/2,
+         clear_payload/1, clear_payload/2,
+         clear_many_payloads/1, clear_many_payloads/2,
 
          abort/1,
          is_transaction/0]).
@@ -668,71 +668,71 @@ delete_many(PathPattern, Options) ->
     ?result_ret_to_minimal_ret(Ret).
 
 %% -------------------------------------------------------------------
-%% delete_payload().
+%% clear_payload().
 %% -------------------------------------------------------------------
 
--spec delete_payload(PathPattern) -> Ret when
+-spec clear_payload(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% This is the same as {@link khepri:delete_payload/2} but inside the context
+%% This is the same as {@link khepri:clear_payload/2} but inside the context
 %% of a transaction function.
 %%
-%% @see khepri:delete_payload/2.
+%% @see khepri:clear_payload/2.
 
-delete_payload(PathPattern) ->
-    delete_payload(PathPattern, #{}).
+clear_payload(PathPattern) ->
+    clear_payload(PathPattern, #{}).
 
--spec delete_payload(PathPattern, Options) -> Ret when
+-spec clear_payload(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options() | khepri:put_options(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% This is the same as {@link khepri:delete_payload/3} but inside the context
+%% This is the same as {@link khepri:clear_payload/3} but inside the context
 %% of a transaction function.
 %%
-%% @see khepri:delete_payload/3.
+%% @see khepri:clear_payload/3.
 
-delete_payload(PathPattern, Options) ->
+clear_payload(PathPattern, Options) ->
     Options1 = Options#{props_to_return => []},
-    Ret = khepri_tx_adv:delete_payload(PathPattern, Options1),
+    Ret = khepri_tx_adv:clear_payload(PathPattern, Options1),
     ?result_ret_to_minimal_ret(Ret).
 
 %% -------------------------------------------------------------------
-%% delete_many_payloads().
+%% clear_many_payloads().
 %% -------------------------------------------------------------------
 
--spec delete_many_payloads(PathPattern) -> Ret when
+-spec clear_many_payloads(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% This is the same as {@link khepri:delete_many_payloads/2} but inside the
+%% This is the same as {@link khepri:clear_many_payloads/2} but inside the
 %% context of a transaction function.
 %%
-%% @see khepri:delete_many_payloads/2.
+%% @see khepri:clear_many_payloads/2.
 
-delete_many_payloads(PathPattern) ->
-    delete_many_payloads(PathPattern, #{}).
+clear_many_payloads(PathPattern) ->
+    clear_many_payloads(PathPattern, #{}).
 
--spec delete_many_payloads(PathPattern, Options) -> Ret when
+-spec clear_many_payloads(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options() | khepri:put_options(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% This is the same as {@link khepri:delete_many_payloads/3} but inside the
+%% This is the same as {@link khepri:clear_many_payloads/3} but inside the
 %% context of a transaction function.
 %%
-%% @see khepri:delete_many_payloads/3.
+%% @see khepri:clear_many_payloads/3.
 
-delete_many_payloads(PathPattern, Options) ->
+clear_many_payloads(PathPattern, Options) ->
     Options1 = Options#{props_to_return => []},
-    Ret = khepri_tx_adv:delete_many_payloads(PathPattern, Options1),
+    Ret = khepri_tx_adv:clear_many_payloads(PathPattern, Options1),
     ?result_ret_to_minimal_ret(Ret).
 
 %% -------------------------------------------------------------------

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -39,8 +39,8 @@
 
          delete/1, delete/2,
          delete_many/1, delete_many/2,
-         delete_payload/1, delete_payload/2,
-         delete_many_payloads/1, delete_many_payloads/2]).
+         clear_payload/1, clear_payload/2,
+         clear_many_payloads/1, clear_many_payloads/2]).
 
 %% For internal user only.
 -export([to_standalone_fun/2,
@@ -413,36 +413,36 @@ delete_many(PathPattern, Options) ->
     handle_state_for_call(Fun).
 
 %% -------------------------------------------------------------------
-%% delete_payload().
+%% clear_payload().
 %% -------------------------------------------------------------------
 
--spec delete_payload(PathPattern) -> Ret when
+-spec clear_payload(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri_adv:single_result().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% This is the same as {@link khepri_adv:delete_payload/2} but inside the
+%% This is the same as {@link khepri_adv:clear_payload/2} but inside the
 %% context of a transaction function.
 %%
-%% @see khepri_adv:delete_payload/2.
+%% @see khepri_adv:clear_payload/2.
 
-delete_payload(PathPattern) ->
-    delete_payload(PathPattern, #{}).
+clear_payload(PathPattern) ->
+    clear_payload(PathPattern, #{}).
 
--spec delete_payload(PathPattern, Options) -> Ret when
+-spec clear_payload(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options() | khepri:put_options(),
       Ret :: khepri_adv:single_result().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
-%% This is the same as {@link khepri_adv:delete_payload/3} but inside the
+%% This is the same as {@link khepri_adv:clear_payload/3} but inside the
 %% context of a transaction function.
 %%
-%% @see khepri_adv:delete_payload/3.
+%% @see khepri_adv:clear_payload/3.
 
-delete_payload(PathPattern, Options) ->
+clear_payload(PathPattern, Options) ->
     Ret = update(PathPattern, khepri_payload:none(), Options),
     case Ret of
         {error, ?khepri_error(node_not_found, _)} -> {ok, #{}};
@@ -450,34 +450,34 @@ delete_payload(PathPattern, Options) ->
     end.
 
 %% -------------------------------------------------------------------
-%% delete_many_payloads().
+%% clear_many_payloads().
 %% -------------------------------------------------------------------
 
--spec delete_many_payloads(PathPattern) -> Ret when
+-spec clear_many_payloads(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Ret :: khepri_adv:many_results().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% This is the same as {@link khepri_adv:delete_many_payloads/2} but inside the
+%% This is the same as {@link khepri_adv:clear_many_payloads/2} but inside the
 %% context of a transaction function.
 %%
-%% @see khepri_adv:delete_many_payloads/2.
+%% @see khepri_adv:clear_many_payloads/2.
 
-delete_many_payloads(PathPattern) ->
-    delete_many_payloads(PathPattern, #{}).
+clear_many_payloads(PathPattern) ->
+    clear_many_payloads(PathPattern, #{}).
 
--spec delete_many_payloads(PathPattern, Options) -> Ret when
+-spec clear_many_payloads(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options() | khepri:put_options(),
       Ret :: khepri_adv:many_results().
 %% @doc Deletes the payload of all tree nodes matching the given path pattern.
 %%
-%% This is the same as {@link khepri_adv:delete_many_payloads/3} but inside the
+%% This is the same as {@link khepri_adv:clear_many_payloads/3} but inside the
 %% context of a transaction function.
 %%
-%% @see khepri_adv:delete_many_payloads/3.
+%% @see khepri_adv:clear_many_payloads/3.
 
-delete_many_payloads(PathPattern, Options) ->
+clear_many_payloads(PathPattern, Options) ->
     put_many(PathPattern, khepri_payload:none(), Options).
 
 %% -------------------------------------------------------------------
@@ -719,8 +719,8 @@ is_remote_call_valid(khepri_tx, update, _) -> true;
 is_remote_call_valid(khepri_tx, compare_and_swap, _) -> true;
 is_remote_call_valid(khepri_tx, delete, _) -> true;
 is_remote_call_valid(khepri_tx, delete_many, _) -> true;
-is_remote_call_valid(khepri_tx, delete_payload, _) -> true;
-is_remote_call_valid(khepri_tx, delete_many_payloads, _) -> true;
+is_remote_call_valid(khepri_tx, clear_payload, _) -> true;
+is_remote_call_valid(khepri_tx, clear_many_payloads, _) -> true;
 is_remote_call_valid(khepri_tx, abort, _) -> true;
 is_remote_call_valid(khepri_tx, is_transaction, _) -> true;
 
@@ -733,8 +733,8 @@ is_remote_call_valid(khepri_tx_adv, update, _) -> true;
 is_remote_call_valid(khepri_tx_adv, compare_and_swap, _) -> true;
 is_remote_call_valid(khepri_tx_adv, delete, _) -> true;
 is_remote_call_valid(khepri_tx_adv, delete_many, _) -> true;
-is_remote_call_valid(khepri_tx_adv, delete_payload, _) -> true;
-is_remote_call_valid(khepri_tx_adv, delete_many_payloads, _) -> true;
+is_remote_call_valid(khepri_tx_adv, clear_payload, _) -> true;
+is_remote_call_valid(khepri_tx_adv, clear_many_payloads, _) -> true;
 
 is_remote_call_valid(_, module_info, _) -> false;
 
@@ -897,12 +897,12 @@ is_standalone_fun_still_needed(#{calls := Calls}, auto) ->
                     #{{khepri_tx, delete, 2} := _}                   -> rw;
                     #{{khepri_tx, delete_many, 1} := _}              -> rw;
                     #{{khepri_tx, delete_many, 2} := _}              -> rw;
-                    #{{khepri_tx, delete_payload, 1} := _}           -> rw;
-                    #{{khepri_tx, delete_payload, 2} := _}           -> rw;
-                    #{{khepri_tx, delete_payload, 3} := _}           -> rw;
-                    #{{khepri_tx, delete_many_payloads, 1} := _}     -> rw;
-                    #{{khepri_tx, delete_many_payloads, 2} := _}     -> rw;
-                    #{{khepri_tx, delete_many_payloads, 3} := _}     -> rw;
+                    #{{khepri_tx, clear_payload, 1} := _}           -> rw;
+                    #{{khepri_tx, clear_payload, 2} := _}           -> rw;
+                    #{{khepri_tx, clear_payload, 3} := _}           -> rw;
+                    #{{khepri_tx, clear_many_payloads, 1} := _}     -> rw;
+                    #{{khepri_tx, clear_many_payloads, 2} := _}     -> rw;
+                    #{{khepri_tx, clear_many_payloads, 3} := _}     -> rw;
 
                     #{{khepri_tx_adv, put, 2} := _}                  -> rw;
                     #{{khepri_tx_adv, put, 3} := _}                  -> rw;
@@ -923,12 +923,12 @@ is_standalone_fun_still_needed(#{calls := Calls}, auto) ->
                     #{{khepri_tx_adv, delete, 2} := _}               -> rw;
                     #{{khepri_tx_adv, delete_many, 1} := _}          -> rw;
                     #{{khepri_tx_adv, delete_many, 2} := _}          -> rw;
-                    #{{khepri_tx_adv, delete_payload, 1} := _}       -> rw;
-                    #{{khepri_tx_adv, delete_payload, 2} := _}       -> rw;
-                    #{{khepri_tx_adv, delete_payload, 3} := _}       -> rw;
-                    #{{khepri_tx_adv, delete_many_payloads, 1} := _} -> rw;
-                    #{{khepri_tx_adv, delete_many_payloads, 2} := _} -> rw;
-                    #{{khepri_tx_adv, delete_many_payloads, 3} := _} -> rw;
+                    #{{khepri_tx_adv, clear_payload, 1} := _}       -> rw;
+                    #{{khepri_tx_adv, clear_payload, 2} := _}       -> rw;
+                    #{{khepri_tx_adv, clear_payload, 3} := _}       -> rw;
+                    #{{khepri_tx_adv, clear_many_payloads, 1} := _} -> rw;
+                    #{{khepri_tx_adv, clear_many_payloads, 2} := _} -> rw;
+                    #{{khepri_tx_adv, clear_many_payloads, 3} := _} -> rw;
                     _                                                -> ro
                 end,
     ReadWrite =:= rw.

--- a/test/advanced_delete.erl
+++ b/test/advanced_delete.erl
@@ -101,20 +101,20 @@ delete_many_on_existing_node_with_condition_false_test_() ->
                 payload_version => 1}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_from_non_existing_node_test_() ->
+clear_payload_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertEqual(
          {ok, #{}},
-         khepri_adv:delete_payload(?FUNCTION_NAME, [foo])),
+         khepri_adv:clear_payload(?FUNCTION_NAME, [foo])),
       ?_assertEqual(
          {error, ?khepri_error(node_not_found, #{node_name => foo,
                                                  node_path => [foo],
                                                  node_is_target => true})},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_from_existing_node_test_() ->
+clear_payload_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -124,12 +124,12 @@ delete_payload_from_existing_node_test_() ->
       ?_assertEqual(
          {ok, #{data => foo_value,
                 payload_version => 2}},
-         khepri_adv:delete_payload(?FUNCTION_NAME, [foo])),
+         khepri_adv:clear_payload(?FUNCTION_NAME, [foo])),
       ?_assertEqual(
          {ok, #{payload_version => 2}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_keep_while_test_() ->
+clear_payload_with_keep_while_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -139,13 +139,13 @@ delete_payload_with_keep_while_test_() ->
       ?_assertEqual(
          {ok, #{data => foo_value,
                 payload_version => 2}},
-         khepri_adv:delete_payload(
+         khepri_adv:clear_payload(
            ?FUNCTION_NAME, [foo], #{keep_while => #{}})),
       ?_assertEqual(
          {ok, #{payload_version => 2}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_options_test_() ->
+clear_payload_with_options_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -155,25 +155,25 @@ delete_payload_with_options_test_() ->
       ?_assertEqual(
          {ok, #{data => foo_value,
                 payload_version => 2}},
-         khepri_adv:delete_payload(?FUNCTION_NAME, [foo], #{async => false})),
+         khepri_adv:clear_payload(?FUNCTION_NAME, [foo], #{async => false})),
       ?_assertEqual(
          {ok, #{payload_version => 2}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_many_payloads_from_non_existing_node_test_() ->
+clear_many_payloads_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertEqual(
          {ok, #{}},
-         khepri_adv:delete_many_payloads(
+         khepri_adv:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}])),
       ?_assertEqual(
          {ok, #{}},
          khepri_adv:get_many(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}]))]}.
 
-delete_many_payloads_from_existing_node_test_() ->
+clear_many_payloads_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -187,7 +187,7 @@ delete_many_payloads_from_existing_node_test_() ->
          {ok, #{[foo1] => #{data => foo1_value,
                             payload_version => 2},
                 [foo2] => #{payload_version => 1}}},
-         khepri_adv:delete_many_payloads(
+         khepri_adv:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}])),
       ?_assertEqual(
          {ok, #{[foo1] => #{payload_version => 2},
@@ -199,12 +199,12 @@ delete_many_payloads_from_existing_node_test_() ->
       ?_assertEqual(
          {ok, #{[foo1] => #{payload_version => 2},
                 [foo2] => #{payload_version => 1}}},
-         khepri_adv:delete_many_payloads(
+         khepri_adv:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}],
            #{})),
       ?_assertEqual(
          {ok, #{[foo1] => #{payload_version => 2},
                 [foo2] => #{payload_version => 1}}},
-         khepri_adv:delete_many_payloads(
+         khepri_adv:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}],
            #{keep_while => #{}}))]}.

--- a/test/advanced_tx_delete.erl
+++ b/test/advanced_tx_delete.erl
@@ -150,7 +150,7 @@ delete_many_on_existing_node_with_condition_false_test_() ->
                 payload_version => 1}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_from_non_existing_node_test_() ->
+clear_payload_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -158,7 +158,7 @@ delete_payload_from_non_existing_node_test_() ->
          {ok, {ok, #{}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_payload([foo])
+                           khepri_tx_adv:clear_payload([foo])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
@@ -168,7 +168,7 @@ delete_payload_from_non_existing_node_test_() ->
                                                  node_is_target => true})},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_from_existing_node_test_() ->
+clear_payload_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -179,7 +179,7 @@ delete_payload_from_existing_node_test_() ->
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_payload([foo])
+                           khepri_tx_adv:clear_payload([foo])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
@@ -189,7 +189,7 @@ delete_payload_from_existing_node_test_() ->
                  payload_version => 2}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_payload([foo])
+                           khepri_tx_adv:clear_payload([foo])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
@@ -197,7 +197,7 @@ delete_payload_from_existing_node_test_() ->
          {ok, #{payload_version => 2}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_keep_while_test_() ->
+clear_payload_with_keep_while_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -210,7 +210,7 @@ delete_payload_with_keep_while_test_() ->
                  payload_version => 2}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_payload(
+                           khepri_tx_adv:clear_payload(
                              [foo], #{keep_while => #{}})
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -219,7 +219,7 @@ delete_payload_with_keep_while_test_() ->
          {ok, #{payload_version => 2}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_options_test_() ->
+clear_payload_with_options_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -232,7 +232,7 @@ delete_payload_with_options_test_() ->
                  payload_version => 2}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_payload(
+                           khepri_tx_adv:clear_payload(
                              [foo], #{})
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -241,7 +241,7 @@ delete_payload_with_options_test_() ->
          {ok, #{payload_version => 2}},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_many_payloads_from_non_existing_node_test_() ->
+clear_many_payloads_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -249,7 +249,7 @@ delete_many_payloads_from_non_existing_node_test_() ->
          {ok, {ok, #{}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_many_payloads(
+                           khepri_tx_adv:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -259,7 +259,7 @@ delete_many_payloads_from_non_existing_node_test_() ->
          khepri_adv:get_many(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}]))]}.
 
-delete_many_payloads_from_existing_node_test_() ->
+clear_many_payloads_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -273,7 +273,7 @@ delete_many_payloads_from_existing_node_test_() ->
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_many_payloads(
+                           khepri_tx_adv:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
@@ -285,7 +285,7 @@ delete_many_payloads_from_existing_node_test_() ->
                  [foo2] => #{payload_version => 1}}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_many_payloads(
+                           khepri_tx_adv:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -303,7 +303,7 @@ delete_many_payloads_from_existing_node_test_() ->
                  [foo2] => #{payload_version => 1}}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_many_payloads(
+                           khepri_tx_adv:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}], #{})
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -314,7 +314,7 @@ delete_many_payloads_from_existing_node_test_() ->
                  [foo2] => #{payload_version => 1}}}},
          begin
              Fun = fun() ->
-                           khepri_tx_adv:delete_many_payloads(
+                           khepri_tx_adv:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}],
                              #{keep_while => #{}})
                    end,

--- a/test/bang_functions.erl
+++ b/test/bang_functions.erl
@@ -362,7 +362,7 @@ delete_many_test_() ->
       ?_assertError(noproc, khepri:'delete_many!'([foo]))
      ]}.
 
-delete_payload_test_() ->
+clear_payload_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -371,17 +371,17 @@ delete_payload_test_() ->
          khepri:create(?FUNCTION_NAME, [foo], value1)),
       ?_assertEqual(
          ok,
-         khepri:'delete_payload!'(?FUNCTION_NAME, [foo])),
+         khepri:'clear_payload!'(?FUNCTION_NAME, [foo])),
       ?_assertEqual(
          ok,
-         khepri:'delete_payload!'(?FUNCTION_NAME, [foo], #{})),
+         khepri:'clear_payload!'(?FUNCTION_NAME, [foo], #{})),
       ?_assertEqual(
          ok,
-         khepri:'delete_payload!'(?FUNCTION_NAME, [foo], #{async => true})),
-      ?_assertError(noproc, khepri:'delete_payload!'([foo]))
+         khepri:'clear_payload!'(?FUNCTION_NAME, [foo], #{async => true})),
+      ?_assertError(noproc, khepri:'clear_payload!'([foo]))
      ]}.
 
-delete_many_payloads_test_() ->
+clear_many_payloads_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -390,12 +390,12 @@ delete_many_payloads_test_() ->
          khepri:create(?FUNCTION_NAME, [foo], value1)),
       ?_assertEqual(
          ok,
-         khepri:'delete_many_payloads!'(?FUNCTION_NAME, [foo])),
+         khepri:'clear_many_payloads!'(?FUNCTION_NAME, [foo])),
       ?_assertEqual(
          ok,
-         khepri:'delete_many_payloads!'(?FUNCTION_NAME, [foo], #{})),
+         khepri:'clear_many_payloads!'(?FUNCTION_NAME, [foo], #{})),
       ?_assertEqual(
          ok,
-         khepri:'delete_many_payloads!'(?FUNCTION_NAME, [foo], #{async => true})),
-      ?_assertError(noproc, khepri:'delete_many_payloads!'([foo]))
+         khepri:'clear_many_payloads!'(?FUNCTION_NAME, [foo], #{async => true})),
+      ?_assertError(noproc, khepri:'clear_many_payloads!'([foo]))
      ]}.

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -986,8 +986,8 @@ can_use_default_store_on_single_node(_Config) ->
     ?assertEqual({ok, ok}, khepri:transaction(fun() -> ok end, ro, #{})),
 
     ?assertEqual(ok, khepri:create([bar], value1)),
-    ?assertEqual(ok, khepri:delete_payload([bar])),
-    ?assertEqual(ok, khepri:delete_many_payloads([bar])),
+    ?assertEqual(ok, khepri:clear_payload([bar])),
+    ?assertEqual(ok, khepri:clear_many_payloads([bar])),
     ?assertEqual(ok, khepri:delete([bar])),
     ?assertEqual(ok, khepri:delete([bar], #{})),
     ?assertEqual(ok, khepri:delete_many([bar])),
@@ -997,10 +997,10 @@ can_use_default_store_on_single_node(_Config) ->
     ?assertEqual(
        {ok, #{data => value1,
               payload_version => 2}},
-       khepri_adv:delete_payload([bar])),
+       khepri_adv:clear_payload([bar])),
     ?assertEqual(
        {ok, #{[bar] => #{payload_version => 2}}},
-       khepri_adv:delete_many_payloads([bar])),
+       khepri_adv:clear_many_payloads([bar])),
     ?assertEqual(
        {ok, #{payload_version => 2}},
        khepri_adv:delete([bar])),
@@ -1068,7 +1068,7 @@ can_start_store_in_specified_data_dir_on_single_node(_Config) ->
     ?assertEqual({ok, 1}, khepri:count("**", #{})),
 
     ?assertEqual(ok, khepri:create([bar], value1)),
-    ?assertEqual(ok, khepri:delete_payload([bar])),
+    ?assertEqual(ok, khepri:clear_payload([bar])),
     ?assertEqual(ok, khepri:delete([bar], #{})),
 
     ?assertEqual({ok, StoreId}, khepri:start(DataDir)),

--- a/test/simple_delete.erl
+++ b/test/simple_delete.erl
@@ -129,18 +129,18 @@ delete_many_recursively_2_test_() ->
          {ok, #{[foo] => foo_value}},
          khepri:get_many(?FUNCTION_NAME, [#if_path_matches{regex = any}]))]}.
 
-delete_payload_from_non_existing_node_test_() ->
+clear_payload_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertEqual(
          ok,
-         khepri:delete_payload(?FUNCTION_NAME, [foo])),
+         khepri:clear_payload(?FUNCTION_NAME, [foo])),
       ?_assertMatch(
          {error, ?khepri_error(node_not_found, _)},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_from_existing_node_test_() ->
+clear_payload_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -149,12 +149,12 @@ delete_payload_from_existing_node_test_() ->
          khepri:create(?FUNCTION_NAME, [foo], foo_value)),
       ?_assertEqual(
          ok,
-         khepri:delete_payload(?FUNCTION_NAME, [foo])),
+         khepri:clear_payload(?FUNCTION_NAME, [foo])),
       ?_assertEqual(
          {ok, undefined},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_keep_while_test_() ->
+clear_payload_with_keep_while_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -163,12 +163,12 @@ delete_payload_with_keep_while_test_() ->
          khepri:create(?FUNCTION_NAME, [foo], foo_value)),
       ?_assertEqual(
          ok,
-         khepri:delete_payload(?FUNCTION_NAME, [foo], #{keep_while => #{}})),
+         khepri:clear_payload(?FUNCTION_NAME, [foo], #{keep_while => #{}})),
       ?_assertEqual(
          {ok, undefined},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_options_test_() ->
+clear_payload_with_options_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -177,25 +177,25 @@ delete_payload_with_options_test_() ->
          khepri:create(?FUNCTION_NAME, [foo], foo_value)),
       ?_assertEqual(
          ok,
-         khepri:delete_payload(?FUNCTION_NAME, [foo], #{async => false})),
+         khepri:clear_payload(?FUNCTION_NAME, [foo], #{async => false})),
       ?_assertEqual(
          {ok, undefined},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_many_payloads_from_non_existing_node_test_() ->
+clear_many_payloads_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_assertEqual(
          ok,
-         khepri:delete_many_payloads(
+         khepri:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}])),
       ?_assertEqual(
          {ok, #{}},
          khepri:get_many(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}]))]}.
 
-delete_many_payloads_from_existing_node_test_() ->
+clear_many_payloads_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -207,7 +207,7 @@ delete_many_payloads_from_existing_node_test_() ->
          khepri:create(?FUNCTION_NAME, [foo2, bar], bar_value)),
       ?_assertEqual(
          ok,
-         khepri:delete_many_payloads(
+         khepri:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}])),
       ?_assertEqual(
          {ok, #{[foo1] => undefined,
@@ -217,11 +217,11 @@ delete_many_payloads_from_existing_node_test_() ->
            ?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR_STAR])),
       ?_assertEqual(
          ok,
-         khepri:delete_many_payloads(
+         khepri:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}],
            #{})),
       ?_assertEqual(
          ok,
-         khepri:delete_many_payloads(
+         khepri:clear_many_payloads(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}],
            #{keep_while => #{}}))]}.

--- a/test/simple_tx_delete.erl
+++ b/test/simple_tx_delete.erl
@@ -186,7 +186,7 @@ delete_many_recursively_2_test_() ->
          {ok, #{[foo] => foo_value}},
          khepri:get_many(?FUNCTION_NAME, [#if_path_matches{regex = any}]))]}.
 
-delete_payload_from_non_existing_node_test_() ->
+clear_payload_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -194,7 +194,7 @@ delete_payload_from_non_existing_node_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_payload([foo])
+                           khepri_tx:clear_payload([foo])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
@@ -202,7 +202,7 @@ delete_payload_from_non_existing_node_test_() ->
          {error, ?khepri_error(node_not_found, _)},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_from_existing_node_test_() ->
+clear_payload_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -213,7 +213,7 @@ delete_payload_from_existing_node_test_() ->
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
              Fun = fun() ->
-                           khepri_tx:delete_payload([foo])
+                           khepri_tx:clear_payload([foo])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
@@ -221,7 +221,7 @@ delete_payload_from_existing_node_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_payload([foo])
+                           khepri_tx:clear_payload([foo])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
@@ -229,7 +229,7 @@ delete_payload_from_existing_node_test_() ->
          {ok, undefined},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_keep_while_test_() ->
+clear_payload_with_keep_while_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -240,7 +240,7 @@ delete_payload_with_keep_while_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_payload(
+                           khepri_tx:clear_payload(
                              [foo], #{keep_while => #{}})
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -249,7 +249,7 @@ delete_payload_with_keep_while_test_() ->
          {ok, undefined},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_payload_with_options_test_() ->
+clear_payload_with_options_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -260,7 +260,7 @@ delete_payload_with_options_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_payload(
+                           khepri_tx:clear_payload(
                              [foo], #{})
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -269,7 +269,7 @@ delete_payload_with_options_test_() ->
          {ok, undefined},
          khepri:get(?FUNCTION_NAME, [foo]))]}.
 
-delete_many_payloads_from_non_existing_node_test_() ->
+clear_many_payloads_from_non_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -277,7 +277,7 @@ delete_many_payloads_from_non_existing_node_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_many_payloads(
+                           khepri_tx:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -287,7 +287,7 @@ delete_many_payloads_from_non_existing_node_test_() ->
          khepri:get_many(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}]))]}.
 
-delete_many_payloads_from_existing_node_test_() ->
+clear_many_payloads_from_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -301,7 +301,7 @@ delete_many_payloads_from_existing_node_test_() ->
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
              Fun = fun() ->
-                           khepri_tx:delete_many_payloads(
+                           khepri_tx:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
@@ -310,7 +310,7 @@ delete_many_payloads_from_existing_node_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_many_payloads(
+                           khepri_tx:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}])
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -325,7 +325,7 @@ delete_many_payloads_from_existing_node_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_many_payloads(
+                           khepri_tx:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}], #{})
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
@@ -334,7 +334,7 @@ delete_many_payloads_from_existing_node_test_() ->
          {ok, ok},
          begin
              Fun = fun() ->
-                           khepri_tx:delete_many_payloads(
+                           khepri_tx:clear_many_payloads(
                              [#if_name_matches{regex = "foo"}],
                              #{keep_while => #{}})
                    end,


### PR DESCRIPTION
Likewise for `delete_many_payloads()`, renamed to `clear_many_payloads()`.

This is more readable in the end and helps with completion.