### PR TITLE
include/khepri.hrl: Expose `?IS_KHEPRI_STORE_ID/1` macro

### DIFF
--- a/include/khepri.hrl
+++ b/include/khepri.hrl
@@ -5,6 +5,8 @@
 %% Copyright © 2021-2023 VMware, Inc. or its affiliates.  All rights reserved.
 %%
 
+-define(IS_KHEPRI_STORE_ID(StoreId), is_atom(StoreId)).
+
 -define(IS_KHEPRI_NODE_ID(PathComponent),
         (is_atom(PathComponent) orelse is_binary(PathComponent))).
 

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -604,7 +604,7 @@ is_empty() ->
 %%
 %% @see is_empty/2.
 
-is_empty(StoreId) when ?IS_STORE_ID(StoreId) ->
+is_empty(StoreId) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     is_empty(StoreId, #{});
 is_empty(Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -676,7 +676,7 @@ get(PathPattern) ->
 %%
 %% @see get/3.
 
-get(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+get(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     get(StoreId, PathPattern, #{});
 get(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -788,7 +788,7 @@ get_or(PathPattern, Default) ->
 %%
 %% @see get_or/4.
 
-get_or(StoreId, PathPattern, Default) when ?IS_STORE_ID(StoreId) ->
+get_or(StoreId, PathPattern, Default) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     get_or(StoreId, PathPattern, Default, #{});
 get_or(PathPattern, Default, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -900,7 +900,7 @@ get_many(PathPattern) ->
 %%
 %% @see get_many/3.
 
-get_many(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+get_many(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     get_many(StoreId, PathPattern, #{});
 get_many(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -998,7 +998,7 @@ get_many_or(PathPattern, Default) ->
 %%
 %% @see get_many_or/4.
 
-get_many_or(StoreId, PathPattern, Default) when ?IS_STORE_ID(StoreId) ->
+get_many_or(StoreId, PathPattern, Default) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     get_many_or(StoreId, PathPattern, Default, #{});
 get_many_or(PathPattern, Default, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1100,7 +1100,7 @@ exists(PathPattern) ->
 %%
 %% @see exists/3.
 
-exists(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+exists(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     exists(StoreId, PathPattern, #{});
 exists(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1193,7 +1193,7 @@ has_data(PathPattern) ->
 %%
 %% @see has_data/3.
 
-has_data(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+has_data(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     has_data(StoreId, PathPattern, #{});
 has_data(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1288,7 +1288,7 @@ is_sproc(PathPattern) ->
 %%
 %% @see is_sproc/3.
 
-is_sproc(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+is_sproc(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     is_sproc(StoreId, PathPattern, #{});
 is_sproc(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1382,7 +1382,7 @@ count(PathPattern) ->
 %%
 %% @see count/3.
 
-count(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+count(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     count(StoreId, PathPattern, #{});
 count(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1473,7 +1473,7 @@ fold(PathPattern, Fun, Acc) ->
 %%
 %% @see fold/5.
 
-fold(StoreId, PathPattern, Fun, Acc) when ?IS_STORE_ID(StoreId) ->
+fold(StoreId, PathPattern, Fun, Acc) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     fold(StoreId, PathPattern, Fun, Acc, #{});
 fold(PathPattern, Fun, Acc, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1577,7 +1577,7 @@ foreach(PathPattern, Fun) ->
 %%
 %% @see foreach/4.
 
-foreach(StoreId, PathPattern, Fun) when ?IS_STORE_ID(StoreId) ->
+foreach(StoreId, PathPattern, Fun) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     foreach(StoreId, PathPattern, Fun, #{});
 foreach(PathPattern, Fun, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1683,7 +1683,7 @@ map(PathPattern, Fun) ->
 %%
 %% @see map/4.
 
-map(StoreId, PathPattern, Fun) when ?IS_STORE_ID(StoreId) ->
+map(StoreId, PathPattern, Fun) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     map(StoreId, PathPattern, Fun, #{});
 map(PathPattern, Fun, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1789,7 +1789,7 @@ filter(PathPattern, Pred) ->
 %%
 %% @see filter/4.
 
-filter(StoreId, PathPattern, Pred) when ?IS_STORE_ID(StoreId) ->
+filter(StoreId, PathPattern, Pred) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     filter(StoreId, PathPattern, Pred, #{});
 filter(PathPattern, Pred, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -1906,7 +1906,7 @@ run_sproc(PathPattern, Args) ->
 %%
 %% @see run_sproc/4.
 
-run_sproc(StoreId, PathPattern, Args) when ?IS_STORE_ID(StoreId) ->
+run_sproc(StoreId, PathPattern, Args) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     run_sproc(StoreId, PathPattern, Args, #{});
 run_sproc(PathPattern, Args, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -2460,7 +2460,7 @@ delete(PathPattern) ->
 %%
 %% @see delete/3.
 
-delete(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+delete(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     delete(StoreId, PathPattern, #{});
 delete(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -2549,7 +2549,7 @@ delete_many(PathPattern) ->
 %%
 %% @see delete_many/3.
 
-delete_many(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+delete_many(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     delete_many(StoreId, PathPattern, #{});
 delete_many(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -2770,7 +2770,7 @@ register_trigger(TriggerId, EventFilter, StoredProcPath) ->
 %% @see register_trigger/5.
 
 register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(TriggerId) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(TriggerId) ->
     register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, #{});
 register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
   when is_atom(TriggerId) andalso is_map(Options) ->
@@ -2889,7 +2889,7 @@ register_projection(PathPattern, Projection) ->
 %% @see register_projection/4.
 
 register_projection(StoreId, PathPattern, Projection)
-  when ?IS_STORE_ID(StoreId) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) ->
     register_projection(StoreId, PathPattern, Projection, #{});
 register_projection(PathPattern, Projection, Options)
   when is_map(Options) ->
@@ -2974,7 +2974,7 @@ unregister_projection(ProjectionName) when is_atom(ProjectionName) ->
 %% @see unregister_projection/3.
 
 unregister_projection(StoreId, ProjectionName)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(ProjectionName) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(ProjectionName) ->
     unregister_projection(StoreId, ProjectionName, #{});
 unregister_projection(ProjectionName, Options)
   when is_atom(ProjectionName) andalso is_map(Options) ->
@@ -2997,7 +2997,7 @@ unregister_projection(ProjectionName, Options)
 %% otherwise.
 
 unregister_projection(StoreId, ProjectionName, Options)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(ProjectionName) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(ProjectionName) andalso
        is_map(Options) ->
     khepri_machine:unregister_projection(StoreId, ProjectionName, Options).
 
@@ -3069,7 +3069,7 @@ transaction(FunOrPath, ReadWriteOrOptions)
     StoreId = khepri_cluster:get_default_store_id(),
     transaction(StoreId, FunOrPath, ReadWriteOrOptions);
 transaction(StoreId, FunOrPath)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        (is_function(FunOrPath) orelse
         ?IS_KHEPRI_PATH_PATTERN(FunOrPath)) ->
     transaction(StoreId, FunOrPath, []).
@@ -3124,13 +3124,13 @@ transaction(StoreId, FunOrPath)
 %% @see transaction/4.
 
 transaction(StoreId, FunOrPath, Args)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        (is_function(FunOrPath) orelse
         ?IS_KHEPRI_PATH_PATTERN(FunOrPath))
        andalso is_list(Args) ->
     transaction(StoreId, FunOrPath, Args, auto);
 transaction(StoreId, FunOrPath, ReadWriteOrOptions)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        (is_function(FunOrPath) orelse
         ?IS_KHEPRI_PATH_PATTERN(FunOrPath)) andalso
        (is_atom(ReadWriteOrOptions) orelse is_map(ReadWriteOrOptions)) ->
@@ -3200,19 +3200,19 @@ transaction(FunOrPath, ReadWrite, Options)
 %% @see transaction/5.
 
 transaction(StoreId, FunOrPath, Args, ReadWrite)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        (is_function(FunOrPath) orelse
         ?IS_KHEPRI_PATH_PATTERN(FunOrPath)) andalso
        is_list(Args) andalso is_atom(ReadWrite) ->
     transaction(StoreId, FunOrPath, Args, ReadWrite, #{});
 transaction(StoreId, FunOrPath, Args, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        (is_function(FunOrPath) orelse
         ?IS_KHEPRI_PATH_PATTERN(FunOrPath)) andalso
        is_list(Args) andalso is_map(Options) ->
     transaction(StoreId, FunOrPath, Args, auto, Options);
 transaction(StoreId, FunOrPath, ReadWrite, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        (is_function(FunOrPath) orelse
         ?IS_KHEPRI_PATH_PATTERN(FunOrPath)) andalso
        is_atom(ReadWrite) andalso is_map(Options) ->
@@ -3397,7 +3397,7 @@ export(Module, ModulePriv) when is_atom(Module) ->
 %% @see export/4.
 
 export(StoreId, Module, ModulePriv)
-  when?IS_STORE_ID(StoreId) andalso is_atom(Module) ->
+  when?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(Module) ->
     export(StoreId, [?KHEPRI_WILDCARD_STAR_STAR], Module, ModulePriv);
 export(PathPattern, Module, ModulePriv)
   when is_atom(Module) ->
@@ -3449,7 +3449,7 @@ export(PathPattern, Module, ModulePriv)
 %% @see import/3.
 
 export(StoreId, PathPattern, Module, ModulePriv)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(Module) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(Module) ->
     khepri_import_export:export(StoreId, PathPattern, Module, ModulePriv).
 
 -spec import(Module, ModulePriv) -> Ret when
@@ -3503,7 +3503,7 @@ import(Module, ModulePriv) when is_atom(Module) ->
 %% @see export/3.
 
 import(StoreId, Module, ModulePriv)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(Module) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(Module) ->
     khepri_import_export:import(StoreId, Module, ModulePriv).
 
 %% -------------------------------------------------------------------

--- a/src/khepri_adv.erl
+++ b/src/khepri_adv.erl
@@ -104,7 +104,7 @@ get(PathPattern) ->
 %%
 %% @see get/3.
 
-get(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+get(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     get(StoreId, PathPattern, #{});
 get(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -211,7 +211,7 @@ get_many(PathPattern) ->
 %%
 %% @see get_many/3.
 
-get_many(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+get_many(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     get_many(StoreId, PathPattern, #{});
 get_many(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -819,7 +819,7 @@ delete(PathPattern) ->
 %%
 %% @see delete/3.
 
-delete(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+delete(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     delete(StoreId, PathPattern, #{});
 delete(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
@@ -929,7 +929,7 @@ delete_many(PathPattern) ->
 %%
 %% @see delete_many/3.
 
-delete_many(StoreId, PathPattern) when ?IS_STORE_ID(StoreId) ->
+delete_many(StoreId, PathPattern) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     delete_many(StoreId, PathPattern, #{});
 delete_many(PathPattern, Options) when is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -290,15 +290,15 @@ ensure_ra_server_config_and_start(
   RaSystemOrDataDir, StoreIdOrRaServerConfig, Timeout)
   when (?IS_DATA_DIR(RaSystemOrDataDir) orelse
         ?IS_RA_SYSTEM(RaSystemOrDataDir)) andalso
-       (?IS_STORE_ID(StoreIdOrRaServerConfig) orelse
+       (?IS_KHEPRI_STORE_ID(StoreIdOrRaServerConfig) orelse
         is_map(StoreIdOrRaServerConfig)) ->
     %% If the store ID derived from `StoreIdOrRaServerConfig' is not an atom,
     %% it will cause a cause clause exception below.
     RaServerConfig =
     case StoreIdOrRaServerConfig of
-        _ when ?IS_STORE_ID(StoreIdOrRaServerConfig) ->
+        _ when ?IS_KHEPRI_STORE_ID(StoreIdOrRaServerConfig) ->
             #{cluster_name => StoreIdOrRaServerConfig};
-        #{cluster_name := CN} when ?IS_STORE_ID(CN) ->
+        #{cluster_name := CN} when ?IS_KHEPRI_STORE_ID(CN) ->
             StoreIdOrRaServerConfig;
         #{} when not is_map_key(cluster_name, StoreIdOrRaServerConfig) ->
             StoreIdOrRaServerConfig#{
@@ -469,7 +469,7 @@ stop() ->
 %%
 %% @returns `ok' if it succeeds, an error tuple otherwise.
 
-stop(StoreId) when ?IS_STORE_ID(StoreId) ->
+stop(StoreId) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     Lock = server_start_lock(StoreId),
     global:set_lock(Lock),
     try
@@ -588,7 +588,7 @@ join(RemoteNode, Timeout)
     StoreId = get_default_store_id(),
     join(StoreId, RemoteNode, Timeout);
 join(StoreId, RemoteNode)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(RemoteNode) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(RemoteNode) ->
     Timeout = khepri_app:get_default_timeout(),
     join(StoreId, RemoteNode, Timeout);
 join({StoreId, RemoteNode} = _RemoteMember, Timeout) ->
@@ -922,7 +922,7 @@ reset(Timeout)
     StoreId = get_default_store_id(),
     reset(StoreId, Timeout);
 reset(StoreId)
-  when ?IS_STORE_ID(StoreId) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) ->
     Timeout = khepri_app:get_default_timeout(),
     reset(StoreId, Timeout).
 
@@ -1080,7 +1080,7 @@ get_default_store_id() ->
                     khepri, default_store_id,
                     ?DEFAULT_STORE_ID),
     if
-        ?IS_STORE_ID(StoreId) ->
+        ?IS_KHEPRI_STORE_ID(StoreId) ->
             ok;
         true ->
             ?LOG_ERROR(

--- a/src/khepri_cluster.hrl
+++ b/src/khepri_cluster.hrl
@@ -7,7 +7,6 @@
 
 -define(DEFAULT_RA_SYSTEM_NAME, khepri).
 -define(DEFAULT_STORE_ID, khepri).
--define(IS_STORE_ID(StoreId), is_atom(StoreId)).
 
 %% timer:sleep/1 time used as a retry interval when the local Ra server is
 %% unaware of a leader exit.

--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -115,7 +115,7 @@
 -include_lib("kernel/include/logger.hrl").
 -include_lib("stdlib/include/assert.hrl").
 
--include("src/khepri_cluster.hrl").
+-include("include/khepri.hrl").
 -include("src/khepri_machine.hrl").
 
 -export([export/4,
@@ -181,7 +181,7 @@
 %% @private
 
 export(StoreId, PathPattern, Module, ModulePriv)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(Module) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(Module) ->
     PathPattern1 = khepri_path:from_string(PathPattern),
     khepri_path:ensure_is_valid(PathPattern1),
     Query = fun(State) ->
@@ -349,7 +349,7 @@ abort_write(Module, ModulePriv) ->
 %% @private
 
 import(StoreId, Module, ModulePriv)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(Module) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(Module) ->
     case open_read(Module, ModulePriv) of
         {ok, ModulePriv1}  -> do_import(StoreId, Module, ModulePriv1);
         {error, _} = Error -> Error

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -164,7 +164,7 @@
 %% entries, or an `{error, Reason}' tuple.
 
 fold(StoreId, PathPattern, Fun, Acc, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        is_function(Fun, 3) ->
     PathPattern1 = khepri_path:from_string(PathPattern),
     khepri_path:ensure_is_valid(PathPattern1),
@@ -207,7 +207,7 @@ fold(StoreId, PathPattern, Fun, Acc, Options)
 %% @private
 
 put(StoreId, PathPattern, Payload, Options)
-  when ?IS_STORE_ID(StoreId) andalso ?IS_KHEPRI_PAYLOAD(Payload) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso ?IS_KHEPRI_PAYLOAD(Payload) ->
     PathPattern1 = khepri_path:from_string(PathPattern),
     khepri_path:ensure_is_valid(PathPattern1),
     Payload1 = khepri_payload:prepare(Payload),
@@ -236,7 +236,7 @@ put(_StoreId, PathPattern, Payload, _Options) ->
 %% in the case of an asynchronous put, always `ok' (the actual return value
 %% may be sent by a message if a correlation ID was specified).
 
-delete(StoreId, PathPattern, Options) when ?IS_STORE_ID(StoreId) ->
+delete(StoreId, PathPattern, Options) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     PathPattern1 = khepri_path:from_string(PathPattern),
     khepri_path:ensure_is_valid(PathPattern1),
     {CommandOptions, TreeOptions} = split_command_options(Options),
@@ -270,7 +270,7 @@ delete(StoreId, PathPattern, Options) when ?IS_STORE_ID(StoreId) ->
 %% correlation ID was specified).
 
 transaction(StoreId, Fun, Args, auto = ReadWrite, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        is_list(Args) andalso
        is_function(Fun, length(Args)) andalso
        is_map(Options) ->
@@ -281,7 +281,7 @@ transaction(StoreId, Fun, Args, auto = ReadWrite, Options)
             readonly_transaction(StoreId, Fun, Args, Options)
     end;
 transaction(StoreId, PathPattern, Args, auto, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        ?IS_KHEPRI_PATH_PATTERN(PathPattern) andalso
        is_list(Args) andalso
        is_map(Options) ->
@@ -289,14 +289,14 @@ transaction(StoreId, PathPattern, Args, auto, Options)
     khepri_path:ensure_is_valid(PathPattern1),
     readwrite_transaction(StoreId, PathPattern1, Args, Options);
 transaction(StoreId, Fun, Args, rw = ReadWrite, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        is_list(Args) andalso
        is_function(Fun, length(Args)) andalso
        is_map(Options) ->
     StandaloneFun = khepri_tx_adv:to_standalone_fun(Fun, ReadWrite),
     readwrite_transaction(StoreId, StandaloneFun, Args, Options);
 transaction(StoreId, PathPattern, Args, rw, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        ?IS_KHEPRI_PATH_PATTERN(PathPattern) andalso
        is_list(Args) andalso
        is_map(Options) ->
@@ -304,13 +304,13 @@ transaction(StoreId, PathPattern, Args, rw, Options)
     khepri_path:ensure_is_valid(PathPattern1),
     readwrite_transaction(StoreId, PathPattern1, Args, Options);
 transaction(StoreId, Fun, Args, ro, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        is_list(Args) andalso
        is_function(Fun, length(Args)) andalso
        is_map(Options) ->
     readonly_transaction(StoreId, Fun, Args, Options);
 transaction(StoreId, PathPattern, Args, ro, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        ?IS_KHEPRI_PATH_PATTERN(PathPattern) andalso
        is_list(Args) andalso
        is_map(Options) ->
@@ -318,7 +318,7 @@ transaction(StoreId, PathPattern, Args, ro, Options)
     khepri_path:ensure_is_valid(PathPattern1),
     readonly_transaction(StoreId, PathPattern1, Args, Options);
 transaction(StoreId, Fun, Args, ReadWrite, Options)
-  when ?IS_STORE_ID(StoreId) andalso
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        is_function(Fun) andalso
        is_list(Args) andalso
        is_atom(ReadWrite) andalso
@@ -449,7 +449,7 @@ handle_tx_exception(
 %% otherwise.
 
 register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options)
-  when ?IS_STORE_ID(StoreId) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) ->
     EventFilter1 = khepri_evf:wrap(EventFilter),
     StoredProcPath1 = khepri_path:from_string(StoredProcPath),
     khepri_path:ensure_is_valid(StoredProcPath1),
@@ -508,7 +508,7 @@ register_projection(
 %% Reason}' tuple otherwise.
 
 unregister_projection(StoreId, ProjectionName, Options0)
-  when ?IS_STORE_ID(StoreId) andalso is_atom(ProjectionName) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(ProjectionName) ->
     Options = Options0#{reply_from => local},
     Command = #unregister_projection{name = ProjectionName},
     process_command(StoreId, Command, Options).
@@ -526,7 +526,7 @@ unregister_projection(StoreId, ProjectionName, Options0)
 %% @private
 
 ack_triggers_execution(StoreId, TriggeredStoredProcs)
-  when ?IS_STORE_ID(StoreId) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) ->
     Command = #ack_triggered{triggered = TriggeredStoredProcs},
     process_command(StoreId, Command, #{async => true}).
 
@@ -546,7 +546,7 @@ ack_triggers_execution(StoreId, TriggeredStoredProcs)
 %% @private
 
 get_keep_while_conds_state(StoreId, Options)
-  when ?IS_STORE_ID(StoreId) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) ->
     Query = fun(#?MODULE{tree = #tree{keep_while_conds = KeepWhileConds}}) ->
                     {ok, KeepWhileConds}
             end,
@@ -571,7 +571,7 @@ get_keep_while_conds_state(StoreId, Options)
 %% @private
 
 get_projections_state(StoreId, Options)
-  when ?IS_STORE_ID(StoreId) ->
+  when ?IS_KHEPRI_STORE_ID(StoreId) ->
     Query = fun(#?MODULE{projections = Projections}) ->
                     {ok, Projections}
             end,


### PR DESCRIPTION
## Why

This allows to abstract the type of the store ID.

## How

The macro already existed for a long time, but was in a private header. This patch moves it to the public header.

In the process, it is renamed from `?IS_STORE_ID/1` to `?IS_KHEPRI_STORE_ID/1` to reduce the namespace pollution.