### PR TITLE
khepri_tx: Support new Erlang/OTP 26 instructions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,11 +11,14 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25]
+        otp_version: [24, 25, 26.0-rc1]
         os: [ubuntu-latest, windows-latest]
         exclude:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.
           - otp_version: 24
+            os: windows-latest
+          # The download for 26.0-rc1 currently hangs for 30min+ for Windows builds.
+          - otp_version: 26.0-rc1
             os: windows-latest
 
     env:

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -2380,6 +2380,9 @@ pass2_process_instruction(
   {bs_init2, _, _, _, _, _, _} = Instruction, State) ->
     replace_label(Instruction, 2, State);
 pass2_process_instruction(
+  {bs_match, _, _, _} = Instruction, State) ->
+    replace_label(Instruction, 2, State);
+pass2_process_instruction(
   {bs_private_append, _, _, _, _, _, _} = Instruction, State) ->
     replace_label(Instruction, 2, State);
 pass2_process_instruction(

--- a/src/khepri_fun.erl
+++ b/src/khepri_fun.erl
@@ -1536,6 +1536,15 @@ pass1_process_instructions(
     Args1 = fix_type_tagged_beam_registers(Args),
     Instruction1 = setelement(4, Instruction, Args1),
     pass1_process_instructions(Rest, State1, [Instruction1 | Result]);
+pass1_process_instructions(
+  [{update_record, _Hint, Size, Src, _Dst, _Updates} = Instruction | Rest],
+  State,
+  Result) ->
+    State1 = ensure_instruction_is_permitted(Instruction, State),
+    Type = {t_tuple, Size, true, #{}},
+    VarInfo = {var_info, Src, [{type, Type}]},
+    Comment = {'%', VarInfo},
+    pass1_process_instructions(Rest, State1, [Instruction, Comment | Result]);
 
 pass1_process_instructions(
   [Instruction | Rest],

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -558,6 +558,8 @@ ensure_instruction_is_permitted({bs_init_bits, _, _, _, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted(bs_init_writable) ->
     ok;
+ensure_instruction_is_permitted({bs_match, _, _, _}) ->
+    ok;
 ensure_instruction_is_permitted({bs_private_append, _, _, _, _, _, _}) ->
     ok;
 ensure_instruction_is_permitted({BsPutSomething, _, _, _, _, _})

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -677,6 +677,8 @@ ensure_instruction_is_permitted({try_end, _}) ->
     ok;
 ensure_instruction_is_permitted({try_case, _}) ->
     ok;
+ensure_instruction_is_permitted({update_record, _, _, _, _, _}) ->
+    ok;
 ensure_instruction_is_permitted(Unknown) ->
     throw({unknown_instruction, Unknown}).
 

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -702,7 +702,7 @@ denied_module_info_1_test() ->
            _ = lists:module_info(compile)
        end).
 
--record(record, {field}).
+-record(record, {field, other_field}).
 
 allowed_erlang_module_api_test() ->
     %% The compiler optimization will replace many of the following calls
@@ -807,6 +807,16 @@ allowed_erlang_module_api_test() ->
 allowed_record_test() ->
     Record = persistent_term:get(record, undefined),
     ?assertStandaloneFun(Record#record.field).
+
+update_record_field(#record{field = foo} = Record) ->
+    Record#record{field = bar}.
+
+allowed_record_update_test() ->
+    %% Note: `other_field' must be masked or else the compiler will optimize
+    %% this into a `move/2' instruction. Here we are trying to provoke an
+    %% OTP26+ `update_record/5' instruction.
+    Record = #record{field = foo, other_field = mask(bar)},
+    ?assertStandaloneFun(update_record_field(Record)).
 
 denied_builtin_make_ref_0_test() ->
     ?assertToFunError(


### PR DESCRIPTION
This change fixes compatibility with Erlang/OTP 26.0-rc1 release candidate which was cut today: https://github.com/erlang/otp/releases/tag/OTP-26.0-rc1

There are two new instructions: `bs_match/3` and `update_record/5`. `bs_match/3` optimizes some bitstring matching and `update_record/5` is used to update record tuples.

`bs_match/3` replaces some other bitstring matching instructions which are already present in the test suite, so this instruction is already covered while running on Erlang/OTP 26. `update_record/5` can be provoked with a new test case which updates a record field.