### PR TITLE
Fix unregistering non-existent projection when pattern tree is non-empty

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1198,7 +1198,7 @@ apply(
     ProjectionTree1 =
     khepri_pattern_tree:filtermap(
       ProjectionTree,
-      fun (PathPattern, Projections) ->
+      fun (_PathPattern, Projections) ->
               Projections1 =
               lists:filter(
                 fun (#khepri_projection{name = Name} = Projection)
@@ -1212,7 +1212,7 @@ apply(
                   [] ->
                       false;
                   _ ->
-                      {PathPattern, Projections1}
+                      {true, Projections1}
               end
       end),
     Reply = case ProjectionTree1 of

--- a/test/projections.erl
+++ b/test/projections.erl
@@ -609,6 +609,11 @@ unregister_projection_test_() ->
          {"The projection contains the triggered change",
           ?_assertEqual(Data, ets:lookup_element(?MODULE, PathPattern, 2))},
 
+         {"Unregister an unknown projection",
+          ?_assertEqual(
+            {error, {khepri, projection_not_found, #{name => undefined}}},
+            khepri:unregister_projection(?FUNCTION_NAME, undefined))},
+
          {"Unregister the projection",
           ?_assertEqual(
             ok,


### PR DESCRIPTION
Attempting to unregister a projection that doesn't exist failed when the `khepri_pattern_tree` of projections was non-empty (i.e. there was some other projection registered) because the call to `khepri_pattern_tree:filtermap/2` returned a value that breaks the `filtermap/2` spec. Fixing the return value fixes the behavior of unregistering the non-existent projection.

Fixes #247 