### PR TITLE
khepri_cluster: Don't log a warning in `query_members()` when store is stopped

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1034,7 +1034,7 @@ do_query_members(StoreId, RaServer, QueryType, Timeout) ->
     case ra:members(Arg, Timeout) of
         {ok, Members, _} ->
             Members;
-        {error, noproc} = Error ->
+        {error, noproc} ->
             case khepri_utils:is_ra_server_alive(RaServer) of
                 true ->
                     NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),
@@ -1043,9 +1043,10 @@ do_query_members(StoreId, RaServer, QueryType, Timeout) ->
                     do_query_members(
                       StoreId, RaServer, QueryType, NewTimeout);
                 false ->
-                    ?LOG_WARNING(
-                       "Failed to query members in store \"~s\": ~p",
-                       [StoreId, Error]),
+                    ?LOG_DEBUG(
+                       "Cannot query members in store \"~s\": "
+                       "the store is stopped or non-existent",
+                       [StoreId]),
                     []
             end;
         Error ->

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -127,13 +127,15 @@ get_store_info_on_non_existing_store_test_() ->
          "\033[1;32m== CLUSTER MEMBERS ==\033[0m\n"
          "\n",
          begin
+             #{level := OldLogLevel} = logger:get_primary_config(),
+             _ = logger:set_primary_config(level, debug),
              Log = helpers:capture_log(
                      fun() ->
                              khepri:info(
                                non_existing_store, #{timeout => 1000})
                      end),
-             ?assertSubString(<<"Failed to query members in store">>, Log),
-             ?assertSubString(<<"{error,noproc}">>, Log),
+             _ = logger:set_primary_config(level, OldLogLevel),
+             ?assertSubString(<<"Cannot query members in store">>, Log),
              ?capturedOutput
          end)]}.
 


### PR DESCRIPTION
We simply log a debug message and return an empty list.