### PR TITLE
khepri_machine: Merge `extra` into `options` in `#put{}` command

### DIFF
--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -288,7 +288,7 @@ write(
         true ->
             Command = #put{path = Path,
                            payload = Payload,
-                           extra = Extra},
+                           options = Extra},
             ?LOG_DEBUG(
                "Khepri export: calling ~s:write/2:~n"
                "  opaque data: ~p~n"

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -45,9 +45,7 @@
 
 -record(put, {path :: khepri_path:native_pattern(),
               payload = ?NO_PAYLOAD :: khepri_payload:payload(),
-              extra = #{} :: #{keep_while =>
-                               khepri_condition:native_keep_while()},
-              options = #{} :: khepri:tree_options()}).
+              options = #{} :: khepri:tree_options() | khepri:put_options()}).
 
 -record(delete, {path :: khepri_path:native_pattern(),
                  options  = #{} :: khepri:tree_options()}).

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -200,8 +200,10 @@ put_many(PathPattern, Data, Options) ->
     ensure_updates_are_allowed(),
     PathPattern1 = path_from_string(PathPattern),
     Payload1 = khepri_payload:wrap(Data),
-    {_CommandOptions, TreeOptions, Extra} =
+    {_CommandOptions, TreeAndPutOptions} =
     khepri_machine:split_command_options(Options),
+    {TreeOptions, Extra} =
+    khepri_machine:split_put_options(TreeAndPutOptions),
     %% TODO: Ensure `CommandOptions' is unset.
     Fun = fun(State) ->
                   khepri_machine:insert_or_update_node(
@@ -403,9 +405,10 @@ delete_many(PathPattern) ->
 delete_many(PathPattern, Options) ->
     ensure_updates_are_allowed(),
     PathPattern1 = path_from_string(PathPattern),
-    {_CommandOptions, TreeOptions, _Extra} =
+    {_CommandOptions, TreeOptions} =
     khepri_machine:split_command_options(Options),
-    %% TODO: Ensure `CommandOptions' and `Extra' are unset.
+    %% TODO: Ensure `CommandOptions' is empty and `TreeOptions' doesn't
+    %% contains put options.
     Fun = fun(State) ->
                   khepri_machine:delete_matching_nodes(
                     State, PathPattern1, TreeOptions)

--- a/test/export.erl
+++ b/test/export.erl
@@ -37,7 +37,7 @@ export_full_store_test_() ->
          khepri:create(?FUNCTION_NAME, [foo, bar], bar_value)),
       ?_assertEqual(
          {ok, [#put{path = [foo],
-                    extra = #{keep_while => #{[foo] => Cond}}},
+                    options = #{keep_while => #{[foo] => Cond}}},
                #put{path = [foo, bar],
                     payload = khepri_payload:data(bar_value)}]},
          khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
@@ -116,10 +116,10 @@ export_keep_while_conds_test_() ->
            #{keep_while => KeepWhile})),
       ?_assertEqual(
          {ok, [#put{path = [foo],
-                    extra = #{keep_while => #{[foo] => Cond1}}},
+                    options = #{keep_while => #{[foo] => Cond1}}},
                #put{path = [foo, bar],
                     payload = ?NO_PAYLOAD,
-                    extra = #{keep_while => #{[foo, bar] => Cond2}}}]},
+                    options = #{keep_while => #{[foo, bar] => Cond2}}}]},
          khepri:export(?FUNCTION_NAME, Module, ModulePriv))]}.
 
 error_to_export_during_open_write_test_() ->

--- a/test/export_erlang.erl
+++ b/test/export_erlang.erl
@@ -59,7 +59,7 @@ export_import_full_store_to_file_test_() ->
       ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Filename)),
       ?_assertEqual(
          {ok, [#put{path = [foo],
-                    extra = #{keep_while => #{[foo] => Cond}}},
+                    options = #{keep_while => #{[foo] => Cond}}},
                #put{path = [foo, bar],
                     payload = khepri_payload:data(bar_value)},
                #put{path = [foo, bar, baz],
@@ -164,7 +164,7 @@ export_import_full_store_to_fd_test_() ->
       ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Fd)),
       ?_assertEqual(
          {ok, [#put{path = [foo],
-                    extra = #{keep_while => #{[foo] => Cond}}},
+                    options = #{keep_while => #{[foo] => Cond}}},
                #put{path = [foo, bar],
                     payload = khepri_payload:data(bar_value)},
                #put{path = [foo, bar, baz],

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -66,7 +66,7 @@ insert_when_keep_while_true_test() ->
     KeepWhile = #{[foo] => #if_node_exists{exists = true}},
     Command = #put{path = [baz],
                    payload = khepri_payload:data(baz_value),
-                   extra = #{keep_while => KeepWhile}},
+                   options = #{keep_while => KeepWhile}},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
     KeepWhileConds = khepri_machine:get_keep_while_conds(S1),
@@ -105,7 +105,7 @@ insert_when_keep_while_false_test() ->
     KeepWhile1 = #{[foo, bar] => #if_node_exists{exists = true}},
     Command1 = #put{path = [baz],
                     payload = khepri_payload:data(baz_value),
-                    extra = #{keep_while => KeepWhile1}},
+                    options = #{keep_while => KeepWhile1}},
     {S1, Ret1, SE1} = khepri_machine:apply(?META, Command1, S0),
 
     ?assertEqual(S0#khepri_machine.root, S1#khepri_machine.root),
@@ -124,8 +124,7 @@ insert_when_keep_while_false_test() ->
     KeepWhile2 = #{[foo] => #if_child_list_length{count = 10}},
     Command2 = #put{path = [baz],
                     payload = khepri_payload:data(baz_value),
-                    extra =
-                    #{keep_while => KeepWhile2}},
+                    options = #{keep_while => KeepWhile2}},
     {S2, Ret2, SE2} = khepri_machine:apply(?META, Command2, S0),
 
     ?assertEqual(S0#khepri_machine.root, S2#khepri_machine.root),
@@ -145,7 +144,7 @@ insert_when_keep_while_true_on_self_test() ->
     KeepWhile = #{[?THIS_KHEPRI_NODE] => #if_child_list_length{count = 0}},
     Command = #put{path = [foo],
                    payload = khepri_payload:data(foo_value),
-                   extra = #{keep_while => KeepWhile}},
+                   options = #{keep_while => KeepWhile}},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -168,7 +167,7 @@ insert_when_keep_while_false_on_self_test() ->
     KeepWhile = #{[?THIS_KHEPRI_NODE] => #if_child_list_length{count = 1}},
     Command = #put{path = [foo],
                    payload = khepri_payload:data(foo_value),
-                   extra = #{keep_while => KeepWhile}},
+                   options = #{keep_while => KeepWhile}},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -192,7 +191,7 @@ keep_while_still_true_after_command_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value),
-                     extra = #{keep_while => KeepWhile}}],
+                     options = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [foo],
@@ -232,7 +231,7 @@ keep_while_now_false_after_command_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value),
-                     extra = #{keep_while => KeepWhile}}],
+                     options = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #put{path = [foo, bar],
@@ -264,10 +263,10 @@ recursive_automatic_cleanup_test() ->
                   #if_child_list_length{count = {gt, 0}}},
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value),
-                     extra = #{keep_while => KeepWhile}},
+                     options = #{keep_while => KeepWhile}},
                 #put{path = [foo, bar],
                      payload = khepri_payload:data(bar_value),
-                     extra = #{keep_while => KeepWhile}},
+                     options = #{keep_while => KeepWhile}},
                 #put{path = [foo, bar, baz],
                      payload = khepri_payload:data(baz_value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
@@ -299,7 +298,7 @@ keep_while_now_false_after_delete_command_test() ->
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [baz],
                      payload = khepri_payload:data(baz_value),
-                     extra = #{keep_while => KeepWhile}}],
+                     options = #{keep_while => KeepWhile}}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
     Command = #delete{path = [foo],


### PR DESCRIPTION
This removes one map from the command. This map would have been empty most of the time (about 6 bytes when converted to binary).