### PR TITLE
Always pass exported functions to Ra queries

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -344,6 +344,14 @@
 %% created/updated tree node.</li>
 %% </ul>
 
+-type mod_func_args() :: {Module :: module(),
+                          Func :: atom(),
+                          Args :: [any()]}.
+%% Module/function/arguments triplet.
+%%
+%% It differs from Erlang's `mfa()' type because it takes a list of arguments,
+%% not an arity as its 3rd element.
+
 -type fold_fun() :: fun((khepri_path:native_path(),
                          khepri:node_props(),
                          khepri:fold_acc()) -> khepri:fold_acc()).
@@ -455,6 +463,7 @@
               tree_options/0,
               put_options/0,
 
+              mod_func_args/0,
               fold_fun/0,
               fold_acc/0,
               foreach_fun/0,

--- a/src/khepri_adv.erl
+++ b/src/khepri_adv.erl
@@ -259,7 +259,7 @@ get_many(PathPattern, Options) when is_map(Options) ->
 %% @see khepri:get_many/3.
 
 get_many(StoreId, PathPattern, Options) ->
-    Fun = fun khepri_tree:collect_node_props_cb/3,
+    Fun = {khepri_tree, collect_node_props_cb, []},
     khepri_machine:fold(StoreId, PathPattern, Fun, #{}, Options).
 
 %% -------------------------------------------------------------------

--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -186,7 +186,7 @@ export(StoreId, PathPattern, Module, ModulePriv)
     khepri_path:ensure_is_valid(PathPattern1),
     Query = fun(State) ->
                     try
-                        do_export(State, PathPattern, Module, ModulePriv)
+                        do_export(State, PathPattern1, Module, ModulePriv)
                     catch
                         Class:Exception:Stacktrace ->
                             {error, {exception, Class, Exception, Stacktrace}}

--- a/src/khepri_mfa.awk
+++ b/src/khepri_mfa.awk
@@ -1,0 +1,81 @@
+# vim:sw=4:et:
+
+BEGIN {
+    print "%% This Source Code Form is subject to the terms of the Mozilla Public";
+    print "%% License, v. 2.0. If a copy of the MPL was not distributed with this";
+    print "%% file, You can obtain one at https://mozilla.org/MPL/2.0/.";
+    print "%%";
+    print "%% Copyright © 2024 Broadcom. All Rights Reserved. The term \"Broadcom\" refers to Broadcom Inc. and/or its subsidiaries.";
+    print "%%";
+    print "";
+    print "-module(khepri_mfa).";
+    print "";
+    print "-include(\"src/khepri_error.hrl\").";
+    print "";
+    print "-export([to_fun/2]).";
+    print "";
+
+    print "-spec to_fun(MFA, Arity) -> Fun when";
+    print "      MFA :: khepri:mod_func_args(),";
+    print "      Arity :: arity(),";
+    print "      Fun :: fun().";
+    print "%% @private";
+    print "";
+
+    print "to_fun({Mod, Func, Args} = MFA, Arity) ->";
+    print "    case {Args, Arity} of";
+
+    # Max arguments supported by Horus extraction.
+    max = 10;
+
+    for (i = 0; i <= max; i++) {
+        for (j = 0; j <= max; j++) {
+            if (i + j > max)
+                continue;
+
+            printf "        {[";
+            for (n = 1; n <= i; n++) {
+                if (n == 1) {
+                    printf "Arg" n;
+                } else {
+                    printf ", Arg" n;
+                }
+            }
+            print "], " j "} ->";
+
+            printf "            fun(";
+            for (n = i + 1; n <= i + j; n++) {
+                if (n == i + 1) {
+                    printf "Arg" n;
+                } else {
+                    printf ", Arg" n;
+                }
+            }
+            print ") ->";
+            printf "                    Mod:Func(";
+            for (n = 1; n <= i + j; n++) {
+                if (n == 1) {
+                    if (i + j < 8) {
+                        printf "Arg" n;
+                    } else {
+                        printf "\n                      Arg" n;
+                    }
+                } else if (n == 10) {
+                    printf ",\n                      Arg" n;
+                } else {
+                    printf ", Arg" n;
+                }
+            }
+            print ")";
+            print "            end;";
+        }
+        print "";
+    }
+
+    print "        _ ->";
+    print "            ?khepri_misuse(";
+    print "               tx_mfa_with_arity_too_great,";
+    print "               #{mfa => MFA,";
+    print "                 arity => Arity})";
+    print "    end.";
+}

--- a/src/khepri_mfa.erl
+++ b/src/khepri_mfa.erl
@@ -1,0 +1,343 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(khepri_mfa).
+
+-include("src/khepri_error.hrl").
+
+-export([to_fun/2]).
+
+-spec to_fun(MFA, Arity) -> Fun when
+      MFA :: khepri:mod_func_args(),
+      Arity :: arity(),
+      Fun :: fun().
+%% @private
+
+to_fun({Mod, Func, Args} = MFA, Arity) ->
+    case {Args, Arity} of
+        {[], 0} ->
+            fun() ->
+                    Mod:Func()
+            end;
+        {[], 1} ->
+            fun(Arg1) ->
+                    Mod:Func(Arg1)
+            end;
+        {[], 2} ->
+            fun(Arg1, Arg2) ->
+                    Mod:Func(Arg1, Arg2)
+            end;
+        {[], 3} ->
+            fun(Arg1, Arg2, Arg3) ->
+                    Mod:Func(Arg1, Arg2, Arg3)
+            end;
+        {[], 4} ->
+            fun(Arg1, Arg2, Arg3, Arg4) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4)
+            end;
+        {[], 5} ->
+            fun(Arg1, Arg2, Arg3, Arg4, Arg5) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5)
+            end;
+        {[], 6} ->
+            fun(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)
+            end;
+        {[], 7} ->
+            fun(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[], 8} ->
+            fun(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[], 9} ->
+            fun(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[], 10} ->
+            fun(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1], 0} ->
+            fun() ->
+                    Mod:Func(Arg1)
+            end;
+        {[Arg1], 1} ->
+            fun(Arg2) ->
+                    Mod:Func(Arg1, Arg2)
+            end;
+        {[Arg1], 2} ->
+            fun(Arg2, Arg3) ->
+                    Mod:Func(Arg1, Arg2, Arg3)
+            end;
+        {[Arg1], 3} ->
+            fun(Arg2, Arg3, Arg4) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4)
+            end;
+        {[Arg1], 4} ->
+            fun(Arg2, Arg3, Arg4, Arg5) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5)
+            end;
+        {[Arg1], 5} ->
+            fun(Arg2, Arg3, Arg4, Arg5, Arg6) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)
+            end;
+        {[Arg1], 6} ->
+            fun(Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[Arg1], 7} ->
+            fun(Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1], 8} ->
+            fun(Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1], 9} ->
+            fun(Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2], 0} ->
+            fun() ->
+                    Mod:Func(Arg1, Arg2)
+            end;
+        {[Arg1, Arg2], 1} ->
+            fun(Arg3) ->
+                    Mod:Func(Arg1, Arg2, Arg3)
+            end;
+        {[Arg1, Arg2], 2} ->
+            fun(Arg3, Arg4) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4)
+            end;
+        {[Arg1, Arg2], 3} ->
+            fun(Arg3, Arg4, Arg5) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5)
+            end;
+        {[Arg1, Arg2], 4} ->
+            fun(Arg3, Arg4, Arg5, Arg6) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)
+            end;
+        {[Arg1, Arg2], 5} ->
+            fun(Arg3, Arg4, Arg5, Arg6, Arg7) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[Arg1, Arg2], 6} ->
+            fun(Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1, Arg2], 7} ->
+            fun(Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2], 8} ->
+            fun(Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3], 0} ->
+            fun() ->
+                    Mod:Func(Arg1, Arg2, Arg3)
+            end;
+        {[Arg1, Arg2, Arg3], 1} ->
+            fun(Arg4) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4)
+            end;
+        {[Arg1, Arg2, Arg3], 2} ->
+            fun(Arg4, Arg5) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5)
+            end;
+        {[Arg1, Arg2, Arg3], 3} ->
+            fun(Arg4, Arg5, Arg6) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)
+            end;
+        {[Arg1, Arg2, Arg3], 4} ->
+            fun(Arg4, Arg5, Arg6, Arg7) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[Arg1, Arg2, Arg3], 5} ->
+            fun(Arg4, Arg5, Arg6, Arg7, Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1, Arg2, Arg3], 6} ->
+            fun(Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2, Arg3], 7} ->
+            fun(Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3, Arg4], 0} ->
+            fun() ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4], 1} ->
+            fun(Arg5) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4], 2} ->
+            fun(Arg5, Arg6) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4], 3} ->
+            fun(Arg5, Arg6, Arg7) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4], 4} ->
+            fun(Arg5, Arg6, Arg7, Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4], 5} ->
+            fun(Arg5, Arg6, Arg7, Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4], 6} ->
+            fun(Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3, Arg4, Arg5], 0} ->
+            fun() ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5], 1} ->
+            fun(Arg6) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5], 2} ->
+            fun(Arg6, Arg7) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5], 3} ->
+            fun(Arg6, Arg7, Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5], 4} ->
+            fun(Arg6, Arg7, Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5], 5} ->
+            fun(Arg6, Arg7, Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6], 0} ->
+            fun() ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6], 1} ->
+            fun(Arg7) ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6], 2} ->
+            fun(Arg7, Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6], 3} ->
+            fun(Arg7, Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6], 4} ->
+            fun(Arg7, Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7], 0} ->
+            fun() ->
+                    Mod:Func(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7], 1} ->
+            fun(Arg8) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7], 2} ->
+            fun(Arg8, Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7], 3} ->
+            fun(Arg8, Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8], 0} ->
+            fun() ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8], 1} ->
+            fun(Arg9) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8], 2} ->
+            fun(Arg9, Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9], 0} ->
+            fun() ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9)
+            end;
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9], 1} ->
+            fun(Arg10) ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        {[Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10], 0} ->
+            fun() ->
+                    Mod:Func(
+                      Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9,
+                      Arg10)
+            end;
+
+        _ ->
+            ?khepri_misuse(
+               tx_mfa_with_arity_too_great,
+               #{mfa => MFA,
+                 arity => Arity})
+    end.

