### PR TITLE
Recreate ETS tables when restoring projections

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1105,6 +1105,7 @@ handle_aux(_RaState, _Type, _Command, AuxState, LogState, _MachineState) ->
     {no_reply, AuxState, LogState}.
 
 restore_projection(Projection, Root, PathPattern) ->
+    _ = khepri_projection:init(Projection),
     TreeOptions = #{props_to_return => ?PROJECTION_PROPS_TO_RETURN,
                     include_root_props => true},
     case find_matching_nodes(Root, PathPattern, TreeOptions) of


### PR DESCRIPTION
When the Ra machine is restarted and enters the `recovered` state, `restore_projection/3` re-fills the ETS table for each projection given the current tree in the store.

This function also must recreate the ETS table for the projection, though: if the Ra machine has snapshotted the `register_projection` commands, they will not be replayed and the ETS tables for the projections will not be recreated.