### PR TITLE
khepri_utils: Gracefully handle unavailable default applications

### DIFF
--- a/src/khepri_utils.erl
+++ b/src/khepri_utils.erl
@@ -255,7 +255,10 @@ init_list_of_modules_to_skip() ->
                                 true  -> ok;
                                 false -> application:load(App)
                             end,
-                        {ok, Mods} = application:get_key(App, modules),
+                        Mods = case application:get_key(App, modules) of
+                                   {ok, Mods0} -> Mods0;
+                                   undefined   -> []
+                               end,
                         lists:foldl(
                           fun(Mod, Modules1) ->
                                   Modules1#{Mod => true}


### PR DESCRIPTION
If the Khepri application is started and any of the default applications (mnesia, sasl, ssl, and khepri itself) are not available, `application:get_key/2` will return `undefined`, causing a badmatch that will terminate the Khepri application. Instead we can gracefully handle these applications being unavailable and not include their modules in the list of modules to skip when extracting functions.

Fixes #214