--- a/src/khepri_mfa.hrl
+++ b/src/khepri_mfa.hrl
@@ -1,0 +1,15 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-define(IS_MFA(Fun), (is_tuple(Fun) andalso size(Fun) =:= 3 andalso
+                      is_atom(element(1, Fun)) andalso
+                      is_atom(element(2, Fun)) andalso
+                      is_list(element(3, Fun)))).
+
+-define(IS_FUN_OR_MFA(Fun), (is_function(Fun) orelse ?IS_MFA(Fun))).
+-define(IS_FUN_OR_MFA(Fun, Arity), (is_function(Fun, Arity) orelse
+                                    ?IS_MFA(Fun))).

--- a/src/khepri_payload.erl
+++ b/src/khepri_payload.erl
@@ -128,13 +128,15 @@ prepare(#p_data{} = Payload) ->
 prepare(#p_sproc{sproc = Fun} = Payload)
   when is_function(Fun) ->
     try
-        case khepri_tx_adv:to_standalone_fun(Fun, auto) of
+        {arity, Arity} = erlang:fun_info(Fun, arity),
+        case khepri_tx_adv:to_standalone_fun(Fun, Arity, auto) of
             StandaloneFun1 when ?IS_HORUS_STANDALONE_FUN(StandaloneFun1) ->
                 Payload#p_sproc{sproc = StandaloneFun1,
                                 is_valid_as_tx_fun = rw};
             _ ->
                 %% TODO: Improve Horus API to avoid a second extraction.
-                StandaloneFun1 = khepri_tx_adv:to_standalone_fun(Fun, rw),
+                StandaloneFun1 = khepri_tx_adv:to_standalone_fun(
+                                   Fun, Arity, rw),
                 Payload#p_sproc{sproc = StandaloneFun1,
                                 is_valid_as_tx_fun = ro}
         end

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -400,7 +400,13 @@ fold(Tree, PathPattern, Fun, Acc, TreeOptions) ->
 
 find_matching_nodes_cb(Path, #node{} = Node, Fun, Acc, TreeOptions) ->
     NodeProps = gather_node_props(Node, TreeOptions),
-    Acc1 = Fun(Path, NodeProps, Acc),
+    Acc1 = case Fun of
+               {Mod, Func, Args} ->
+                   Args1 = Args ++ [Path, NodeProps, Acc],
+                   erlang:apply(Mod, Func, Args1);
+               _ when is_function(Fun, 3) ->
+                   Fun(Path, NodeProps, Acc)
+           end,
     {ok, keep, Acc1};
 find_matching_nodes_cb(
   _,

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -99,7 +99,7 @@
 -type tx_fun_result() :: any() | no_return().
 %% Return value of a transaction function.
 
--type tx_fun() :: fun().
+-type tx_fun() :: fun() | khepri:mod_func_args().
 %% Transaction function signature.
 
 -type tx_abort() :: khepri:error(any()).

--- a/test/advanced_tx_delete.erl
+++ b/test/advanced_tx_delete.erl
@@ -41,9 +41,7 @@ delete_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:delete([foo])
-                   end,
+             Fun = {khepri_tx_adv, delete, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -106,10 +104,8 @@ delete_many_on_existing_node_with_condition_true_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:delete_many(
-                             [#if_name_matches{regex = "foo"}])
-                   end,
+             Fun = {khepri_tx_adv, delete_many,
+                    [[#if_name_matches{regex = "foo"}]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -178,9 +174,7 @@ clear_payload_from_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:clear_payload([foo])
-                   end,
+             Fun = {khepri_tx_adv, clear_payload, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -272,10 +266,8 @@ clear_many_payloads_from_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:clear_many_payloads(
-                             [#if_name_matches{regex = "foo"}])
-                   end,
+             Fun = {khepri_tx_adv, clear_many_payloads,
+                    [[#if_name_matches{regex = "foo"}]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(

--- a/test/advanced_tx_get.erl
+++ b/test/advanced_tx_get.erl
@@ -43,9 +43,7 @@ get_existing_node_test_() ->
           {ok, #{data => foo_value,
                  payload_version => 1}}},
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:get([foo])
-                   end,
+             Fun = {khepri_tx_adv, get, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -138,9 +136,7 @@ get_many_existing_nodes_test_() ->
                  [baz] => #{data => baz_value,
                             payload_version => 1}}}},
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:get_many([?KHEPRI_WILDCARD_STAR])
-                   end,
+             Fun = {khepri_tx_adv, get_many, [[?KHEPRI_WILDCARD_STAR]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(

--- a/test/advanced_tx_put.erl
+++ b/test/advanced_tx_put.erl
@@ -21,9 +21,7 @@ create_non_existing_node_test_() ->
      [?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:create([foo], foo_value)
-                   end,
+             Fun = {khepri_tx_adv, create, [[foo], foo_value]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -124,9 +122,7 @@ insert_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:put([foo], foo_value2)
-                   end,
+             Fun = {khepri_tx_adv, put, [[foo], foo_value2]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -210,10 +206,8 @@ insert_many_existing_nodes_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:put_many(
-                             [?KHEPRI_WILDCARD_STAR, foo], foo_value_all)
-                   end,
+             Fun = {khepri_tx_adv, put_many,
+                    [[?KHEPRI_WILDCARD_STAR, foo], foo_value_all]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -298,9 +292,7 @@ update_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:update([foo], foo_value2)
-                   end,
+             Fun = {khepri_tx_adv, update, [[foo], foo_value2]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -367,10 +359,8 @@ compare_and_swap_matching_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx_adv:compare_and_swap(
-                             [foo], foo_value1, foo_value2)
-                   end,
+             Fun = {khepri_tx_adv, compare_and_swap,
+                    [[foo], foo_value1, foo_value2]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -46,6 +46,9 @@
          projections_are_consistent_on_three_node_cluster/1,
          async_command_leader_change_in_three_node_cluster/1]).
 
+%% Exported functions passed to ra:*_query().
+-export([return_metrics_qf/1]).
+
 all() ->
     [can_start_a_single_node,
      can_restart_a_single_node_with_ra_server_config,
@@ -1234,9 +1237,7 @@ can_set_snapshot_interval(Config) ->
     ?assertEqual(
        #{},
        khepri_machine:process_query(
-         StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
-         #{})),
+         StoreId, {?MODULE, return_metrics_qf, []}, #{})),
 
     ct:pal("Use database after starting it"),
     ?assertEqual(ok, khepri:put(StoreId, [foo], value1)),
@@ -1245,9 +1246,7 @@ can_set_snapshot_interval(Config) ->
     ?assertEqual(
        #{applied_command_count => 1},
        khepri_machine:process_query(
-         StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
-         #{})),
+         StoreId, {?MODULE, return_metrics_qf, []}, #{})),
 
     ct:pal("Use database after starting it"),
     ?assertEqual(ok, khepri:put(StoreId, [foo], value1)),
@@ -1256,9 +1255,7 @@ can_set_snapshot_interval(Config) ->
     ?assertEqual(
        #{applied_command_count => 2},
        khepri_machine:process_query(
-         StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
-         #{})),
+         StoreId, {?MODULE, return_metrics_qf, []}, #{})),
 
     ct:pal("Use database after starting it"),
     ?assertEqual(ok, khepri:put(StoreId, [foo], value1)),
@@ -1267,9 +1264,7 @@ can_set_snapshot_interval(Config) ->
     ?assertEqual(
        #{},
        khepri_machine:process_query(
-         StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
-         #{})),
+         StoreId, {?MODULE, return_metrics_qf, []}, #{})),
 
     ct:pal("Stop database"),
     ?assertEqual(
@@ -1277,6 +1272,9 @@ can_set_snapshot_interval(Config) ->
        khepri:stop(StoreId)),
 
     ok.
+
+return_metrics_qf(#khepri_machine{metrics = Metrics}) ->
+    Metrics.
 
 projections_are_consistent_on_three_node_cluster(Config) ->
     ProjectionName = ?MODULE,

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -47,7 +47,11 @@
          async_command_leader_change_in_three_node_cluster/1]).
 
 %% Exported functions passed to ra:*_query().
--export([return_metrics_qf/1]).
+-export([return_metrics_qf/1,
+         can_use_default_store_on_single_node_qf1/3,
+         can_use_default_store_on_single_node_qf2/2,
+         can_use_default_store_on_single_node_qf3/2,
+         can_use_default_store_on_single_node_qf4/0]).
 
 all() ->
     [can_start_a_single_node,
@@ -1037,31 +1041,52 @@ can_use_default_store_on_single_node(_Config) ->
 
     ?assertEqual(
        {ok, #{[foo] => ok}},
-       khepri:fold([foo], fun(P, _NP, Acc) -> Acc#{P => ok} end, #{})),
+       khepri:fold(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf1, []},
+         #{})),
     ?assertEqual(
        {ok, #{[foo] => ok}},
-       khepri:fold([foo], fun(P, _NP, Acc) -> Acc#{P => ok} end, #{}, #{})),
+       khepri:fold(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf1, []},
+         #{}, #{})),
 
     ?assertEqual(
        ok,
-       khepri:foreach([foo], fun(_P, _NP) -> ok end)),
+       khepri:foreach(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf2, []})),
     ?assertEqual(
        ok,
-       khepri:foreach([foo], fun(_P, _NP) -> ok end, #{})),
+       khepri:foreach(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf2, []},
+         #{})),
 
     ?assertEqual(
        {ok, #{[foo] => ok}},
-       khepri:map([foo], fun(_P, _NP) -> ok end)),
+       khepri:map(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf2, []})),
     ?assertEqual(
        {ok, #{[foo] => ok}},
-       khepri:map([foo], fun(_P, _NP) -> ok end, #{})),
+       khepri:map(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf2, []},
+         #{})),
 
     ?assertEqual(
        {ok, #{[foo] => value4}},
-       khepri:filter([foo], fun(_P, _NP) -> true end)),
+       khepri:filter(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf3, []})),
     ?assertEqual(
        {ok, #{[foo] => value4}},
-       khepri:filter([foo], fun(_P, _NP) -> true end, #{})),
+       khepri:filter(
+         [foo],
+         {?MODULE, can_use_default_store_on_single_node_qf3, []},
+         #{})),
 
     ?assertEqual(
        {ok, #{data => value4,
@@ -1111,9 +1136,20 @@ can_use_default_store_on_single_node(_Config) ->
          trigger_id,
          [foo],
          [sproc], #{})),
-    ?assertEqual({ok, ok}, khepri:transaction(fun() -> ok end)),
-    ?assertEqual({ok, ok}, khepri:transaction(fun() -> ok end, ro)),
-    ?assertEqual({ok, ok}, khepri:transaction(fun() -> ok end, ro, #{})),
+    ?assertEqual(
+       {ok, ok},
+       khepri:transaction(
+         {?MODULE, can_use_default_store_on_single_node_qf4, []})),
+    ?assertEqual(
+       {ok, ok},
+       khepri:transaction(
+         {?MODULE, can_use_default_store_on_single_node_qf4, []},
+         ro)),
+    ?assertEqual(
+       {ok, ok},
+       khepri:transaction(
+         {?MODULE, can_use_default_store_on_single_node_qf4, []},
+         ro, #{})),
 
     ?assertEqual(ok, khepri:create([bar], value1)),
     ?assertEqual(ok, khepri:clear_payload([bar])),
@@ -1159,6 +1195,18 @@ can_use_default_store_on_single_node(_Config) ->
 
     helpers:remove_store_dir(DataDir),
     ?assertNot(filelib:is_dir(DataDir)).
+
+can_use_default_store_on_single_node_qf1(P, _NP, Acc) ->
+    Acc#{P => ok}.
+
+can_use_default_store_on_single_node_qf2(_P, _NP) ->
+    ok.
+
+can_use_default_store_on_single_node_qf3(_P, _NP) ->
+    true.
+
+can_use_default_store_on_single_node_qf4() ->
+    ok.
 
 can_start_store_in_specified_data_dir_on_single_node(_Config) ->
     DataDir = atom_to_list(?FUNCTION_NAME),

--- a/test/display_tree.erl
+++ b/test/display_tree.erl
@@ -365,7 +365,7 @@ machine_overview_test() ->
     %% implementation.
     Fun = fun() -> return_value end,
     helpers:init_list_of_modules_to_skip(),
-    StandaloneFun = khepri_tx_adv:to_standalone_fun(Fun, rw),
+    StandaloneFun = khepri_tx_adv:to_standalone_fun(Fun, 0, rw),
     Commands = [#put{path = [foo],
                      payload = khepri_payload:data(foo_value)},
                 #put{path = [foo, bar],

--- a/test/favor_option.erl
+++ b/test/favor_option.erl
@@ -164,7 +164,7 @@ favor_compromise_in_transaction_test_() ->
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_test(
          begin
-             Fun = fun() -> khepri_tx:get([foo]) end,
+             Fun = {khepri_tx, get, [[foo]]},
 
              ?assertEqual(
                 undefined,
@@ -223,7 +223,7 @@ favor_consistency_in_transaction_test_() ->
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [?_test(
          begin
-             Fun = fun() -> khepri_tx:get([foo]) end,
+             Fun = {khepri_tx, get, [[foo]]},
 
              ?assertEqual(
                 undefined,

--- a/test/mfa_to_fun.awk
+++ b/test/mfa_to_fun.awk
@@ -1,0 +1,113 @@
+# vim:sw=4:et:
+
+BEGIN {
+    print "%% This Source Code Form is subject to the terms of the Mozilla Public";
+    print "%% License, v. 2.0. If a copy of the MPL was not distributed with this";
+    print "%% file, You can obtain one at https://mozilla.org/MPL/2.0/.";
+    print "%%";
+    print "%% Copyright © 2024 Broadcom. All Rights Reserved. The term \"Broadcom\" refers to Broadcom Inc. and/or its subsidiaries.";
+    print "%%";
+    print "";
+    print "-module(mfa_to_fun).";
+    print "";
+    print "-include_lib(\"eunit/include/eunit.hrl\").";
+    print "";
+    print "-include(\"src/khepri_error.hrl\").";
+    print "-include(\"src/khepri_mfa.hrl\").";
+    print "";
+
+    # Max arguments supported by Horus extraction.
+    max = 10;
+
+    for (i = 0; i <= max; i++) {
+        if (i == 0) {
+            print "-export([args_to_list/" i ",";
+        } else if (i < max) {
+            print "         args_to_list/" i ",";
+        } else {
+            print "         args_to_list/" i "]).";
+        }
+    }
+
+    print "";
+    print "-dialyzer([{nowarn_function, [mfa_to_fun_0_11_test/0]}]).";
+
+    for (i = 0; i <= max + 1; i++) {
+        for (j = 0; j <= max + 1; j++) {
+            if (i + j > max + 1)
+                continue;
+
+            print "";
+            print "mfa_to_fun_" i "_" j "_test() ->";
+
+            printf "    MFA = {?MODULE, args_to_list, [";
+            for (n = 1; n <= i; n++) {
+                if (n == 1) {
+                    printf "arg" n;
+                } else if (n == 8) {
+                    printf ",\n                                   arg" n;
+                } else {
+                    printf ", arg" n;
+                }
+            }
+            print "]},";
+
+            if (i + j <= max) {
+                print "    Fun = khepri_mfa:to_fun(MFA, " j "),";
+                print "    ?assert(is_function(Fun, " j ")),";
+
+                print "    ?assertEqual(";
+                printf "       args_to_list(";
+                for (n = 1; n <= i + j; n++) {
+                    if (n == 1) {
+                        printf "arg" n;
+                    } else if (n == 10) {
+                        printf ",\n                    arg" n;
+                    } else {
+                        printf ", arg" n;
+                    }
+                }
+                print "),";
+                printf "       Fun(";
+                for (n = i + 1; n <= i + j; n++) {
+                    if (n == i + 1) {
+                        printf "arg" n;
+                    } else {
+                        printf ", arg" n;
+                    }
+                }
+                print ")).";
+            } else {
+                print "    ?assertError(";
+                print "      ?khepri_exception(";
+                print "        tx_mfa_with_arity_too_great,";
+                print "        #{mfa := MFA,";
+                print "          arity := " j "}),";
+                print "      khepri_mfa:to_fun(MFA, " j ")).";
+            }
+        }
+    }
+
+    for (i = 0; i <= max; i++) {
+        print "";
+        printf "args_to_list(";
+        for (n = 1; n <= i; n++) {
+            if (n == 1) {
+                printf "Arg" n;
+            } else {
+                printf ", Arg" n;
+            }
+        }
+        print ") ->";
+
+        printf "    [";
+        for (n = 1; n <= i; n++) {
+            if (n == 1) {
+                printf "Arg" n;
+            } else {
+                printf ", Arg" n;
+            }
+        }
+        print "].";
+    }
+}

--- a/test/mfa_to_fun.erl
+++ b/test/mfa_to_fun.erl
@@ -1,0 +1,717 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(mfa_to_fun).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("src/khepri_error.hrl").
+-include("src/khepri_mfa.hrl").
+
+-export([args_to_list/0,
+         args_to_list/1,
+         args_to_list/2,
+         args_to_list/3,
+         args_to_list/4,
+         args_to_list/5,
+         args_to_list/6,
+         args_to_list/7,
+         args_to_list/8,
+         args_to_list/9,
+         args_to_list/10]).
+
+-dialyzer([{nowarn_function, [mfa_to_fun_0_11_test/0]}]).
+
+mfa_to_fun_0_0_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(),
+       Fun()).
+
+mfa_to_fun_0_1_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1),
+       Fun(arg1)).
+
+mfa_to_fun_0_2_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2),
+       Fun(arg1, arg2)).
+
+mfa_to_fun_0_3_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3),
+       Fun(arg1, arg2, arg3)).
+
+mfa_to_fun_0_4_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 4),
+    ?assert(is_function(Fun, 4)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4),
+       Fun(arg1, arg2, arg3, arg4)).
+
+mfa_to_fun_0_5_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 5),
+    ?assert(is_function(Fun, 5)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5),
+       Fun(arg1, arg2, arg3, arg4, arg5)).
+
+mfa_to_fun_0_6_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 6),
+    ?assert(is_function(Fun, 6)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6),
+       Fun(arg1, arg2, arg3, arg4, arg5, arg6)).
+
+mfa_to_fun_0_7_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 7),
+    ?assert(is_function(Fun, 7)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun(arg1, arg2, arg3, arg4, arg5, arg6, arg7)).
+
+mfa_to_fun_0_8_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 8),
+    ?assert(is_function(Fun, 8)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)).
+
+mfa_to_fun_0_9_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 9),
+    ?assert(is_function(Fun, 9)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)).
+
+mfa_to_fun_0_10_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    Fun = khepri_mfa:to_fun(MFA, 10),
+    ?assert(is_function(Fun, 10)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)).
+
+mfa_to_fun_0_11_test() ->
+    MFA = {?MODULE, args_to_list, []},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 11}),
+      khepri_mfa:to_fun(MFA, 11)).
+
+mfa_to_fun_1_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1),
+       Fun()).
+
+mfa_to_fun_1_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2),
+       Fun(arg2)).
+
+mfa_to_fun_1_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3),
+       Fun(arg2, arg3)).
+
+mfa_to_fun_1_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4),
+       Fun(arg2, arg3, arg4)).
+
+mfa_to_fun_1_4_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 4),
+    ?assert(is_function(Fun, 4)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5),
+       Fun(arg2, arg3, arg4, arg5)).
+
+mfa_to_fun_1_5_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 5),
+    ?assert(is_function(Fun, 5)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6),
+       Fun(arg2, arg3, arg4, arg5, arg6)).
+
+mfa_to_fun_1_6_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 6),
+    ?assert(is_function(Fun, 6)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun(arg2, arg3, arg4, arg5, arg6, arg7)).
+
+mfa_to_fun_1_7_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 7),
+    ?assert(is_function(Fun, 7)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg2, arg3, arg4, arg5, arg6, arg7, arg8)).
+
+mfa_to_fun_1_8_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 8),
+    ?assert(is_function(Fun, 8)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)).
+
+mfa_to_fun_1_9_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    Fun = khepri_mfa:to_fun(MFA, 9),
+    ?assert(is_function(Fun, 9)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)).
+
+mfa_to_fun_1_10_test() ->
+    MFA = {?MODULE, args_to_list, [arg1]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 10}),
+      khepri_mfa:to_fun(MFA, 10)).
+
+mfa_to_fun_2_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2),
+       Fun()).
+
+mfa_to_fun_2_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3),
+       Fun(arg3)).
+
+mfa_to_fun_2_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4),
+       Fun(arg3, arg4)).
+
+mfa_to_fun_2_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5),
+       Fun(arg3, arg4, arg5)).
+
+mfa_to_fun_2_4_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 4),
+    ?assert(is_function(Fun, 4)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6),
+       Fun(arg3, arg4, arg5, arg6)).
+
+mfa_to_fun_2_5_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 5),
+    ?assert(is_function(Fun, 5)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun(arg3, arg4, arg5, arg6, arg7)).
+
+mfa_to_fun_2_6_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 6),
+    ?assert(is_function(Fun, 6)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg3, arg4, arg5, arg6, arg7, arg8)).
+
+mfa_to_fun_2_7_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 7),
+    ?assert(is_function(Fun, 7)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg3, arg4, arg5, arg6, arg7, arg8, arg9)).
+
+mfa_to_fun_2_8_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    Fun = khepri_mfa:to_fun(MFA, 8),
+    ?assert(is_function(Fun, 8)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)).
+
+mfa_to_fun_2_9_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 9}),
+      khepri_mfa:to_fun(MFA, 9)).
+
+mfa_to_fun_3_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3),
+       Fun()).
+
+mfa_to_fun_3_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4),
+       Fun(arg4)).
+
+mfa_to_fun_3_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5),
+       Fun(arg4, arg5)).
+
+mfa_to_fun_3_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6),
+       Fun(arg4, arg5, arg6)).
+
+mfa_to_fun_3_4_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 4),
+    ?assert(is_function(Fun, 4)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun(arg4, arg5, arg6, arg7)).
+
+mfa_to_fun_3_5_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 5),
+    ?assert(is_function(Fun, 5)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg4, arg5, arg6, arg7, arg8)).
+
+mfa_to_fun_3_6_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 6),
+    ?assert(is_function(Fun, 6)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg4, arg5, arg6, arg7, arg8, arg9)).
+
+mfa_to_fun_3_7_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    Fun = khepri_mfa:to_fun(MFA, 7),
+    ?assert(is_function(Fun, 7)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg4, arg5, arg6, arg7, arg8, arg9, arg10)).
+
+mfa_to_fun_3_8_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 8}),
+      khepri_mfa:to_fun(MFA, 8)).
+
+mfa_to_fun_4_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4),
+       Fun()).
+
+mfa_to_fun_4_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5),
+       Fun(arg5)).
+
+mfa_to_fun_4_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6),
+       Fun(arg5, arg6)).
+
+mfa_to_fun_4_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun(arg5, arg6, arg7)).
+
+mfa_to_fun_4_4_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    Fun = khepri_mfa:to_fun(MFA, 4),
+    ?assert(is_function(Fun, 4)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg5, arg6, arg7, arg8)).
+
+mfa_to_fun_4_5_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    Fun = khepri_mfa:to_fun(MFA, 5),
+    ?assert(is_function(Fun, 5)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg5, arg6, arg7, arg8, arg9)).
+
+mfa_to_fun_4_6_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    Fun = khepri_mfa:to_fun(MFA, 6),
+    ?assert(is_function(Fun, 6)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg5, arg6, arg7, arg8, arg9, arg10)).
+
+mfa_to_fun_4_7_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 7}),
+      khepri_mfa:to_fun(MFA, 7)).
+
+mfa_to_fun_5_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5),
+       Fun()).
+
+mfa_to_fun_5_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6),
+       Fun(arg6)).
+
+mfa_to_fun_5_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun(arg6, arg7)).
+
+mfa_to_fun_5_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5]},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg6, arg7, arg8)).
+
+mfa_to_fun_5_4_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5]},
+    Fun = khepri_mfa:to_fun(MFA, 4),
+    ?assert(is_function(Fun, 4)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg6, arg7, arg8, arg9)).
+
+mfa_to_fun_5_5_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5]},
+    Fun = khepri_mfa:to_fun(MFA, 5),
+    ?assert(is_function(Fun, 5)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg6, arg7, arg8, arg9, arg10)).
+
+mfa_to_fun_5_6_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 6}),
+      khepri_mfa:to_fun(MFA, 6)).
+
+mfa_to_fun_6_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6),
+       Fun()).
+
+mfa_to_fun_6_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun(arg7)).
+
+mfa_to_fun_6_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg7, arg8)).
+
+mfa_to_fun_6_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6]},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg7, arg8, arg9)).
+
+mfa_to_fun_6_4_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6]},
+    Fun = khepri_mfa:to_fun(MFA, 4),
+    ?assert(is_function(Fun, 4)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg7, arg8, arg9, arg10)).
+
+mfa_to_fun_6_5_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 5}),
+      khepri_mfa:to_fun(MFA, 5)).
+
+mfa_to_fun_7_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7),
+       Fun()).
+
+mfa_to_fun_7_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun(arg8)).
+
+mfa_to_fun_7_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg8, arg9)).
+
+mfa_to_fun_7_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]},
+    Fun = khepri_mfa:to_fun(MFA, 3),
+    ?assert(is_function(Fun, 3)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg8, arg9, arg10)).
+
+mfa_to_fun_7_4_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 4}),
+      khepri_mfa:to_fun(MFA, 4)).
+
+mfa_to_fun_8_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8),
+       Fun()).
+
+mfa_to_fun_8_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun(arg9)).
+
+mfa_to_fun_8_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8]},
+    Fun = khepri_mfa:to_fun(MFA, 2),
+    ?assert(is_function(Fun, 2)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg9, arg10)).
+
+mfa_to_fun_8_3_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 3}),
+      khepri_mfa:to_fun(MFA, 3)).
+
+mfa_to_fun_9_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8, arg9]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9),
+       Fun()).
+
+mfa_to_fun_9_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8, arg9]},
+    Fun = khepri_mfa:to_fun(MFA, 1),
+    ?assert(is_function(Fun, 1)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun(arg10)).
+
+mfa_to_fun_9_2_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8, arg9]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 2}),
+      khepri_mfa:to_fun(MFA, 2)).
+
+mfa_to_fun_10_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8, arg9, arg10]},
+    Fun = khepri_mfa:to_fun(MFA, 0),
+    ?assert(is_function(Fun, 0)),
+    ?assertEqual(
+       args_to_list(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
+                    arg10),
+       Fun()).
+
+mfa_to_fun_10_1_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8, arg9, arg10]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 1}),
+      khepri_mfa:to_fun(MFA, 1)).
+
+mfa_to_fun_11_0_test() ->
+    MFA = {?MODULE, args_to_list, [arg1, arg2, arg3, arg4, arg5, arg6, arg7,
+                                   arg8, arg9, arg10, arg11]},
+    ?assertError(
+      ?khepri_exception(
+        tx_mfa_with_arity_too_great,
+        #{mfa := MFA,
+          arity := 0}),
+      khepri_mfa:to_fun(MFA, 0)).
+
+args_to_list() ->
+    [].
+
+args_to_list(Arg1) ->
+    [Arg1].
+
+args_to_list(Arg1, Arg2) ->
+    [Arg1, Arg2].
+
+args_to_list(Arg1, Arg2, Arg3) ->
+    [Arg1, Arg2, Arg3].
+
+args_to_list(Arg1, Arg2, Arg3, Arg4) ->
+    [Arg1, Arg2, Arg3, Arg4].
+
+args_to_list(Arg1, Arg2, Arg3, Arg4, Arg5) ->
+    [Arg1, Arg2, Arg3, Arg4, Arg5].
+
+args_to_list(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6) ->
+    [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6].
+
+args_to_list(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7) ->
+    [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7].
+
+args_to_list(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8) ->
+    [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8].
+
+args_to_list(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9) ->
+    [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9].
+
+args_to_list(Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10) ->
+    [Arg1, Arg2, Arg3, Arg4, Arg5, Arg6, Arg7, Arg8, Arg9, Arg10].

