### PR TITLE
khepri_cluster: Fix how we reset a node to join a cluster

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -898,14 +898,10 @@ wait_for_cluster_readiness(StoreId, Timeout) ->
 %% @private
 
 wait_for_remote_cluster_readiness(StoreId, RemoteNode, Timeout) ->
-    Ret = rpc:call(
-            RemoteNode,
-            khepri_cluster, wait_for_cluster_readiness, [StoreId, Timeout],
-            Timeout),
-    case Ret of
-        {badrpc, _} -> {error, Ret};
-        _           -> Ret
-    end.
+    erpc:call(
+      RemoteNode,
+      khepri_cluster, wait_for_cluster_readiness, [StoreId, Timeout],
+      Timeout).
 
 -spec reset() -> Ret when
       Ret :: ok | khepri:error().

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -672,7 +672,7 @@ check_status_and_join_locked(StoreId, RemoteNode, Timeout) ->
     Prop2 = get_store_prop(StoreId, ra_server_config),
     case {RaServerRunning, Prop1, Prop2} of
         {true, {ok, RaSystem}, {ok, RaServerConfig}} ->
-            reset_and_join_locked(
+            reset_remotely_and_join_locked(
               StoreId, ThisMember, RaSystem, RaServerConfig,
               RemoteNode, Timeout);
         {false, {error, _} = Error, _} ->
@@ -693,7 +693,7 @@ check_status_and_join_locked(StoreId, RemoteNode, Timeout) ->
                    ra_server_config => Prop2}))
     end.
 
