### PR TITLE
khepri_condition: Broaden pattern type for 'if_data_matches'

### DIFF
--- a/include/khepri.hrl
+++ b/include/khepri.hrl
@@ -61,7 +61,7 @@
         {has_sproc = true :: boolean()}).
 
 -record(if_data_matches,
-        {pattern = '_' :: ets:match_pattern(),
+        {pattern = '_' :: ets:match_pattern() | term(),
          conditions = [] :: [any()],
          compiled = undefined :: ets:comp_match_spec() | undefined}).
 


### PR DESCRIPTION
The `ets:match_pattern()` type is limited to `atom() | tuple()` for its use against ETS tables but other terms can be valid. For example, when using match specifications in tracing, another form using a list is valid:

```erl
-type match_function() :: {match_head(),
                           match_conditions(),
                           match_body()}.
-type match_head() :: '_' |
                      match_variable() |
                      [match_head_part(), ...].
-type match_head_part() :: term() | match_variable() | '_'.
-type match_variable() :: atom(). %% '$<n>'
```
`ets:match_spec_compile/1` and `ets:match_spec_run/2` accept just about any term; for example maps:

```erl
MS1 = ets:match_spec_compile([#{hello => foo}, [], [match]]),
MS2 = ets:match_spec_compile([#{hello => bar}, [], [match]]),
[match] = ets:match_spec_run(#{hello => foo}, MS1),
[] = ets:match_spec_run(#{hello => foo}, MS2).
```

So this change allows `term()`s for the pattern field of the `if_data_matches` condition.