### PR TITLE
Memoize the compiled projections pattern tree

### DIFF
--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -26,8 +26,7 @@
                event_filter := khepri_evf:event_filter()}},
          emitted_triggers = [] :: [khepri_machine:triggered()],
          projections = khepri_pattern_tree:empty() ::
-                       khepri_pattern_tree:tree(
-                         khepri_projection:projection()),
+                       khepri_machine:projection_tree(),
          metrics = #{} :: #{applied_command_count => non_neg_integer()}}).
 
 -record(khepri_machine_aux,


### PR DESCRIPTION
Pattern trees must be compiled with `khepri_pattern_tree:compile/1` before they can be queried into with `khepri_pattern_tree:fold/5`. We can't store the compiled pattern tree in the `khepri_machine` state though because some conditions like `#if_name_matches{}`, `#if_path_matches{}` and `#if_data_matches{}` create runtime-only values during compilation (compiled regular expressions and compiled match specifications) which cannot be serialized/deserialized to/from the Ra log. Currently we recompile the projections pattern tree once per change to the store just before looking up projections with `khepri_pattern_tree:fold/5`. The projections pattern tree changes very infrequently though so this wastes some work.

This change computes the compiled projection pattern tree lazily and stores the result in the process dictionary. This ensures that the compiled pattern tree is never written to disk but allows us to re-use the compiled conditions. Cutting out this extra work improves performance slightly. The main impact is to memory consumption: this branch doesn't need to introduce duplicate new terms for compiled conditions.

<details><summary>CPU utilization...</summary><br>

These flamegraphs are from `rabbitmqctl import_definitions` runs for one million topic bindings on the `khepri` branch in the server repository.

* [`main`](https://user-images.githubusercontent.com/21230295/227579509-8bdfe6ef-c786-43ea-881e-d4481dd4378d.svg)
* [`lazily-compiled-pattern-tree`](https://user-images.githubusercontent.com/21230295/227579585-e5bc41d8-9805-46b8-bd43-81f94f726929.svg)

The difference is the near elimination of the `khepri_pattern_tree:compile/1` branch of the flamegraph. If we zoom in on `khepri_machine:create_tree_change_side_effects/4` this is more visible - before:

![main](https://user-images.githubusercontent.com/21230295/227579232-e3ee4b54-2f7d-4eea-b87a-2397c353d9fb.png)

after:

![lazily-compiled-pattern-tree](https://user-images.githubusercontent.com/21230295/227579159-0385af97-2f06-4655-b02c-be02c35e73d0.png)

<hr/></details>

<details><summary>Memory consumption...</summary><br>

I also ran the one million topic binding import test case with `hprof` running in the background. (`hprof` is a new memory profiler that might be added in a future OTP release.)

Tracing the memory activities for the `metadata_store` process, this change reduces the consumption for that process across the definition import by 5% - about 200 million words of memory.

When running OTP including `hprof`, this can be reproduced with the following code:

```erl
MetadataStorePid = erlang:whereis(metadata_store),
hprof:start(),
hprof:set_pattern('_', '_', '_'),
hprof:enable_trace(MetadataStorePid),
timer:sleep(160_000),
hprof:disable_trace(MetadataStorePid),
hprof:format(hprof:inspect(hprof:collect())).
```

<hr/></details>

<details><summary>Import time...</summary><br>

The time it takes to import definitions is reduced with these changes. The change is not exceptional though - in most cases only a few seconds are shaved off for even very large inputs.

| Case              | mnesia | khepri with cache | khepri main |
|---                |---     |---                |---          |
| 100k classic Qs   | 15.20  | 15.43             | 15.62       |
| 1M topic bindings | 202.07 | 159.10            | 161.44      |
| 100k users        | 12.83  | 15.39             | 16.35       |

(All times are in seconds.)

</details>