### PR TITLE
khepri_cluster: Functions returning members now wrap them in `{ok, Members}`

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -3601,9 +3601,13 @@ info(StoreId) ->
 
 info(StoreId, Options) ->
     io:format("~n\033[1;32m== CLUSTER MEMBERS ==\033[0m~n~n", []),
-    Nodes = lists:sort(
-              [Node || {_, Node} <- khepri_cluster:members(StoreId)]),
-    lists:foreach(fun(Node) -> io:format("~ts~n", [Node]) end, Nodes),
+    case khepri_cluster:nodes(StoreId) of
+        {ok, Nodes} ->
+            Nodes1 = lists:sort(Nodes),
+            lists:foreach(fun(Node) -> io:format("~ts~n", [Node]) end, Nodes1);
+        {error, _} = Error ->
+            io:format("Failed to query cluster members: ~p~n", [Error])
+    end,
 
     case khepri_machine:get_keep_while_conds_state(StoreId, Options) of
         {ok, KeepWhileConds} when KeepWhileConds =/= #{} ->

--- a/test/db_info.erl
+++ b/test/db_info.erl
@@ -125,7 +125,8 @@ get_store_info_on_non_existing_store_test_() ->
       ?_assertEqual(
          "\n"
          "\033[1;32m== CLUSTER MEMBERS ==\033[0m\n"
-         "\n",
+         "\n"
+         "Failed to query cluster members: {error,noproc}\n",
          begin
              #{level := OldLogLevel} = logger:get_primary_config(),
              _ = logger:set_primary_config(level, debug),

--- a/test/test_ra_server_helpers.erl
+++ b/test/test_ra_server_helpers.erl
@@ -30,8 +30,8 @@ cleanup(#{store_id := StoreId} = Props) ->
                 %% If the list is empty, assumed it was running on this node
                 %% but the store was stopped. This is the case in
                 %% app_starts_workers_test_() for instance.
-                [] -> [node()];
-                L  -> L
+                {ok, L}    -> L;
+                {error, _} -> [node()]
             end,
     lists:foreach(
       fun(Node) ->


### PR DESCRIPTION
## Why

Always returning a list, hiding any error behind an empty list, proved to be a bad design, as it made it really difficult to detect errors and act upon them.

This kind of return value was also inconsistent with the rest of the API.

## How

The `members/{0,1,2}`, `locally_known_members/{0,1,2}`, `nodes/{0,1,2}` and `locally_known_nodes/{0,1,2}` functions now return `{ok, List}` or `{error, Reason}`, like other APIs.

The returned list is never empty.

While working on this, the variants taking no arguments were added to work with the default store.

Fixes #243.