### PR TITLE
Fix supervision tree shutdown

### DIFF
--- a/src/khepri.app.src
+++ b/src/khepri.app.src
@@ -6,7 +6,8 @@
   %%   * doc/overview.edoc
   %% Pay attention to links in particular.
   {vsn, "0.6.0"},
-  {registered, []},
+  {registered, [khepri_sup,
+                khepri_event_handler]},
   {applications,
    [kernel,
     stdlib,

--- a/src/khepri_event_handler.erl
+++ b/src/khepri_event_handler.erl
@@ -41,6 +41,7 @@ handle_triggered_sprocs(StoreId, TriggeredStoredProcs) ->
     gen_server:cast(?SERVER, {?FUNCTION_NAME, StoreId, TriggeredStoredProcs}).
 
 init(_) ->
+    erlang:process_flag(trap_exit, true),
     State = #?MODULE{},
     {ok, State}.
 


### PR DESCRIPTION
We now trap exit signals in `khepri_event_handler`. This is mandatory so that `terminate/3` is called when the supervision tree is shutted down.