### PR TITLE
Special-case trivial "copy"-style projections

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -477,12 +477,13 @@ register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options)
 register_projection(
   StoreId, PathPattern0,
   #khepri_projection{name = Name,
-                     projection_fun = StandaloneFun,
+                     projection_fun = ProjectionFun,
                      ets_options = EtsOptions} = Projection,
   Options0)
   when is_atom(Name) andalso
        is_list(EtsOptions) andalso
-       ?IS_HORUS_STANDALONE_FUN(StandaloneFun) ->
+       (?IS_HORUS_STANDALONE_FUN(ProjectionFun) orelse
+        ProjectionFun =:= copy) ->
     Options = Options0#{reply_from => local},
     PathPattern = khepri_path:from_string(PathPattern0),
     khepri_path:ensure_is_valid(PathPattern),

--- a/src/khepri_projection.hrl
+++ b/src/khepri_projection.hrl
@@ -11,6 +11,9 @@
          name :: atom(),
          %% A function compiled by Horus which "projects" entries from
          %% a Khepri store into records stored in a "projected" ETS table.
-         projection_fun :: horus:horus_fun(),
+         %% This field may be the atom `copy' instead. This is a special case
+         %% for a simple and common-case projection that inserts each tree
+         %% node's payload as the record in the ETS table.
+         projection_fun :: copy | horus:horus_fun(),
          %% Options passed to `ets:new/2'
          ets_options :: [atom() | tuple()]}).


### PR DESCRIPTION
A common case for projection functions is to re-use each tree node's payload as the record for the projection ETS table. In terms of a simple projection, this is:

```erl
ProjectionFun = fun(_Path, Payload) -> Payload end
```

This change allows passing a special 'copy' atom to stand for this case. When triggering a projection we don't execute a Horus function so 'copy' projections have minimal overhead.