### PR TITLE
khepri_machine: Use cached leader for async commands

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -740,8 +740,9 @@ process_sync_command(StoreId, Command, Options) ->
     end.
 
 process_async_command(StoreId, Command, Correlation, Priority) ->
-    LocalServerId = {StoreId, node()},
-    ra:pipeline_command(LocalServerId, Command, Correlation, Priority).
+    LeaderId = khepri_cluster:get_cached_leader(StoreId),
+    RaServer = use_leader_or_local_ra_server(StoreId, LeaderId),
+    ra:pipeline_command(RaServer, Command, Correlation, Priority).
 
 -spec select_command_type(Options) -> CommandType when
       Options :: khepri:command_options(),


### PR DESCRIPTION
Async commands will fail to be applied unless they're sent to the cluster's current leader. With this change we always try to use the cached leader from synchronous commands if available and use the local member if the leader isn't cached. The caller can then update the cached leader value when the async response says that the command was sent against a non-leader member, like so:

```erlang
receive
    {ra_event,
     FromId,
     {rejected, {not_leader, MaybeLeader, CorrelationId}}} ->
        ok = khepri_cluster:cache_leader_if_changed(
               StoreId, FromId, MaybeLeader),
        %% ... retry the command for `CorrelationId' ...
        ok
end
```