--spec reset_and_join_locked(
+-spec reset_remotely_and_join_locked(
   StoreId, ThisMember, RaSystem, RaServerConfig, RemoteNode, Timeout) ->
     Ret when
       StoreId :: khepri:store_id(),
@@ -705,15 +705,21 @@ check_status_and_join_locked(StoreId, RemoteNode, Timeout) ->
       Ret :: ok | khepri:error().
 %% @private
 
-reset_and_join_locked(
-  StoreId, ThisMember, RaSystem, RaServerConfig, RemoteNode, Timeout) ->
-    %% The local node is reset in case it is already a standalone elected
-    %% leader (which would be the case after a successful call to
-    %% `khepri_cluster:start()') or part of a cluster, and have any data.
+reset_remotely_and_join_locked(
+  StoreId, ThisMember, RaSystem, RaServerConfig, RemoteNode, Timeout)
+  when RemoteNode =/= node() ->
+    %% We attempt to remove the local Ra server from the remote cluster we
+    %% want to join.
     %%
-    %% Just after the reset, we restart it skipping the `trigger_election()'
-    %% step: this is required so that it does not become a leader before
-    %% joining the remote node. Otherwise, we hit an assertion in Ra.
+    %% This is usually a no-op because it is not part of it yet. However, if
+    %% the local Ra server lost its data on disc for whatever reason, the
+    %% cluster membership view will be inconsistent (the local Ra server won't
+    %% know about its former cluster anymore).
+    %%
+    %% Therefore, it is safer to ask the remote cluster to remove the local Ra
+    %% server, just in case. If we don't do that and the remote cluster starts
+    %% to send messages to the local Ra server, the local Ra server might
+    %% crash with a `leader_saw_append_entries_rpc_in_same_term' exception.
     %%
     %% TODO: Should we verify the cluster membership first? To avoid resetting
     %% a node which is already part of the cluster? On the other hand, such a
@@ -723,6 +729,69 @@ reset_and_join_locked(
     %% TODO: Do we want to provide an option to verify the state of the local
     %% node before resetting it? Like "if it has data in the Khepri database,
     %% abort". It may be difficult to make this kind of check atomic though.
+    RemoteMember = node_to_member(StoreId, RemoteNode),
+    ?LOG_DEBUG(
+       "Removing this node (~0p) from the remote node's cluster (~0p) to "
+       "make sure the membership view is consistent",
+       [ThisMember, RemoteMember]),
+    T1 = khepri_utils:start_timeout_window(Timeout),
+    Ret1 = ra:remove_member(RemoteMember, ThisMember, Timeout),
+    Timeout1 = khepri_utils:end_timeout_window(Timeout, T1),
+    case Ret1 of
+        {ok, _, _} ->
+            reset_locally_and_join_locked(
+              StoreId, ThisMember, RaSystem, RaServerConfig, RemoteNode,
+              Timeout1);
+        {error, not_member} ->
+            reset_locally_and_join_locked(
+              StoreId, ThisMember, RaSystem, RaServerConfig, RemoteNode,
+              Timeout1);
+        {error, cluster_change_not_permitted} ->
+            T2 = khepri_utils:start_timeout_window(Timeout1),
+            ?LOG_DEBUG(
+               "Remote cluster (reached through node ~0p) is not ready "
+               "for a membership change yet; waiting...", [RemoteNode]),
+            Ret2 = wait_for_cluster_readiness(StoreId, Timeout1),
+            Timeout2 = khepri_utils:end_timeout_window(Timeout1, T2),
+            case Ret2 of
+                ok ->
+                    reset_remotely_and_join_locked(
+                      StoreId, ThisMember, RaSystem, RaServerConfig,
+                      RemoteNode, Timeout2);
+                Error ->
+                    Error
+            end;
+        {timeout, _} = TimedOut ->
+            {error, TimedOut};
+        {error, _} = Error ->
+            Error
+    end;
+reset_remotely_and_join_locked(
+  _StoreId, _ThisMember, _RaSystem, _RaServerConfig, RemoteNode, _Timeout)
+  when RemoteNode =:= node() ->
+    ok.
+
+-spec reset_locally_and_join_locked(
+  StoreId, ThisMember, RaSystem, RaServerConfig, RemoteNode, Timeout) ->
+    Ret when
+      StoreId :: khepri:store_id(),
+      ThisMember :: ra:server_id(),
+      RaSystem :: atom(),
+      RaServerConfig :: ra_server:config(),
+      RemoteNode :: node(),
+      Timeout :: timeout(),
+      Ret :: ok | khepri:error().
+%% @private
+
+reset_locally_and_join_locked(
+  StoreId, ThisMember, RaSystem, RaServerConfig, RemoteNode, Timeout) ->
+    %% The local node is reset in case it is already a standalone elected
+    %% leader (which would be the case after a successful call to
+    %% `khepri_cluster:start()') or part of a cluster, and have any data.
+    %%
+    %% Just after the reset, we restart it skipping the `trigger_election()'
+    %% step: this is required so that it does not become a leader before
+    %% joining the remote node. Otherwise, we hit an assertion in Ra.
     T0 = khepri_utils:start_timeout_window(Timeout),
     case do_reset(RaSystem, StoreId, ThisMember, Timeout) of
         ok ->
@@ -753,11 +822,9 @@ do_join_locked(StoreId, ThisMember, RemoteNode, Timeout) ->
     ?LOG_DEBUG(
        "Adding this node (~0p) to the remote node's cluster (~0p)",
        [ThisMember, RemoteMember]),
+    RemoteMember = node_to_member(StoreId, RemoteNode),
     T1 = khepri_utils:start_timeout_window(Timeout),
-    Ret1 = rpc:call(
-             RemoteNode,
-             ra, add_member, [StoreId, ThisMember, Timeout],
-             Timeout),
+    Ret1 = ra:add_member(RemoteMember, ThisMember, Timeout),
     Timeout1 = khepri_utils:end_timeout_window(Timeout, T1),
     case Ret1 of
         {ok, _, _StoreId} ->
@@ -774,8 +841,8 @@ do_join_locked(StoreId, ThisMember, RemoteNode, Timeout) ->
         {error, cluster_change_not_permitted} ->
             T2 = khepri_utils:start_timeout_window(Timeout1),
             ?LOG_DEBUG(
-               "Remote cluster (reached through node node ~0p) is not ready "
-               "for a membership change yet; waiting", [RemoteNode]),
+               "Remote cluster (reached through node ~0p) is not ready "
+               "for a membership change yet; waiting...", [RemoteNode]),
             Ret2 = wait_for_remote_cluster_readiness(
                      StoreId, RemoteNode, Timeout1),
             Timeout2 = khepri_utils:end_timeout_window(Timeout1, T2),
@@ -796,8 +863,8 @@ do_join_locked(StoreId, ThisMember, RemoteNode, Timeout) ->
             %% point.
             _ = trigger_election(ThisMember, Timeout1),
             case Error of
-                {badrpc, _} -> {error, Error};
-                _           -> Error
+                {timeout, _} = TimedOut -> {error, TimedOut};
+                {error, _}              -> Error
             end
     end.
 

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -539,6 +539,11 @@ can_rejoin_after_a_reset_in_a_three_node_cluster(Config) ->
     ?assertMatch(
        ok,
        rpc:call(LeaderNode1, helpers, stop_ra_system, [Props])),
+
+    %% Wait for a new leader to be elected among the remaining members.
+    NewLeader = get_leader_in_store(StoreId, OtherNodes1),
+    ?assertNotEqual(LeaderId1, NewLeader),
+
     %% The following call removes the existing data directory.
     ?assertMatch(
        #{},


### PR DESCRIPTION
### Why

The initial code followed these steps:
1. It removed the local Ra server from its cluster, if any. It is usually a no-op.
2. It force-deleted the local Ra server and deleted its data on disc.
3. It restarted it without any election.
4. It asked the remote cluster to add the local Ra server as a member.

There is one problem with them if the local Ra server was a member of the remote cluster but it lost its data (for whatever reason). In this case, the local Ra server didn't know about any cluster, but the remote cluster still knew about it. When we tried to join them, depending on the order of events, the remote cluster could send a `append_entries_rpc` message to the local Ra server and the latter could crash with a `leader_saw_append_entries_rpc_in_same_term` exception. The root cause is the inconsistent view on the membership.

The remote cluster must somehow forget about the local Ra server beforehand.

### How

The new code does this:
1. It removes the local Ra server from the remote cluster, just in case. This will be a no-op in most of the cases.
2. It removes the local Ra server from its cluster, if any. This will be a no-op in most of the cases too.
3. It force-deletes the local Ra server and deletes its data on disc.
4. It restarts it without any election.
5. It asks the remote cluster to add the local Ra server as a member.

Basically, we remove the local Ra server from its own cluster and from the remote cluster it wants to join. This ensures both sides are on the same page.

While here, we do the following two changes:
* Fix a duplicate word in a log message
* Change an RPC call to a direct use of the Ra API which handles remote nodes just fine.