### PR TITLE
khepri_machine: Do not enforce `favor` options in machine state queries

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -551,8 +551,7 @@ get_keep_while_conds_state(StoreId, Options)
     Query = fun(#?MODULE{tree = #tree{keep_while_conds = KeepWhileConds}}) ->
                     {ok, KeepWhileConds}
             end,
-    Options1 = Options#{favor => consistency},
-    process_query(StoreId, Query, Options1).
+    process_query(StoreId, Query, Options).
 
 -spec get_projections_state(StoreId, Options) -> Ret when
       StoreId :: khepri:store_id(),
@@ -576,8 +575,7 @@ get_projections_state(StoreId, Options)
     Query = fun(#?MODULE{projections = Projections}) ->
                     {ok, Projections}
             end,
-    Options1 = Options#{favor => consistency},
-    process_query(StoreId, Query, Options1).
+    process_query(StoreId, Query, Options).
 
 -spec split_query_options(Options) -> {QueryOptions, TreeOptions} when
       Options :: QueryOptions | TreeOptions,


### PR DESCRIPTION
## Why

We want to leave the caller decide the consistency it wants.

Also, there is a problem with leader and consistent queries in Ra because the function is executed on a remote node and the function reference or the MFA may not be valid, leading to an exception.

## How

We just stop setting the `favor` option.