### PR TITLE
export_erlang: Use cwd for fail_to_open_file_test_

### DIFF
--- a/test/export_erlang.erl
+++ b/test/export_erlang.erl
@@ -79,7 +79,7 @@ export_import_full_store_to_file_test_() ->
 
 fail_to_open_file_test_() ->
     Module = khepri_export_erlang,
-    Filename = "/",
+    {ok, Filename} = file:get_cwd(),
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) ->


### PR DESCRIPTION
Using root for the filename fails for me locally on a Mac laptop. I guess it must have something to do with the read-only root feature - there is some sort of misdirection between `/` and `/private`. This case fails on my machine but with `{error,eexist}` rather than the expected `{error,eisdir}`. Using the current working directory fails as expected.