### PR TITLE
Compile conditions before checking path pattern matching

### DIFF
--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -452,7 +452,8 @@ delete_matching_nodes_cb(_, {interrupted, _, _}, _Options, Result) ->
 %% -------------------------------------------------------------------
 
 does_path_match(Path, PathPattern, Tree) ->
-    does_path_match(Path, PathPattern, [], Tree).
+    PathPattern1 = khepri_path:compile(PathPattern),
+    does_path_match(Path, PathPattern1, [], Tree).
 
 does_path_match(PathRest, PathRest, _ReversedPath, _Tree) ->
     true;


### PR DESCRIPTION
`khepri_machine` compiles path patterns before traversing the tree in `walk_down_the_tree/6`. Path patterns also must be compiled before checking against paths in `does_path_match/4`.

This fixes a potential crash within `khepri_machine` when a projection is registered to a path pattern containing a condition which must be compiled such as `#if_data_matches{}`.