### PR TITLE
khepri_machine: Define the Ra machine version to 0

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -50,7 +50,8 @@
          handle_aux/6,
          apply/3,
          state_enter/2,
-         overview/1]).
+         overview/1,
+         version/0]).
 
 %% For internal use only.
 -export([clear_cache/1,
@@ -1315,6 +1316,9 @@ overview(#?MODULE{config = #config{store_id = StoreId},
       tree => NodeTree,
       triggers => Triggers,
       keep_while_conds => KeepWhileConds}.
+
+version() ->
+    0.
 
 %% -------------------------------------------------------------------
 %% Internal functions.


### PR DESCRIPTION
## Why

This is not required at this point. However, users can query the machine version without having to worry if the callback is defined (version = 0 when the callback is missing) or not.

## How

We define the first version to be 0.

Depends on rabbitmq/ra#399.