### PR TITLE
Hex: Publish license files

### DIFF
--- a/src/khepri.app.src
+++ b/src/khepri.app.src
@@ -18,7 +18,7 @@
   {env,[]},
   {mod, {khepri_app, []}},
   {files, [
-    "README.md", "LICENSE", "mix.exs",
+    "README.md", "LICENSE-Apache-2.0", "LICENSE-MPL-2.0", "mix.exs",
     "rebar.config", "rebar.lock", "src", "include"]},
   {modules, []},
   {licenses, ["Apache-2.0", "MPL-2.0"]},


### PR DESCRIPTION
Previously the two license files wouldn't be published in the Hex package because of their suffixes. We can publish them if we specify the full filenames in the `files` part of the app spec.