### PR TITLE
khepri_machine: Run the query anonymous function from the calling process

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -303,13 +303,19 @@
 %% </ul>
 
 -type query_options() :: #{timeout => timeout(),
-                           favor => favor_option()}.
+                           favor => favor_option(),
+                           copy_tree_and_run_from_caller => boolean()}.
 %% Options used in queries.
 %%
 %% <ul>
 %% <li>`timeout' is passed to Ra query processing function.</li>
 %% <li>`favor' indicates where to put the cursor between freshness of the
 %% returned data and low latency of queries; see {@link favor_option()}.</li>
+%% <li>`copy_tree_and_run_from_caller' indicates if the query anonymous
+%% function should run from the calling process instead of the Ra process.
+%% This allows to recursively query the Khepri store from the anonymous
+%% function. However, this means the Khepri tree is copied to the calling
+%% process. Defaults to `false'</li>
 %% </ul>
 
 -type tree_options() :: #{expect_specific_node => boolean(),

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -39,7 +39,7 @@ query_a_node_test_() ->
              khepri:get(?FUNCTION_NAME, [foo])
          end)]}.
 
-query_nested_in_other_query_test_() ->
+correct_query_nested_in_other_query_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -51,8 +51,28 @@ query_nested_in_other_query_test_() ->
              khepri:map(
                ?FUNCTION_NAME,
                [foo],
+               fun([foo], _) -> khepri:get(?FUNCTION_NAME, [foo]) end,
+               #{copy_tree_and_run_from_caller => true})
+         end)]}.
+
+-if(?OTP_RELEASE >= 25).
+%% We only test this starting from Erlang/OTP 25.0 because previous versions
+%% didn't have the "calling self" check.
+incorrect_query_nested_in_other_query_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertExit(
+         {calling_self, _},
+         begin
+             _ = khepri:put(
+                   ?FUNCTION_NAME, [foo], khepri_payload:data(foo_value)),
+             khepri:map(
+               ?FUNCTION_NAME,
+               [foo],
                fun([foo], _) -> khepri:get(?FUNCTION_NAME, [foo]) end)
          end)]}.
+-endif.
 
 delete_a_node_test_() ->
     {setup,

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -39,6 +39,21 @@ query_a_node_test_() ->
              khepri:get(?FUNCTION_NAME, [foo])
          end)]}.
 
+query_nested_in_other_query_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, #{[foo] => {ok, foo_value}}},
+         begin
+             _ = khepri:put(
+                   ?FUNCTION_NAME, [foo], khepri_payload:data(foo_value)),
+             khepri:map(
+               ?FUNCTION_NAME,
+               [foo],
+               fun([foo], _) -> khepri:get(?FUNCTION_NAME, [foo]) end)
+         end)]}.
+
 delete_a_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,


### PR DESCRIPTION
### Why

Before this change, the anonymous function passed to `khepri_machine:fold/5` was executed by the Ra server process. This had two downsides:
* it blocked the Ra server to serve writes
* the anonymous function couldn't query the Ra server itself because it would deadlock

### How

The alternative implemented in this patch is to get the whole Khepri tree from the Ra server, then run the anonymous function, this time from the calling process.

The downside is that the whole Khepri tree is copied to that calling process.