### PR TITLE
khepri_tree: Rename `find_matching_nodes/5` as `fold/5`

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -169,7 +169,7 @@ fold(StoreId, PathPattern, Fun, Acc, Options)
     {QueryOptions, TreeOptions} = split_query_options(Options),
     Query = fun(#?MODULE{tree = Tree}) ->
                     try
-                        khepri_tree:find_matching_nodes(
+                        khepri_tree:fold(
                           Tree, PathPattern1, Fun, Acc, TreeOptions)
                     catch
                         Class:Reason:Stacktrace ->

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -24,7 +24,7 @@
          count_node_cb/3,
 
          find_matching_nodes/3,
-         find_matching_nodes/5,
+         fold/5,
          delete_matching_nodes/4,
          insert_or_update_node/5,
          does_path_match/3,
@@ -343,7 +343,7 @@ update_keep_while_conds_revidx(
 %% @private
 
 find_matching_nodes(Tree, PathPattern, TreeOptions) ->
-    find_matching_nodes(
+    fold(
       Tree, PathPattern,
       fun collect_node_props_cb/3, #{},
       TreeOptions).
@@ -370,7 +370,7 @@ collect_node_props_cb(Path, NodeProps, Map) when is_map(Map) ->
 count_node_cb(_Path, _NodeProps, Count) when is_integer(Count) ->
     Count + 1.
 
--spec find_matching_nodes(Tree, PathPattern, Fun, Acc, TreeOptions) ->
+-spec fold(Tree, PathPattern, Fun, Acc, TreeOptions) ->
     Ret when
       Tree :: tree(),
       PathPattern :: khepri_path:native_pattern(),
@@ -378,9 +378,12 @@ count_node_cb(_Path, _NodeProps, Count) when is_integer(Count) ->
       Acc :: khepri:fold_acc(),
       TreeOptions :: khepri:tree_options(),
       Ret :: khepri:ok(Acc) | khepri:error().
+%% @doc Folds the given `Fun' over each tree node which matches the path
+%% pattern.
+%%
 %% @private
 
-find_matching_nodes(Tree, PathPattern, Fun, Acc, TreeOptions) ->
+fold(Tree, PathPattern, Fun, Acc, TreeOptions) ->
     WalkFun = fun(Path, Node, Acc1) ->
                       find_matching_nodes_cb(
                         Path, Node, Fun, Acc1, TreeOptions)

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -424,8 +424,7 @@ count(PathPattern, Options) ->
     Fun = fun khepri_tree:count_node_cb/3,
     {_QueryOptions, TreeOptions} = khepri_machine:split_query_options(Options),
     TreeOptions1 = TreeOptions#{expect_specific_node => false},
-    Ret = khepri_tree:find_matching_nodes(
-            Tree, PathPattern1, Fun, 0, TreeOptions1),
+    Ret = khepri_tree:fold(Tree, PathPattern1, Fun, 0, TreeOptions1),
     case Ret of
         {error, ?khepri_exception(_, _) = Exception} ->
             ?khepri_misuse(Exception);
@@ -475,8 +474,7 @@ fold(PathPattern, Fun, Acc, Options) ->
      _SideEffects} = khepri_tx_adv:get_tx_state(),
     {_QueryOptions, TreeOptions} = khepri_machine:split_query_options(Options),
     TreeOptions1 = TreeOptions#{expect_specific_node => false},
-    Ret = khepri_tree:find_matching_nodes(
-            Tree, PathPattern1, Fun, Acc, TreeOptions1),
+    Ret = khepri_tree:fold(Tree, PathPattern1, Fun, Acc, TreeOptions1),
     case Ret of
         {error, ?khepri_exception(_, _) = Exception} ->
             ?khepri_misuse(Exception);

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -130,8 +130,7 @@ do_get_many(PathPattern, Fun, Acc, Options) ->
     PathPattern1 = path_from_string(PathPattern),
     {_QueryOptions, TreeOptions} = khepri_machine:split_query_options(Options),
     {#khepri_machine{tree = Tree}, _SideEffects} = get_tx_state(),
-    Ret = khepri_tree:find_matching_nodes(
-            Tree, PathPattern1, Fun, Acc, TreeOptions),
+    Ret = khepri_tree:fold(Tree, PathPattern1, Fun, Acc, TreeOptions),
     case Ret of
         {error, ?khepri_exception(_, _) = Exception} ->
             ?khepri_misuse(Exception);


### PR DESCRIPTION
This change renames `khepri_tree:find_matching_nodes/5` to the more fitting name `fold/5`. `find_matching_nodes` is still a good name for the 3-arity version of this function: it accumulates a map of the matching nodes and their properties. However the 5-arity function is a more generic fold function similar to `maps:fold/3` or `lists:foldl/3` so the name should reflect that.

See the comments in https://github.com/rabbitmq/khepri/pull/188#discussion_r1142347075