### PR TITLE
khepri_fun: Work around Rebar's use of `cth_readable` parse_transform

### DIFF
--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -72,7 +72,8 @@
          override_object_code/2,
          get_object_code/1,
          decode_line_chunk/2,
-         compile/1]).
+         compile/1,
+         to_actual_arg/1]).
 -endif.
 
 %% FIXME: compile:forms/2 is incorrectly specified and doesn't accept
@@ -1706,9 +1707,25 @@ disassemble_module1(Module, Checksum) when is_binary(Checksum) ->
                                        Module, Checksum, Beam),
                     {BeamFileRecord, Checksum};
                 _ ->
-                    throw(
-                      {mismatching_module_checksum,
-                       Module, Checksum, ActualChecksum})
+                    CompileInfoFromFun = Module:module_info(compile),
+                    CompileInfoOnDisk = get_and_decode_compile_chunk(
+                                          Module, Beam),
+                    IsAcceptable = is_recompiled_module_acceptable(
+                                     CompileInfoFromFun, CompileInfoOnDisk),
+                    case IsAcceptable of
+                        true ->
+                            BeamFileRecord = do_disassemble_and_cache(
+                                               Module, Checksum, Beam),
+                            {BeamFileRecord, Checksum};
+                        false ->
+                            throw(
+                              {mismatching_module_checksum,
+                               #{module => Module,
+                                 checksum_from_fun => Checksum,
+                                 checksum_on_disk => ActualChecksum,
+                                 compile_info_from_fun => CompileInfoFromFun,
+                                 compile_info_on_disk => CompileInfoOnDisk}})
+                    end
             end
     end;
 disassemble_module1(Module, undefined) ->
