### PR TITLE
Store projections in a tree of patterns

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -3432,15 +3432,23 @@ info(StoreId, Options) ->
     end,
 
     case khepri_machine:get_projections_state(StoreId, Options) of
-        {ok, ProjectionMapping} when ProjectionMapping =/= #{} ->
-            io:format("~n\033[1;32m== PROJECTIONS ==\033[0m~n", []),
-            maps:foreach(
-              fun(Projection, PathPattern) ->
-                      Name = khepri_projection:name(Projection),
-                      io:format(
-                        "~n~p:~n"
-                        "    ~p~n", [Name, PathPattern])
-              end, ProjectionMapping);
+        {ok, ProjectionTree} ->
+            case khepri_pattern_tree:is_empty(ProjectionTree) of
+                true ->
+                    ok;
+                false ->
+                    io:format("~n\033[1;32m== PROJECTIONS ==\033[0m~n", []),
+                    khepri_pattern_tree:foreach(
+                      ProjectionTree,
+                      fun(PathPattern, Projections) ->
+                              [begin
+                                   Name = khepri_projection:name(Projection),
+                                   io:format(
+                                     "~n~p:~n"
+                                     "    ~p~n", [Name, PathPattern])
+                               end || Projection <- Projections]
+                      end)
+            end;
         _ ->
             ok
     end,

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -25,7 +25,9 @@
              #{sproc := khepri_path:native_path(),
                event_filter := khepri_evf:event_filter()}},
          emitted_triggers = [] :: [khepri_machine:triggered()],
