### PR TITLE
khepri_machine: Handle `{error,shutdown}` response from Ra queries

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -890,7 +890,8 @@ process_query_response(
   StoreId, _RaServer, true = _IsLeader, QueryFun, QueryType, Timeout,
   {error, Reason})
   when QueryType =/= local andalso ?HAS_TIME_LEFT(Timeout) andalso
-       (Reason == noproc orelse Reason == nodedown) ->
+       (Reason == noproc orelse Reason == nodedown orelse
+        Reason == shutdown) ->
     %% The cached leader is no more. We simply clear the cache
     %% entry and retry. It may time out eventually.
     khepri_cluster:clear_cached_leader(StoreId),
@@ -899,7 +900,8 @@ process_query_response(
   StoreId, RaServer, false = _IsLeader, QueryFun, QueryType, Timeout,
   {error, Reason} = Error)
   when QueryType =/= local andalso ?HAS_TIME_LEFT(Timeout) andalso
-       (Reason == noproc orelse Reason == nodedown)->
+       (Reason == noproc orelse Reason == nodedown orelse
+        Reason == shutdown) ->
     case khepri_utils:is_ra_server_alive(RaServer) of
         true ->
             %% The follower doesn't know about the new leader yet. Retry again


### PR DESCRIPTION
Ra's query functions may return `{error,shutdown}` if the server process receives the query but shuts down before it is able to reply. This is the same as the change in #211 but covers queries.