--- a/test/simple_tx_delete.erl
+++ b/test/simple_tx_delete.erl
@@ -39,9 +39,7 @@ delete_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:delete([foo])
-                   end,
+             Fun = {khepri_tx, delete, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -98,10 +96,8 @@ delete_many_on_existing_node_with_condition_true_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:delete_many(
-                             [#if_name_matches{regex = "foo"}])
-                   end,
+             Fun = {khepri_tx, delete_many,
+                    [[#if_name_matches{regex = "foo"}]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -212,9 +208,7 @@ clear_payload_from_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:clear_payload([foo])
-                   end,
+             Fun = {khepri_tx, clear_payload, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -300,10 +294,8 @@ clear_many_payloads_from_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:clear_many_payloads(
-                             [#if_name_matches{regex = "foo"}])
-                   end,
+             Fun = {khepri_tx, clear_many_payloads,
+                    [[#if_name_matches{regex = "foo"}]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(

--- a/test/simple_tx_get.erl
+++ b/test/simple_tx_get.erl
@@ -15,6 +15,10 @@
 -include("src/khepri_error.hrl").
 -include("test/helpers.hrl").
 
+%% Exported functions passed to khepri_machine:readonly_transaction().
+-export([foreach_node_cb_qf1/0,
+         foreach_node_cb_qf2/0]).
+
 -dialyzer([{no_return,
             [crash_during_fold_test_/0]}]).
 
@@ -44,17 +48,13 @@ get_existing_node_test_() ->
       ?_assertEqual(
          {ok, {ok, foo_value}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get([foo])
-                   end,
+             Fun = {khepri_tx, get, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
          {ok, {ok, foo_value}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get([foo])
-                   end,
+             Fun = {khepri_tx, get, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -87,6 +87,36 @@ get_existing_node_with_no_payload_test_() ->
              Fun = fun() ->
                            khepri_tx:get([foo])
                    end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
+get_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:get([foo])
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, foo_value}},
+         begin
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -128,17 +158,13 @@ get_or_default_on_existing_node_test_() ->
       ?_assertEqual(
          {ok, {ok, foo_value}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get_or([foo], default)
-                   end,
+             Fun = {khepri_tx, get_or, [[foo], default]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
          {ok, {ok, foo_value}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get_or([foo], default)
-                   end,
+             Fun = {khepri_tx, get_or, [[foo], default]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -155,6 +181,36 @@ get_or_default_on_existing_node_with_no_payload_test_() ->
              Fun = fun() ->
                            khepri_tx:get_or([foo], default)
                    end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
+get_or_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:get_or([foo], default)
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, foo_value}},
+         begin
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -201,9 +257,7 @@ get_many_existing_nodes_test_() ->
           {ok, #{[foo] => undefined,
                  [baz] => baz_value}}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get_many([?KHEPRI_WILDCARD_STAR])
-                   end,
+             Fun = {khepri_tx, get_many, [[?KHEPRI_WILDCARD_STAR]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -211,9 +265,7 @@ get_many_existing_nodes_test_() ->
           {ok, #{[foo] => undefined,
                  [baz] => baz_value}}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get_many([?KHEPRI_WILDCARD_STAR])
-                   end,
+             Fun = {khepri_tx, get_many, [[?KHEPRI_WILDCARD_STAR]]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
       ?_assertError(
@@ -226,6 +278,36 @@ get_many_existing_nodes_test_() ->
                              [?KHEPRI_WILDCARD_STAR],
                              #{expect_specific_node => true})
                    end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
+get_many_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:get_many([foo])
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, #{[foo] => foo_value}}},
+         begin
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -258,10 +340,8 @@ get_many_or_default_existing_nodes_test_() ->
           {ok, #{[foo] => default,
                  [baz] => baz_value}}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get_many_or(
-                             [?KHEPRI_WILDCARD_STAR], default)
-                   end,
+             Fun = {khepri_tx, get_many_or,
+                    [[?KHEPRI_WILDCARD_STAR], default]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -269,10 +349,8 @@ get_many_or_default_existing_nodes_test_() ->
           {ok, #{[foo] => default,
                  [baz] => baz_value}}},
          begin
-             Fun = fun() ->
-                           khepri_tx:get_many_or(
-                             [?KHEPRI_WILDCARD_STAR], default)
-                   end,
+             Fun = {khepri_tx, get_many_or,
+                    [[?KHEPRI_WILDCARD_STAR], default]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
       ?_assertError(
@@ -288,6 +366,36 @@ get_many_or_default_existing_nodes_test_() ->
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
+get_many_or_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:get_many_or([foo], default)
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, #{[foo] => foo_value}}},
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
 check_node_exists_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
@@ -298,33 +406,55 @@ check_node_exists_test_() ->
       ?_assertEqual(
          {ok, true},
          begin
-             Fun = fun() ->
-                           khepri_tx:exists([foo])
-                   end,
+             Fun = {khepri_tx, exists, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
       ?_assertEqual(
          {ok, true},
          begin
-             Fun = fun() ->
-                           khepri_tx:exists([foo, bar])
-                   end,
+             Fun = {khepri_tx, exists, [[foo, bar]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
          {ok, true},
          begin
-             Fun = fun() ->
-                           khepri_tx:exists([foo, bar])
-                   end,
+             Fun = {khepri_tx, exists, [[foo, bar]]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
       ?_assertEqual(
          {ok, false},
          begin
-             Fun = fun() ->
-                           khepri_tx:exists([baz])
-                   end,
+             Fun = {khepri_tx, exists, [[baz]]},
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
+check_node_exists_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:exists([foo])
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, true},
+         begin
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -377,17 +507,13 @@ check_node_has_data_on_existing_node_test_() ->
       ?_assertEqual(
          {ok, true},
          begin
-             Fun = fun() ->
-                           khepri_tx:has_data([foo, bar])
-                   end,
+             Fun = {khepri_tx, has_data, [[foo, bar]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
          {ok, true},
          begin
-             Fun = fun() ->
-                           khepri_tx:has_data([foo, bar])
-                   end,
+             Fun = {khepri_tx, has_data, [[foo, bar]]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
       ?_assertEqual(
@@ -396,6 +522,36 @@ check_node_has_data_on_existing_node_test_() ->
              Fun = fun() ->
                            khepri_tx:has_data([baz])
                    end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
+check_node_has_data_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:has_data([foo])
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, true},
+         begin
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -448,17 +604,13 @@ check_node_is_sproc_on_existing_node_test_() ->
       ?_assertEqual(
          {ok, true},
          begin
-             Fun = fun() ->
-                           khepri_tx:is_sproc([foo, bar])
-                   end,
+             Fun = {khepri_tx, is_sproc, [[foo, bar]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
          {ok, true},
          begin
-             Fun = fun() ->
-                           khepri_tx:is_sproc([foo, bar])
-                   end,
+             Fun = {khepri_tx, is_sproc, [[foo, bar]]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end),
       ?_assertEqual(
@@ -467,6 +619,36 @@ check_node_is_sproc_on_existing_node_test_() ->
              Fun = fun() ->
                            khepri_tx:is_sproc([baz])
                    end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
+check_node_is_sproc_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:is_sproc([foo])
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, false},
+         begin
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -517,17 +699,13 @@ count_existing_node_test_() ->
       ?_assertEqual(
          {ok, {ok, 1}},
          begin
-             Fun = fun() ->
-                           khepri_tx:count([foo])
-                   end,
+             Fun = {khepri_tx, count, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
          {ok, {ok, 1}},
          begin
-             Fun = fun() ->
-                           khepri_tx:count([foo])
-                   end,
+             Fun = {khepri_tx, count, [[foo]]},
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -557,6 +735,36 @@ count_many_nodes_test_() ->
              Fun = fun() ->
                            khepri_tx:count([?KHEPRI_WILDCARD_STAR_STAR])
                    end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end)]}.
+
+count_using_anonymous_fun_test_() ->
+    Fun = fun() ->
+                  khepri_tx:count([foo])
+          end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Fun}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Fun, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, 1}},
+         begin
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
 
@@ -594,17 +802,13 @@ fold_existing_node_test_() ->
       ?_assertEqual(
          {ok, {ok, [[foo]]}},
          begin
-             Tx = fun() ->
-                          khepri_tx:fold([foo], Fun, [])
-                  end,
+             Tx = {khepri_tx, fold, [[foo], Fun, []]},
              khepri:transaction(?FUNCTION_NAME, Tx, ro)
          end),
       ?_assertEqual(
          {ok, {ok, [[foo]]}},
          begin
-             Tx = fun() ->
-                          khepri_tx:fold([foo], Fun, [])
-                  end,
+             Tx = {khepri_tx, fold, [[foo], Fun, []]},
              khepri:transaction(?FUNCTION_NAME, Tx, rw)
          end)]}.
 
@@ -636,6 +840,37 @@ fold_many_nodes_test_() ->
              Tx = fun() ->
                           khepri_tx:fold([?KHEPRI_WILDCARD_STAR_STAR], Fun, [])
                   end,
+             khepri:transaction(?FUNCTION_NAME, Tx, rw)
+         end)]}.
+
+fold_using_anonymous_fun_test_() ->
+    Fun = fun list_nodes_cb/3,
+    Tx = fun() ->
+                 khepri_tx:fold([foo], Fun, [])
+         end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, [[foo]]}},
+         begin
              khepri:transaction(?FUNCTION_NAME, Tx, rw)
          end)]}.
 
@@ -712,9 +947,7 @@ foreach_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Tx = fun() ->
-                          khepri_tx:foreach([foo], Fun)
-                  end,
+             Tx = {khepri_tx, foreach, [[foo], Fun]},
              khepri:transaction(?FUNCTION_NAME, Tx, ro)
          end),
       ?_assertEqual(
@@ -724,9 +957,7 @@ foreach_existing_node_test_() ->
       ?_assertEqual(
          {ok, ok},
          begin
-             Tx = fun() ->
-                          khepri_tx:foreach([foo], Fun)
-                  end,
+             Tx = {khepri_tx, foreach, [[foo], Fun]},
              khepri:transaction(?FUNCTION_NAME, Tx, rw)
          end),
       ?_assertEqual(
@@ -735,7 +966,6 @@ foreach_existing_node_test_() ->
          khepri_adv:get_many(?FUNCTION_NAME, "**"))]}.
 
 foreach_many_nodes_test_() ->
-    Fun = fun foreach_node_cb/2,
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
@@ -749,10 +979,7 @@ foreach_many_nodes_test_() ->
       ?_assertEqual(
          {ok, ok},
          begin
-             Tx = fun() ->
-                          khepri_tx:foreach(
-                            [?THIS_KHEPRI_NODE, ?KHEPRI_WILDCARD_STAR], Fun)
-                  end,
+             Tx = {?MODULE, foreach_node_cb_qf1, []},
              khepri:transaction(?FUNCTION_NAME, Tx, rw)
          end),
       ?_assertEqual(
@@ -766,9 +993,7 @@ foreach_many_nodes_test_() ->
       ?_assertEqual(
          {ok, ok},
          begin
-             Tx = fun() ->
-                          khepri_tx:foreach([?KHEPRI_WILDCARD_STAR_STAR], Fun)
-                  end,
+             Tx = {?MODULE, foreach_node_cb_qf2, []},
              khepri:transaction(?FUNCTION_NAME, Tx, rw)
          end),
       ?_assertEqual(
@@ -779,6 +1004,45 @@ foreach_many_nodes_test_() ->
                 [baz] => #{data => foreach_value2,
                            payload_version => 3}}},
          khepri_adv:get_many(?FUNCTION_NAME, "**"))]}.
+
+foreach_using_anonymous_fun_test_() ->
+    Fun = fun(_Path, _NodeProps) -> ok end,
+    Tx = fun() ->
+                 khepri_tx:foreach([foo], Fun)
+         end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, auto)
+         end),
+      ?_assertEqual(
+         {ok, ok},
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, rw)
+         end)]}.
+
+foreach_node_cb_qf1() ->
+    Fun = fun foreach_node_cb/2,
+    khepri_tx:foreach([?THIS_KHEPRI_NODE, ?KHEPRI_WILDCARD_STAR], Fun).
+
+foreach_node_cb_qf2() ->
+    Fun = fun foreach_node_cb/2,
+    khepri_tx:foreach([?KHEPRI_WILDCARD_STAR_STAR], Fun).
 
 foreach_node_cb(Path, #{data := foreach_value1}) ->
     ok = khepri_tx:put(Path, foreach_value2);
@@ -861,6 +1125,37 @@ map_many_nodes_test_() ->
              khepri:transaction(?FUNCTION_NAME, Tx, rw)
          end)]}.
 
+map_using_anonymous_fun_test_() ->
+    Fun = fun map_node_cb/2,
+    Tx = fun() ->
+                 khepri_tx:map([foo], Fun)
+         end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, #{[foo] => {data, foo_value}}}},
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, rw)
+         end)]}.
+
 map_node_cb(_Path, #{data := Data}) ->
     {data, Data};
 map_node_cb(_Path, _NodeProps) ->
@@ -934,6 +1229,37 @@ filter_many_nodes_test_() ->
                           khepri_tx:filter(
                             [?KHEPRI_WILDCARD_STAR_STAR], Pred)
                   end,
+             khepri:transaction(?FUNCTION_NAME, Tx, rw)
+         end)]}.
+
+filter_using_anonymous_fun_test_() ->
+    Pred = fun filter_node_cb/2,
+    Tx = fun() ->
+                 khepri_tx:filter([foo], Pred)
+         end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, ro)
+         end),
+      ?_assertError(
+         ?khepri_exception(
+            denied_fun_in_non_local_query,
+            #{'fun' := Tx}),
+         begin
+             khepri:transaction(?FUNCTION_NAME, Tx, auto)
+         end),
+      ?_assertEqual(
+         {ok, {ok, #{}}},
+         begin
              khepri:transaction(?FUNCTION_NAME, Tx, rw)
          end)]}.
 

--- a/test/simple_tx_put.erl
+++ b/test/simple_tx_put.erl
@@ -21,9 +21,7 @@ create_non_existing_node_test_() ->
      [?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:create([foo], foo_value)
-                   end,
+             Fun = {khepri_tx, create, [[foo], foo_value]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -102,9 +100,7 @@ insert_non_existing_node_test_() ->
      [?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:put([foo], foo_value)
-                   end,
+             Fun = {khepri_tx, put, [[foo], foo_value]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -129,9 +125,7 @@ insert_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:put([foo], foo_value2)
-                   end,
+             Fun = {khepri_tx, put, [[foo], foo_value2]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -182,10 +176,8 @@ insert_many_non_existing_nodes_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:put_many(
-                             [?KHEPRI_WILDCARD_STAR, foo], foo_value)
-                   end,
+             Fun = {khepri_tx, put_many,
+                    [[?KHEPRI_WILDCARD_STAR, foo], foo_value]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -215,10 +207,8 @@ insert_many_existing_nodes_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:put_many(
-                             [?KHEPRI_WILDCARD_STAR, foo], foo_value_all)
-                   end,
+             Fun = {khepri_tx, put_many,
+                    [[?KHEPRI_WILDCARD_STAR, foo], foo_value_all]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -293,9 +283,7 @@ update_existing_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:update([foo], foo_value2)
-                   end,
+             Fun = {khepri_tx, update, [[foo], foo_value2]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(
@@ -358,10 +346,8 @@ compare_and_swap_matching_node_test_() ->
       ?_assertError(
          ?khepri_exception(denied_update_in_readonly_tx, #{}),
          begin
-             Fun = fun() ->
-                           khepri_tx:compare_and_swap(
-                             [foo], foo_value1, foo_value2)
-                   end,
+             Fun = {khepri_tx, compare_and_swap,
+                    [[foo], foo_value1, foo_value2]},
              khepri:transaction(?FUNCTION_NAME, Fun, ro)
          end),
       ?_assertEqual(

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -22,7 +22,7 @@
         fun() ->
             helpers:init_list_of_modules_to_skip(),
             __Fun = fun() -> Expression end,
-            khepri_tx_adv:to_standalone_fun(__Fun, rw)
+            khepri_tx_adv:to_standalone_fun(__Fun, 0, rw)
         end()).
 
 -define(assertStandaloneFun(Expression),
@@ -535,6 +535,7 @@ when_readwrite_mode_is_true_test() ->
             fun() ->
                     khepri_tx:get([foo])
             end,
+            0,
             rw))),
     ?assert(
        ?IS_HORUS_STANDALONE_FUN(
@@ -542,6 +543,7 @@ when_readwrite_mode_is_true_test() ->
             fun() ->
                     khepri_tx:put([foo], khepri_payload:data(value))
             end,
+            0,
             rw))),
     ?assertError(
        ?khepri_exception(
@@ -555,6 +557,7 @@ when_readwrite_mode_is_true_test() ->
                  _ = khepri_tx:get([foo]),
                  self() ! message
          end,
+         0,
          rw)),
     ?assertError(
        ?khepri_exception(
@@ -568,15 +571,18 @@ when_readwrite_mode_is_true_test() ->
                  _ = khepri_tx:put([foo], khepri_payload:data(value)),
                  self() ! message
          end,
+         0,
          rw)),
     ?assert(
        ?IS_HORUS_STANDALONE_FUN(
           khepri_tx_adv:to_standalone_fun(
             fun mod_used_for_transactions:exported/0,
+            0,
             rw))),
     ?assert(
        is_function(khepri_tx_adv:to_standalone_fun(
                      fun dict:new/0,
+                     0,
                      rw),
                    0)),
 
@@ -585,6 +591,7 @@ when_readwrite_mode_is_true_test() ->
        ?IS_HORUS_STANDALONE_FUN(
           khepri_tx_adv:to_standalone_fun(
             fun() -> Fun() end,
+            0,
             rw))).
 
 when_readwrite_mode_is_false_test() ->
@@ -594,6 +601,7 @@ when_readwrite_mode_is_false_test() ->
                      fun() ->
                              khepri_tx:get([foo])
                      end,
+                     0,
                      ro),
                    0)),
     %% In the following case, `to_standalone()' works, but the transaction
@@ -604,6 +612,7 @@ when_readwrite_mode_is_false_test() ->
                              khepri_tx:put(
                                [foo], khepri_payload:data(value))
                      end,
+                     0,
                      ro),
                    0)),
     ?assert(
@@ -612,6 +621,7 @@ when_readwrite_mode_is_false_test() ->
                              _ = khepri_tx:get([foo]),
                              self() ! message
                      end,
+                     0,
                      ro),
                    0)),
     %% In the following case, `to_standalone()' works, but the transaction
@@ -623,16 +633,19 @@ when_readwrite_mode_is_false_test() ->
                                    [foo], khepri_payload:data(value)),
                              self() ! message
                      end,
+                     0,
                      ro),
                    0)),
     ?assert(
        is_function(khepri_tx_adv:to_standalone_fun(
                      fun mod_used_for_transactions:exported/0,
+                     0,
                      ro),
                    0)),
     ?assert(
        is_function(khepri_tx_adv:to_standalone_fun(
                      fun dict:new/0,
+                     0,
                      ro),
                    0)),
 