-         projections = #{} :: khepri_machine:projections_map(),
+         projections = khepri_pattern_tree:empty() ::
+                       khepri_pattern_tree:tree(
+                         khepri_projection:projection()),
          metrics = #{} :: #{applied_command_count => non_neg_integer()}}).
 
 -record(khepri_machine_aux,

--- a/src/khepri_pattern_tree.erl
+++ b/src/khepri_pattern_tree.erl
@@ -1,0 +1,270 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+%% @doc
+%% Khepri tree data structure where each tree node is a pattern component.
+%%
+%% The tree structure used to store data in the Khepri store (see {@link
+%% khepri_tree}) uses path components for branches (see {@link
+%% khepri_path:component()}).
+%%
+%% The tree structure in {@link khepri_tree} can find many matching paths given
+%% a pattern while this tree structure can find many matching patterns given
+%% a path.
+%%
+%% @hidden
+
+-module(khepri_pattern_tree).
+
+-include("src/khepri_tree.hrl").
+
+-record(pattern_node, {child_nodes = #{},
+                       payload = ?NO_PAYLOAD}).
+
+-opaque tree_node(Payload) ::
+        #pattern_node{child_nodes :: #{khepri_path:pattern_component() =>
+                                       tree_node(Payload)},
+                      payload :: Payload | ?NO_PAYLOAD}.
+%% A node in the tree structure.
+
+-opaque tree(Payload) :: tree_node(Payload).
+
+-type payload() :: any().
+
+-type fold_acc() :: term().
+-type fold_fun(Payload) :: fun((khepri_path:native_pattern(),
+                                Payload,
+                                fold_acc()) -> fold_acc()).
+
+-type update_fun(Payload) :: fun((Payload) -> Payload).
+
+-export_type([tree_node/1,
+              tree/1]).
+
+-export([empty/0,
+         is_empty/1,
+         update/3,
+         fold/5,
+         foreach/2,
+         compile/1]).
+
+-spec empty() -> TreeNode when
+      TreeNode :: khepri_pattern_tree:tree(Payload),
+      Payload :: ?NO_PAYLOAD.
+%% @doc Returns a new empty tree node.
+%%
+%% @see tree().
+%% @see tree_node().
+
+empty() ->
+    #pattern_node{}.
+
+-spec is_empty(PatternTree) -> IsEmpty when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      IsEmpty :: boolean(),
+      Payload :: payload().
+%% @doc Checks whether the given pattern tree is empty.
+%%
+%% A pattern tree node is empty if it contains no payload and has no children.
+%%
+%% @see empty/0.
+
+is_empty(#pattern_node{payload = ?NO_PAYLOAD, child_nodes = ChildNodes})
+  when ChildNodes =:= #{} ->
+    true;
+is_empty(_PatternTree) ->
+    false.
+
+-spec update(PatternTree, PathPattern, UpdateFun) -> Ret when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      PathPattern :: khepri_path:native_pattern(),
+      UpdateFun :: update_fun(Payload),
+      Ret :: khepri_pattern_tree:tree(Payload),
+      Payload :: payload().
+%% @doc Updates the node of the given pattern tree with the given update
+%% function.
+%%
+%% If any pattern components of `PathPattern' do not yet exist in the tree,
+%% this function will add any necessary branches to the tree using empty tree
+%% nodes.
+%%
+%% If the tree node for the given `PathPattern' does not yet exist, the
+%% `?NO_PAYLOAD' constant will be passed to the `UpdateFun'.
+%%
+%% @see empty/0.
+
+update(PatternTree, [], UpdateFun) ->
+    update_payload(PatternTree, UpdateFun);
+update(
+  #pattern_node{child_nodes = ChildNodes0} = PatternTree,
+  [Component | Rest],
+  UpdateFun) ->
+    PatternSubtree = case ChildNodes0 of
+                         #{Component := PatternNode} ->
+                             PatternNode;
+                         _ ->
+                             empty()
+                     end,
+    PatternSubtree1 = update(PatternSubtree, Rest, UpdateFun),
+    ChildNodes = maps:put(Component, PatternSubtree1, ChildNodes0),
+    PatternTree#pattern_node{child_nodes = ChildNodes}.
+
+-spec update_payload(PatternTreeNode, UpdateFun) -> Ret when
+      PatternTreeNode :: khepri_pattern_tree:tree_node(Payload),
+      UpdateFun :: update_fun(Payload),
+      Ret :: khepri_pattern_tree:tree_node(Payload),
+      Payload :: payload().
+%% @doc Updates the payload of the given node with the given update function.
+%%
+%% @private
+
+update_payload(#pattern_node{payload = Payload} = PatternTree, UpdateFun) ->
+    Payload1 = UpdateFun(Payload),
+    PatternTree#pattern_node{payload = Payload1}.
+
+-spec fold(PatternTree, Tree, Path, FoldFun, Acc) -> Ret when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      Tree :: khepri_tree:tree(),
+      Path :: khepri_path:native_path(),
+      FoldFun :: fold_fun(Payload),
+      Acc :: fold_acc(),
+      Ret :: fold_acc(),
+      Payload :: payload().
+%% @doc Folds over the given pattern tree to find all patterns in the tree
+%% which match the given path.
+%%
+%% The `FoldFun' function takes a path pattern, the payload stored in the
+%% pattern tree at that tree node, and an accumulator as arguments. Only tree
+%% nodes which have payloads are passed to this function.
+%%
+%% @see fold_fun().
+%% @see fold_acc().
+
+fold(PatternTree, Tree, Path, FoldFun, Acc) ->
+    Acc1 = fold_data(PatternTree, [], FoldFun, Acc),
+    Root = Tree#tree.root,
+    fold1(PatternTree, Root, Path, FoldFun, Acc1, []).
+
+-spec fold1(PatternTree, Node, Path, FoldFun, Acc, ReversedPath) -> Ret when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      Node :: khepri_tree:tree_node(),
+      Path :: khepri_path:native_path(),
+      FoldFun :: fold_fun(Payload),
+      Acc :: fold_acc(),
+      ReversedPath :: khepri_path:native_path(),
+      Ret :: fold_acc(),
+      Payload :: payload().
+%% @private
+
+fold1(_PatternTree, _Node, [], _FoldFun, Acc, _ReversedPath) ->
+    Acc;
+fold1(PatternTree, Parent, [Component | Rest], FoldFun, Acc0, ReversedPath) ->
+    case Parent of
+        #node{child_nodes = #{Component := Node}} ->
+            ReversedPath1 = [Component | ReversedPath],
+            CurrentPath = lists:reverse(ReversedPath1),
+            maps:fold(
+              fun(Condition, PatternSubtree, Acc) ->
+                      case khepri_condition:is_met(Condition, Component, Node) of
+                          true ->
+                              Acc1 = fold_data(
+                                       PatternSubtree, CurrentPath,
+                                       FoldFun, Acc),
+                              Acc2 = fold1(
+                                       PatternSubtree, Node, Rest,
+                                       FoldFun, Acc1, ReversedPath1),
+                              AppliesToGrandchildren =
+                              khepri_condition:applies_to_grandchildren(
+                                Condition),
+                              case AppliesToGrandchildren of
+                                  true ->
+                                      fold1(
+                                        PatternTree, Node, Rest,
+                                        FoldFun, Acc2, ReversedPath1);
+                                  false ->
+                                      Acc2
+                              end;
+                          {false, _} ->
+                              Acc
+                      end
+              end, Acc0, PatternTree#pattern_node.child_nodes);
+        _ChildNotFound ->
+            Acc0
+    end.
+
+-spec fold_data(PatternTreeNode, CurrentPath, FoldFun, Acc) -> Ret when
+      PatternTreeNode :: khepri_pattern_tree:tree_node(Payload),
+      CurrentPath :: khepri_path:native_path(),
+      FoldFun :: fold_fun(Payload),
+      Acc :: fold_acc(),
+      Ret :: fold_acc(),
+      Payload :: payload().
+%% @doc Calls the given fold function with the given tree node's payload, if
+%% the given tree node has a payload.
+%%
+%% @private
+
+fold_data(PatternTreeNode, CurrentPath, FoldFun, Acc) ->
+    case PatternTreeNode of
+        #pattern_node{payload = ?NO_PAYLOAD} ->
+            Acc;
+        #pattern_node{payload = Payload} ->
+            FoldFun(CurrentPath, Payload, Acc)
+    end.
+
+-spec foreach(PatternTree, Fun) -> Ret when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      Fun :: fun((khepri_path:native_pattern(), Payload) -> any()),
+      Payload :: payload(),
+      Ret :: ok.
+%% @doc Iterates over the path patterns and associated payloads for any
+%% patterns in the given pattern tree with payloads.
+
+foreach(PatternTree, Fun) ->
+    foreach(PatternTree, Fun, []).
+
+foreach(
+  #pattern_node{child_nodes = ChildNodes, payload = Payload},
+  Fun, ReversedPathPattern) ->
+    CurrentPathPattern = lists:reverse(ReversedPathPattern),
+    case Payload of
+        ?NO_PAYLOAD ->
+            ok;
+        _ ->
+            _ = Fun(CurrentPathPattern, Payload),
+            ok
+    end,
+    maps:foreach(
+      fun(Condition, Child) ->
+          ReversedPathPattern1 = [Condition | ReversedPathPattern],
+          foreach(Child, Fun, ReversedPathPattern1)
+      end, ChildNodes).
+
+-spec compile(PatternTree) -> Ret when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      Ret :: khepri_pattern_tree:tree(Payload),
+      Payload :: payload().
+%% @doc Compiles conditions in the given pattern tree.
+%%
+%% Some conditions must be compiled before being checked against paths and tree
+%% nodes such as ETS match specifications in the `#if_data_matches{}' condition
+%% or regular expressions in the `#if_name_matches{}' condition.
+%%
+%% The pattern tree must be compiled before running {@link fold/5} against the
+%% tree. Compiled trees should not be (de)serialized though since the compiled
+%% information depends on the runtime system.
+%%
+%% @see khepri_condition:compile/1.
+
+compile(#pattern_node{child_nodes = ChildNodes0} = PatternTree) ->
+    ChildNodes = maps:fold(
+                   fun(Condition0, Child0, Acc) ->
+                       Condition = khepri_condition:compile(Condition0),
+                       Child = compile(Child0),
+                       Acc#{Condition => Child}
+                   end, #{}, ChildNodes0),
+    PatternTree#pattern_node{child_nodes = ChildNodes}.

--- a/test/helpers.hrl
+++ b/test/helpers.hrl
@@ -23,3 +23,46 @@
 %% the same type in any call.
 -define(assertSubString(SubString, String),
         ?assertNotMatch(nomatch, string:find(String, SubString))).
+
+%% Asserts that a message matching the pattern `Pattern' <em>is</em> received
+%% by the current process in the time window `Timeout'.
+-define(assertReceive(Pattern, Timeout),
+        receive
+            Pattern ->
+                ok
+        after
+            Timeout ->
+                error(
+                  "Did not receive a message matching the given pattern "
+                  "within the timeout")
+        end).
+
+%% Asserts that a message matching the pattern `Pattern' <em>is</em> in the
+%% mailbox of the current process.
+-define(assertReceived(Pattern), ?assertReceive(Pattern, 0)).
+
+%% Asserts that a message matching the pattern `Pattern' is <em>not</em>
+%% received by the current process in the time window `Timeout'.
+-define(assertNotReceive(Pattern, Timeout),
+        receive
+            Pattern = Msg ->
+                error(
+                  lists:flatten(
+                    io_lib:format(
+                      "Expected no messages matching the given pattern but "
+                      "received ~p", [Msg])))
+        after
+            Timeout ->
+                ok
+        end).
+
+%% Asserts that a message matching the pattern `Pattern' is <em>not</em> in the
+%% mailbox of the current process.
+-define(assertNotReceived(Pattern), ?assertNotReceive(Pattern, 0)).
+
+%% Asserts that the `Expected' list is equal to the `Actual' list when sorted.
+-define(assertListsEqual(Expected, Actual),
+        fun() ->
+                ExpectedSorted = lists:sort(Expected),
+                ?assertEqual(ExpectedSorted, lists:sort(Actual))
+        end()).

--- a/test/pattern_tree.erl
+++ b/test/pattern_tree.erl
@@ -1,0 +1,137 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(pattern_tree).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/khepri_tree.hrl").
+-include("test/helpers.hrl").
+
+is_empty_test() ->
+    Empty = khepri_pattern_tree:empty(),
+    ?assert(khepri_pattern_tree:is_empty(Empty)),
+    NonEmpty = put_new(Empty, [stock, wood, <<"oak">>], 100),
+    ?assertNot(khepri_pattern_tree:is_empty(NonEmpty)),
+    ok.
+
+foreach_iterates_over_all_payloads_test() ->
+    PathPattern1 = [stock, wood, <<"oak">>],
+    Payload1 = 100,
+    PathPattern2 = [stock, wood, <<"birch">>],
+    Payload2 = 200,
+    PathPattern3 = [stock, wood, <<"maple">>],
+    Payload3 = 300,
+    PatternTree0 = khepri_pattern_tree:empty(),
+    PatternTree1 = put_new(PatternTree0, PathPattern1, Payload1),
+    PatternTree2 = put_new(PatternTree1, PathPattern2, Payload2),
+    PatternTree3 = put_new(PatternTree2, PathPattern3, Payload3),
+    ok = khepri_pattern_tree:foreach(
+           PatternTree3,
+           fun(PathPattern, Payload) ->
+               self() ! {entry, PathPattern, Payload}
+           end),
+    %% NOTE: the ordering in which tree nodes are visited by foreach is not
+    %% guaranteed.
+    ?assertReceived({entry, PathPattern1, Payload1}),
+    ?assertReceived({entry, PathPattern2, Payload2}),
+    ?assertReceived({entry, PathPattern3, Payload3}),
+    ?assertNotReceived(_),
+    ok.
+
+update_passes_current_payload_test() ->
+    PathPattern = [stock, wood, <<"oak">>],
+    PatternTree0 = khepri_pattern_tree:empty(),
+    Payload1 = 100,
+    PatternTree1 = khepri_pattern_tree:update(
+                     PatternTree0, PathPattern,
+                     fun(Payload) ->
+                             ?assertEqual(?NO_PAYLOAD, Payload),
+                             Payload1
+                     end),
+    _ = khepri_pattern_tree:update(
+          PatternTree1, PathPattern,
+          fun(Payload) ->
+                  ?assertEqual(Payload1, Payload)
+          end),
+    ok.
+
+fold_finds_all_patterns_matching_a_path_test() ->
+    TreePayload = #p_data{data = 100},
+    Tree = lists:foldl(
+             fun(Path, Tree0) ->
+                 {ok, Tree, _AppliedChanges, _NodeProps} =
+                 khepri_tree:insert_or_update_node(
+                   Tree0, Path, TreePayload, #{}, #{}),
+                 Tree
+             end, #tree{}, [[stock, wood, <<"oak">>],
+                            [stock, wood, <<"birch">>]]),
+    PathPatterns =
+    [[stock, wood, <<"oak">>],                               %% 1
+     [stock, wood, <<"birch">>],                             %% 2
+     [stock, wood, <<"oak">>],                               %% 3
+     [stock, wood, #if_has_data{}],                          %% 4
+     [stock, wood, #if_child_list_length{count = 0}],        %% 5
+     [stock, #if_child_list_length{count = 2}],              %% 6
+     [stock, wood, #if_name_matches{regex = "^b"}]],         %% 7
+    PatternTree0 = lists:foldl(
+                     fun({Index, PathPattern}, Acc) ->
+                             khepri_pattern_tree:update(
+                               Acc, PathPattern,
+                               fun (?NO_PAYLOAD) ->
+                                       [Index];
+                                   (Indices) ->
+                                       [Index | Indices]
+                               end)
+                     end,
+                     khepri_pattern_tree:empty(),
+                     lists_enumerate(PathPatterns)),
+    PatternTree = khepri_pattern_tree:compile(PatternTree0),
+    MatchingIndices = fun(Path) ->
+                              khepri_pattern_tree:fold(
+                                PatternTree, Tree, Path,
+                                fun(_PathPattern, Indices, Acc) ->
+                                    Acc ++ Indices
+                                end, [])
+                      end,
+    ?assertListsEqual(
+      [1, 3, 4, 5, 6],
+      MatchingIndices([stock, wood, <<"oak">>])),
+    ?assertListsEqual(
+      [2, 4, 5, 6, 7],
+      MatchingIndices([stock, wood, <<"birch">>])),
+    ?assertListsEqual(
+      [6],
+      MatchingIndices([stock, wood, <<"maple">>])),
+    ok.
+
+%% Helper functions.
+
+-spec put_new(PatternTree, PathPattern, Payload) -> Ret when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      PathPattern :: khepri_path:native_pattern(),
+      Payload :: term(),
+      Ret :: khepri_pattern_tree:tree(Payload).
+
+put_new(PatternTree, PathPattern, Data) ->
+    khepri_pattern_tree:update(
+      PatternTree, PathPattern,
+      fun(Payload) ->
+              ?assertEqual(?NO_PAYLOAD, Payload),
+              Data
+      end).
+
+%% TODO: When Erlang/OTP 25 is the minimum supported version, remove this
+%% function and replace its callers with `lists:enumerate/1'.
+lists_enumerate(List) ->
+    lists_enumerate(List, 1, []).
+
+lists_enumerate([Head | Rest], Index, Acc) ->
+    lists_enumerate(Rest, Index + 1, [{Index, Head} | Acc]);
+lists_enumerate([], _Index, Acc) ->
+    lists:reverse(Acc).


### PR DESCRIPTION
~Depends on #187~

The main tree structure used to store data in the Khepri store is a tree where each edge is a path component and that tree can look up all matching paths for a given pattern. This change introduces a new tree structure that instead uses pattern components as edges and can be used to look up all matching patterns for a given path.

This replaces the data structure used to hold projections in the machine's state. The prior structure was a mapping from projections to path patterns. Every change to the store was checked against all patterns for registered projections using `khepri_tree:does_path_match/3`. The existing approach is fast in practice but it duplicates some work: pattern components shared between multiple patterns would all be re-compiled and re-checked for each projection and for every change to the store. The new pattern tree eliminates the duplicate work and saves a small but noticeable amount of time when a store uses many projections and sees a large number of changes.

In particular I tested this against a `rabbitmqctl import_definitions` of 1 million topic bindings against the `khepri` branch in the server's repository. The time with this change is now an improvement over mnesia:

| Store                  | Time (seconds, lower is better) |
|---                     |---                              |
| Mnesia                 | 200.64                          |
| Khepri (main)          | 238.17                          |
| Khepri w/ pattern tree | 158.32                          |

<details><summary>We can compare the flamegraphs recorded during these tests...</summary>

`main`:

![main](https://user-images.githubusercontent.com/21230295/225439437-6244e852-6627-4384-9e47-28621901836c.svg)

This branch:

![pattern-tree](https://user-images.githubusercontent.com/21230295/225439522-7c0a6167-1a94-4b75-a266-4c9e7d4a9d7c.svg)

One of the largest spans in the flamegraph on `main` is around the `khepri_machine:create_projection_side_effects/3` function which spends much of its time in `khepri_tree:does_path_match/3,4` and `khepri_condition:compile/1` under that. This branch eliminates the duplicate `khepri_condition:compile/1` calls and spends less time checking whether patterns match.

</details>