### PR TITLE
GitHub Actions: Test against Erlang/OTP 26 stable release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,18 +11,19 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25, 26.0-rc2]
+        otp_version: [24, 25, 26]
         os: [ubuntu-latest, windows-latest]
         exclude:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.
           - otp_version: 24
             os: windows-latest
-          # The download for 26.0-rc2 currently hangs for 30min+ for Windows builds.
-          - otp_version: 26.0-rc2
+          # setup-beam currently hangs for 30+ minutes for Windows builds and
+          # Erlang/OTP 26.0.
+          - otp_version: 26
             os: windows-latest
 
     env:
-      RUN_DIALYZER_ON_OTP_RELEASE: 25
+      RUN_DIALYZER_ON_OTP_RELEASE: 26
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
We also run Dialyzer from Erlang/OTP 26.

There is still an issue with setup-beam which prevents us from testing with Erlang/OTP 26 on Windows...