### PR TITLE
Replace `wait_for_async_ret` with `handle_async_ret` for handling async Ra events

### DIFF
--- a/src/khepri_adv.erl
+++ b/src/khepri_adv.erl
@@ -360,8 +360,8 @@ put(StoreId, PathPattern, Data) ->
 %% khepri:command_options()}, {@link khepri:tree_options()} and {@link
 %% khepri:put_options()}.
 %%
-%% When doing an asynchronous update, the {@link khepri:wait_for_async_ret/1}
-%% function can be used to receive the message from Ra.
+%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% function should be used to handle the message received from Ra.
 %%
 %% The returned `{ok, NodeProps}' tuple contains a map with the properties and
 %% payload (if any) of the targeted tree node as they were before the put.
@@ -481,8 +481,8 @@ put_many(StoreId, PathPattern, Data) ->
 %% khepri:command_options()}, {@link khepri:tree_options()} and {@link
 %% khepri:put_options()}.
 %%
-%% When doing an asynchronous update, the {@link khepri:wait_for_async_ret/1}
-%% function can be used to receive the message from Ra.
+%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% function should be used to handle the message received from Ra.
 %%
 %% Example:
 %% ```
@@ -847,8 +847,8 @@ delete(PathPattern, Options) when is_map(Options) ->
 %% payload (if any) of the targeted tree node as they were before the delete.
 %% If the targeted tree node didn't exist, `NodeProps' will be an empty map.
 %%
-%% When doing an asynchronous update, the {@link khepri:wait_for_async_ret/1}
-%% function can be used to receive the message from Ra.
+%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% function should be used to handle the message received from Ra.
 %%
 %% Example:
 %% ```
@@ -951,8 +951,8 @@ delete_many(PathPattern, Options) when is_map(Options) ->
 %% map containing the properties and payload (if any) of that deleted tree
 %% node as they were before the delete.
 %%
-%% When doing an asynchronous update, the {@link khepri:wait_for_async_ret/1}
-%% function can be used to receive the message from Ra.
+%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% function should be used to handle the message received from Ra.
 %%
 %% Example:
 %% ```

--- a/test/async_option.erl
+++ b/test/async_option.erl
@@ -493,8 +493,3 @@ wait_for_async_error_test_() ->
              end
          end)
      ]}.
-
-wait_for_async_ret_but_no_async_call_test() ->
-    ?assertEqual(
-       {error, timeout},
-       khepri:wait_for_async_ret(1, 100)).


### PR DESCRIPTION
This is similar to `wait_for_async_ret/1,2` except that the caller is expected to `receive` the Ra event. This is necessary because the Ra event sent when a batch of commands is applied includes a list of correlation and result pairs, making it impossible to use a selective receive to look for a single correlation ID.

We could alternatively map the `ra_event` message into some other value like `{ok, Correlations} | {error, CorrelationId}` but this isn't much easier to work with than the `ra_event`s themselves and would be brittle for changes to `ra_event`. Instead we leave it to the caller to receive and handle the events. This function is then responsible only for calling internal functions to update the cached leader for the given store ID.

I've also added deprecations for `wait_for_async_ret/1,2` since it can't be used to reliably find if a given correlation ID was applied. Instead we should prefer to have the caller `receive` the Ra event and handle the correlation IDs within.