@@ -640,6 +653,7 @@ when_readwrite_mode_is_false_test() ->
     ?assert(
        is_function(khepri_tx_adv:to_standalone_fun(
                      fun() -> Fun() end,
+                     0,
                      ro),
                    0)).
 
@@ -650,6 +664,7 @@ when_readwrite_mode_is_auto_test() ->
                      fun() ->
                              khepri_tx:get([foo])
                      end,
+                     0,
                      auto),
                    0)),
     ?assert(
@@ -658,6 +673,7 @@ when_readwrite_mode_is_auto_test() ->
             fun() ->
                     khepri_tx:put([foo], khepri_payload:data(value))
             end,
+            0,
             auto))),
     ?assert(
        is_function(khepri_tx_adv:to_standalone_fun(
@@ -665,6 +681,7 @@ when_readwrite_mode_is_auto_test() ->
                              _ = khepri_tx:get([foo]),
                              self() ! message
                      end,
+                     0,
                      auto),
                    0)),
     ?assertError(
@@ -679,15 +696,18 @@ when_readwrite_mode_is_auto_test() ->
                  _ = khepri_tx:put([foo], khepri_payload:data(value)),
                  self() ! message
          end,
+         0,
          auto)),
     ?assert(
        is_function(khepri_tx_adv:to_standalone_fun(
                      fun mod_used_for_transactions:exported/0,
+                     0,
                      auto),
                    0)),
     ?assert(
        is_function(khepri_tx_adv:to_standalone_fun(
                      fun dict:new/0,
+                     0,
                      auto),
                    0)),
 
@@ -698,4 +718,5 @@ when_readwrite_mode_is_auto_test() ->
        ?IS_HORUS_STANDALONE_FUN(
           khepri_tx_adv:to_standalone_fun(
             fun() -> Fun() end,
+            0,
             auto))).


### PR DESCRIPTION
## Why

Using `fun()` is fragile if it has to be executed on a remote node. Indeed, the remote node may have another version of the module hosting the function and the function reference may be invalid.

## How

There are two parts:

1. We always use an exported function inside Khepri.
2. We ensure that the caller of folding APIs passes MFA if they request leader or consistent queries. `fun()` are only accepted for local queries.

Fixes #238.