### PR TITLE
projections: Trigger changes for leaf node deletions

### DIFF
--- a/test/projections.erl
+++ b/test/projections.erl
@@ -427,6 +427,14 @@ delete_removes_entries_recursively_test_() ->
             lists:sort(
               [{Path1, Data}, {Path2, Data}, {Path3, Data}]),
             lists:sort(ets:tab2list(?MODULE)))},
+         {"Delete one of the leaf nodes",
+          ?_assertEqual(
+            ok,
+            khepri:delete(?FUNCTION_NAME, Path3))},
+         {"List the projection",
+          ?_assertEqual(
+            #{Path1 => Data, Path2 => Data},
+            maps:from_list(ets:tab2list(?MODULE)))},
          {"Delete a branch of the tree",
           %% All tree nodes in the branch are removed from the tree and all
           %% projection records are removed from the projection table.


### PR DESCRIPTION
This change fixes a regression introduced with the refactor to the pattern tree to hold projections for a specific case of deletions from the tree tree.

To hit this edge-case, a path must be deleted from the tree with no other sibling tree nodes. In other words, the deletion must not trigger any ancestor tree nodes from being cleaned up by the default keep-while conditions. Also, a projection must be registered to a path pattern which would match this deleted path.

For deletion changes, we look at all of the children of the deleted path to check if child node deletions should trigger any projections. This block mistakenly forgot to also check if the deleted path itself should trigger any projections.