@@ -1924,6 +1941,57 @@ decode_lambda_chunk_entries(
     decode_lambda_chunk_entries(Rest, Count - 1, AtomsTable, Entries1);
 decode_lambda_chunk_entries(<<>>, 0, _AtomsTable, Entries) ->
     lists:reverse(Entries).
+
+is_recompiled_module_acceptable(CompileInfoFromFun, CompileInfoOnDisk) ->
+    %% Rebar 3 recompiles application modules on-the-fly to use the
+    %% `cth_readable_transform' parse_transform helper. This is used to provide
+    %% a better output from common_test testsuites in the terminal.
+    %%
+    %% This changes the checksum of the module loaded in memory compared to the
+    %% file on disk. To determine if we can still use the code on disk for
+    %% function extraction, we compare the source file name and the compiler
+    %% options.
+    %%
+    %% If both copies were compiled for tests (`-DTEST') and the only
+    %% difference is the fact that `cth_readable_transform' is used, we
+    %% consider that the actual code didn't change and we can extract the
+    %% function.
+    RelevantOptionsFromFun = filter_relevant_compile_options(
+                               CompileInfoFromFun),
+    RelevantOptionsOnDisk = filter_relevant_compile_options(
+                              CompileInfoOnDisk),
+    RelevantOptionsDiff1 = RelevantOptionsFromFun -- RelevantOptionsOnDisk,
+    RelevantOptionsDiff2 = RelevantOptionsOnDisk -- RelevantOptionsFromFun,
+    TestDefinedFromFun = lists:member({d, 'TEST'}, RelevantOptionsFromFun),
+    TestDefinedOnDisk = lists:member({d, 'TEST'}, RelevantOptionsOnDisk),
+    SourceFromFun = proplists:get_value(source, CompileInfoFromFun),
+    SourceOnDisk = proplists:get_value(source, CompileInfoOnDisk),
+
+    CthReadablePT = {parse_transform, cth_readable_transform},
+
+    TestDefinedFromFun andalso TestDefinedOnDisk andalso
+    is_list(SourceFromFun) andalso SourceFromFun =:= SourceOnDisk andalso
+    (RelevantOptionsDiff1 =:= [] orelse
+     RelevantOptionsDiff1 =:= [CthReadablePT]) andalso
+    (RelevantOptionsDiff2 =:= [] orelse
+     RelevantOptionsDiff2 =:= [CthReadablePT]).
+
+filter_relevant_compile_options(CompileInfo) ->
+    Options = proplists:get_value(options, CompileInfo, []),
+    lists:sort([Option ||
+                Option <- Options,
+                is_tuple(Option),
+                element(1, Option) =:= d orelse
+                element(1, Option) =:= i orelse
+                element(1, Option) =:= parse_transform]).
+
+get_and_decode_compile_chunk(Module, Beam) ->
+    case beam_lib:chunks(Beam, [compile_info]) of
+        {ok, {Module, [{compile_info, CompileInfo}]}} ->
+            CompileInfo;
+        _ ->
+            undefined
+    end.
 
 %% See: erts/emulator/beam/beam_file.c, beamreader_read_tagged().
 

--- a/test/fun_extraction_SUITE.erl
+++ b/test/fun_extraction_SUITE.erl
@@ -1,0 +1,112 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2022 VMware, Inc. or its affiliates. All rights reserved.
+%%
+
+-module(fun_extraction_SUITE).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("include/khepri.hrl").
+-include("src/khepri_error.hrl").
+-include("src/khepri_machine.hrl").
+
+-export([all/0,
+         groups/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_group/2,
+         end_per_group/2,
+         init_per_testcase/2,
+         end_per_testcase/2,
+
+         fun_extraction_works_in_rebar3_ct/1]).
+
+all() ->
+    [fun_extraction_works_in_rebar3_ct].
+
+groups() ->
+    [].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(khepri),
+    ok = cth_log_redirect:handle_remote_events(true),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(fun_extraction_works_in_rebar3_ct, Config) ->
+    ModifiedMods = code:modified_modules(),
+    KhepriFunModified = lists:member(khepri_fun, ModifiedMods),
+    ct:pal(
+      "Modified modules: ~p~n"
+      "khepri_fun recompiled: ~s",
+      [ModifiedMods, KhepriFunModified]),
+    case KhepriFunModified of
+        true ->
+            Config;
+        false ->
+            {skip,
+             "Khepri not recompiled at runtime by Rebar; "
+             "test conditions not met"}
+    end;
+init_per_testcase(_Testcase, Config) ->
+    Config.
+
+end_per_testcase(_Testcase, _Config) ->
+    ok.
+
+fun_extraction_works_in_rebar3_ct(_Config) ->
+    %% Rebar3 uses `cth_readable' to offer a cleaner output of common_test on
+    %% stdout. As part of that, it recompiles the entire application on-the-fly
+    %% with the `cth_readable_transform' parse_transform. This means that the
+    %% module on disk and the one loaded in memory are different. See
+    %% `khepri_fun:is_recompiled_module_acceptable()'.
+    %%
+    %% This testcase depends on that behavior (see `init_per_testcase').
+    %%
+    %% To test `khepri_fun', it needs to get an anonymous function created by
+    %% the application (not the testsuite) as the top-level function to
+    %% extract.
+    %%
+    %% The `InnerFun' is just here to have an argument to pass to
+    %% `khepri_fun:to_actual_arg()'. `khepri_fun:to_actual_arg()' is the
+    %% function we call to get that anonymous function from the application.
+    InnerFun = fun() -> true end,
+    InnerStandaloneFun = khepri_fun:to_standalone_fun(InnerFun),
+    Options = #{ensure_instruction_is_permitted =>
+                fun(_) -> ok end,
+                should_process_function =>
+                fun
+                    (code, _, _, _)   -> false;
+                    (erlang, _, _, _) -> false;
+                    (lists, _, _, _)  -> false;
+                    (maps, _, _, _)   -> false;
+                    (khepri_fun, exec, _, _) -> false;
+                    (_Mod, _, _, _)   -> true
+                end},
+    OuterFun = khepri_fun:to_actual_arg(InnerStandaloneFun),
+
+    %% Without `khepri_fun:is_recompiled_module_acceptable()', `khepri_fun'
+    %% would fail the extraction below because of the two copies of the
+    %% `khepri_fun' module.
+    OuterStandaloneFun = khepri_fun:to_standalone_fun(OuterFun, Options),
+
+    %% We execute the extracted function just as an extra check, but this is
+    %% not critical for this testcase.
+    ?assertEqual(
+       OuterFun(),
+       khepri_fun:exec(OuterStandaloneFun, [])),
+
+    ok.


### PR DESCRIPTION
To improve the output of common_test in the terminal, Rebar uses [`cth_readable`](https://hex.pm/packages/cth_readable). This library comes with a parse_transform module to convert all calls to `ct:pal()`.

The application modules are thus recompiled on-the-fly (i.e. the result is not written to disk) with this parse_transform. The result is that the module loaded in memory doesn't match the one on disk (different checksums).

This causes the following exception while trying to extract a transaction function. Here is an example:

```erlang
{khepri_ex, failed_to_prepare_tx_fun,
 #{error =>
   {mismatching_module_checksum,
    #{checksum_from_fun =>
      <<194,208,71,94,61,101,247,31,220,109,126,242,101,120,40,129>>,
      checksum_on_disk =>
      <<152,39,250,105,94,89,145,46,251,4,237,114,45,132,63,33>>,
      compile_info_from_fun =>
      [{version, "8.2.1"},
       {options,
        [{d, 'COMMON_TEST'},
         {d, 'TEST'},
         {i, ".../_build/test/lib/khepri_mnesia_migration/src"},
         {i, ".../_build/test/lib/khepri_mnesia_migration/test"},
         {i, ".../_build/test/lib/khepri_mnesia_migration/include"},
         {i, ".../_build/test/lib/khepri_mnesia_migration"}]},
       {source, ".../src/m2k_table_copy.erl"}],
      compile_info_on_disk =>
      [{version, "8.2.1"},
       {options,
        [debug_info,no_spawn_compiler_process,
         {d, 'COMMON_TEST'},
         warn_export_vars,
         {d, 'TEST'},
         {parse_transform,cth_readable_transform},
         {i, ".../_build/test/lib/khepri_mnesia_migration/src"},
         {i, ".../_build/test/lib/khepri_mnesia_migration/test"},
         {i, ".../_build/test/lib/khepri_mnesia_migration/include"},
         {i, ".../_build/test/lib/khepri_mnesia_migration"}]},
       {source, ".../src/m2k_table_copy.erl"}],
      module => m2k_table_copy}}}}
```

The solutions consists in comparing the source filename and compiler options. If both copies are compiled for tests and one of them uses `cth_readable_transform`, we accept the inconsistency and continue.

While here, the error returned when modules mismatch was updated to include more details.
