### PR TITLE
khepri_cluster: Make `join/3` idempotent

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -616,7 +616,11 @@ join({StoreId, RemoteNode} = _RemoteMember, Timeout) ->
 %%
 %% As part of this function, the local Khepri store will reset. It means it
 %% will leave the cluster it is already part of (if any) and all its data
-%% removed.
+%% removed. This is also the case if the node is already part of the given
+%% cluster (i.e. the joining node will be reset and clustered again).
+%%
+%% If a clustered node loses its data directory for any reason, this function
+%% can be called again to make it join the cluster again and restore its data.
 %%
 %% @param StoreId the ID of the local Khepri store.
 %% @param RemoteNode the name of remote Erlang node running Khepri to join.
@@ -760,6 +764,12 @@ do_join_locked(StoreId, ThisMember, RemoteNode, Timeout) ->
             ?LOG_DEBUG(
                "Cluster for store \"~s\" successfully expanded",
                [StoreId]),
+            ok;
+        {error, already_member} ->
+            ?LOG_DEBUG(
+               "This node (~0p) is already a member of the remote node's "
+               "cluster (~0p)",
+               [ThisMember, RemoteMember]),
             ok;
         {error, cluster_change_not_permitted} ->
             T2 = khepri_utils:start_timeout_window(Timeout1),

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -32,6 +32,7 @@
          initial_members_are_ignored/1,
          can_start_a_three_node_cluster/1,
          can_join_several_times_a_three_node_cluster/1,
+         can_rejoin_after_a_reset_in_a_three_node_cluster/1,
          can_restart_nodes_in_a_three_node_cluster/1,
          can_reset_a_cluster_member/1,
          fail_to_join_if_not_started/1,
@@ -51,6 +52,7 @@ all() ->
      initial_members_are_ignored,
      can_start_a_three_node_cluster,
      can_join_several_times_a_three_node_cluster,
+     can_rejoin_after_a_reset_in_a_three_node_cluster,
      can_restart_nodes_in_a_three_node_cluster,
      can_reset_a_cluster_member,
      fail_to_join_if_not_started,
@@ -94,6 +96,7 @@ init_per_testcase(Testcase, Config)
 init_per_testcase(Testcase, Config)
   when Testcase =:= can_start_a_three_node_cluster orelse
        Testcase =:= can_join_several_times_a_three_node_cluster orelse
+       Testcase =:= can_rejoin_after_a_reset_in_a_three_node_cluster orelse
        Testcase =:= can_restart_nodes_in_a_three_node_cluster orelse
        Testcase =:= can_reset_a_cluster_member orelse
        Testcase =:= fail_to_join_if_not_started orelse
@@ -475,7 +478,82 @@ can_join_several_times_a_three_node_cluster(Config) ->
        rpc:call(
          LeaderNode1, khepri_cluster, join, [StoreId, hd(OtherNodes1)])),
 
-    ct:pal("Use database after recreating the cluster it"),
+    ct:pal("Use database after recreating the cluster"),
+    ?assertEqual(
+       ok,
+       rpc:call(LeaderNode1, khepri, put, [StoreId, [foo], value2])),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, value2},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, Nodes),
+
+    ok.
+
+can_rejoin_after_a_reset_in_a_three_node_cluster(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1, Node2, Node3] = Nodes = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    #{ra_system := RaSystem} = maps:get(Node1, PropsPerNode),
+    StoreId = RaSystem,
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 rpc:call(Node, khepri, start, [RaSystem, StoreId]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 rpc:call(Node, khepri_cluster, join, [StoreId, Node3]))
+      end, [Node1, Node2]),
+
+    ct:pal("Use database after starting it"),
+    ?assertEqual(ok, rpc:call(Node1, khepri, put, [StoreId, [foo], value1])),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:get() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, value1},
+                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+      end, Nodes),
+
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, LeaderNode1} = LeaderId1,
+    OtherNodes1 = Nodes -- [LeaderNode1],
+
+    ct:pal("Stop and reset leader node"),
+    ?assertEqual(
+       ok,
+       rpc:call(
+         LeaderNode1, khepri, stop, [StoreId])),
+    Props = maps:get(LeaderNode1, PropsPerNode),
+    ?assertMatch(
+       ok,
+       rpc:call(LeaderNode1, helpers, stop_ra_system, [Props])),
+    %% The following call removes the existing data directory.
+    ?assertMatch(
+       #{},
+       rpc:call(LeaderNode1, helpers, start_ra_system, [RaSystem])),
+    ?assertEqual(
+       {ok, StoreId},
+       rpc:call(LeaderNode1, khepri, start, [RaSystem, StoreId])),
+
+    ct:pal("Make leader node join the cluster again"),
+    ?assertEqual(
+       ok,
+       rpc:call(
+         LeaderNode1, khepri_cluster, join, [StoreId, hd(OtherNodes1)])),
+
+    ct:pal("Use database after recreating the cluster"),
     ?assertEqual(
        ok,
        rpc:call(LeaderNode1, khepri, put, [StoreId, [foo], value2])),


### PR DESCRIPTION
### Why

If `khepri_cluster:join/3` is called twice in a row, the join succeeds because the joining node is reset before it joins the cluster again. This is not exactly idempotent, but the end result is the same.

However if the joining node was reset somehow (e.g. its data directory was lost) and therefore thinks it is a standalone store, calling `khepri_cluster:join/1` again would return `{error, already_member}`.

It is more comfortable if the function just does what it takes to achieve the wanted result of expanding the cluster.

### How

The `{error, already_member}` error is caught and the function returns `ok` instead. Behind the scene, Ra did the correct thing and the joining node is back in the cluster.