### PR TITLE
khepri_fun: Fix translation for bs_get_float2

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1205,7 +1205,8 @@ pass1_process_instructions(
   State,
   Result)
   when (BsGetSomething =:= bs_get_integer2 orelse
-        BsGetSomething =:= bs_get_binary2) andalso
+        BsGetSomething =:= bs_get_binary2 orelse
+        BsGetSomething =:= bs_get_float2) andalso
        is_integer(FF) ->
     %% `beam_disasm' did not decode this instruction correctly. We need to
     %% patch it to move `Live' before the list. We also need to decode field

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -450,6 +450,15 @@ allowed_bs_match_accepts_match_context_test() ->
            <<"5">> = trim_leading_dash3([], "-5")
        end).
 
+match_float(<<Float/float>>) -> Float.
+
+allowed_bs_get_float_test() ->
+    FloatBin = mask(<<3.14/float>>),
+    ?assertStandaloneFun(
+      begin
+          3.14 = match_float(FloatBin)
+      end).
+
 make_tuple([A]) ->
     {a, A};
 make_tuple([A, B]) ->


### PR DESCRIPTION
The resolution for `bs_get_float2` in `beam_disasm` is [in the same block and has the same body](https://github.com/erlang/otp/blob/7da89b77373985277892ab8b957550be5ca2474d/lib/compiler/src/beam_disasm.erl#L1042-L1050) as the translations for `bs_get_integer2` and `bs_get_binary2` so it has the same mistranslations and can be fixed in the same way.

We can provoke a `{test,bs_get_float2,..}` instruction by pattern matching on a bitstring that uses the `float` type specifier.