### PR TITLE
Add a link to the repository as a GitHub ribbon

### DIFF
--- a/doc/_head.html
+++ b/doc/_head.html
@@ -1,1 +1,2 @@
 <link rel="icon" href="khepri-favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css" />

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -22,6 +22,8 @@ algorithm</a>. In Ra parlance, Khepri is a state machine in a Ra cluster.
 This page <strong>describes all the concepts in Khepri</strong> and points the
 reader to the modules' documentation for more details.
 
+<a class="github-fork-ribbon" href="https://github.com/rabbitmq/khepri" data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
+
 <hr/>
 
 == Why Khepri? ==


### PR DESCRIPTION
We lacked this reference back to the GitHub repository so far.

This ribbon is quite common for GitHub-hosted projects. Here, we use the CSS version of the ribbon:
https://simonwhitaker.github.io/github-fork-ribbon-css/