### PR TITLE
khepri_machine: Add command deduplication mechanism

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -267,7 +267,8 @@
 
 -type command_options() :: #{timeout => timeout(),
                              async => async_option(),
-                             reply_from => reply_from_option()}.
+                             reply_from => reply_from_option(),
+                             protect_against_dups => boolean()}.
 %% Options used in commands.
 %%
 %% Commands are {@link put/4}, {@link delete/3} and read-write {@link
@@ -279,6 +280,11 @@
 %% command; see {@link async_option()}.</li>
 %% <li>`reply_from' indicates which cluster member should reply to the
 %% command request; see {@link reply_from_option()}.</li>
+%% <li>`protect_against_dups' indicates if the deduplication mechanism should
+%% be used for the command. This mechanism helps to avoid the same command to
+%% be processed multiple times if there is a Ra cluster member stopping or a
+%% change of leadership occurring at the same time. It is disabled by default,
+%% except for R/W transactions.</li>
 %% </ul>
 
 -type favor_option() :: consistency | compromise | low_latency.

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -19,7 +19,7 @@
 -record(khepri_machine_aux,
         {store_id :: khepri:store_id()}).
 
-%% State machine commands.
+%% State machine commands and aux. effects.
 
 -record(put, {path :: khepri_path:native_pattern(),
               payload = ?NO_PAYLOAD :: khepri_payload:payload(),
@@ -56,3 +56,9 @@
 
 -record(restore_projection, {pattern :: khepri_path:native_pattern(),
                              projection :: khepri_projection:projection()}).
+
+-record(dedup, {ref :: reference(),
+                expiry :: integer(),
+                command :: khepri_machine:command()}).
+
+-record(dedup_ack, {ref :: reference()}).

--- a/src/khepri_machine_v0.erl
+++ b/src/khepri_machine_v0.erl
@@ -1,0 +1,201 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2021-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+%% @doc
+%% Khepri machine state V0 handling functions.
+%%
+%% @hidden
+
+-module(khepri_machine_v0).
+
+-include("src/khepri_machine.hrl").
+
+-export([init/1]).
+
+%% Internal functions to access the opaque #khepri_machine{} state.
+-export([is_state/1,
+         get_config/1,
+         get_tree/1, set_tree/2,
+         get_triggers/1, set_triggers/2,
+         get_emitted_triggers/1, set_emitted_triggers/2,
+         get_projections/1, set_projections/2,
+         get_metrics/1, set_metrics/2,
+         state_to_list/1]).
+
+-record(khepri_machine,
+        {config = #config{} :: khepri_machine:machine_config(),
+         tree = #tree{} :: khepri_tree:tree(),
+         triggers = #{} ::
+           #{khepri:trigger_id() =>
+             #{sproc := khepri_path:native_path(),
+               event_filter := khepri_evf:event_filter()}},
+         emitted_triggers = [] :: [khepri_machine:triggered()],
+         projections = khepri_pattern_tree:empty() ::
+                       khepri_machine:projection_tree(),
+         metrics = #{} :: #{applied_command_count => non_neg_integer()}}).
+
+-opaque state() :: #khepri_machine{}.
+%% State of this Ra state machine, version 0.
+
+-export_type([state/0]).
+
+-spec init(Params) -> State when
+      Params :: khepri_machine:machine_init_args(),
+      State :: state().
+%% @private
+
+init(#{store_id := StoreId,
+       member := Member} = Params) ->
+    Config = case Params of
+                 #{snapshot_interval := SnapshotInterval} ->
+                     #config{store_id = StoreId,
+                             member = Member,
+                             snapshot_interval = SnapshotInterval};
+                 _ ->
+                     #config{store_id = StoreId,
+                             member = Member}
+             end,
+    #khepri_machine{config = Config}.
+
+%% -------------------------------------------------------------------
+%% State record management functions.
+%% -------------------------------------------------------------------
+
+-spec is_state(State) -> IsState when
+      State :: khepri_machine_v0:state(),
+      IsState :: boolean().
+%% @doc Tells if the given argument is a valid state.
+%%
+%% @private
+
+is_state(State) ->
+    is_record(State, khepri_machine).
+
+-spec get_config(State) -> Config when
+      State :: khepri_machine_v0:state(),
+      Config :: khepri_machine:machine_config().
+%% @doc Returns the config from the given state.
+%%
+%% @private
+
+get_config(#khepri_machine{config = Config}) ->
+    Config.
+
+-spec get_tree(State) -> Tree when
+      State :: khepri_machine_v0:state(),
+      Tree :: khepri_tree:tree().
+%% @doc Returns the tree from the given state.
+%%
+%% @private
+
+get_tree(#khepri_machine{tree = Tree}) ->
+    Tree.
+
+-spec set_tree(State, Tree) -> NewState when
+      State :: khepri_machine_v0:state(),
+      Tree :: khepri_tree:tree(),
+      NewState :: khepri_machine_v0:state().
+%% @doc Sets the tree in the given state.
+%%
+%% @private
+
+set_tree(#khepri_machine{} = State, Tree) ->
+    State#khepri_machine{tree = Tree}.
+
+-spec get_triggers(State) -> Triggers when
+      State :: khepri_machine_v0:state(),
+      Triggers :: khepri_machine:triggers_map().
+%% @doc Returns the triggers from the given state.
+%%
+%% @private
+
+get_triggers(#khepri_machine{triggers = Triggers}) ->
+    Triggers.
+
+-spec set_triggers(State, Triggers) -> NewState when
+      State :: khepri_machine_v0:state(),
+      Triggers :: khepri_machine:triggers_map(),
+      NewState :: khepri_machine_v0:state().
+%% @doc Sets the triggers in the given state.
+%%
+%% @private
+
+set_triggers(#khepri_machine{} = State, Triggers) ->
+    State#khepri_machine{triggers = Triggers}.
+
+-spec get_emitted_triggers(State) -> EmittedTriggers when
+      State :: khepri_machine_v0:state(),
+      EmittedTriggers :: [khepri_machine:triggered()].
+%% @doc Returns the emitted_triggers from the given state.
+%%
+%% @private
+
+get_emitted_triggers(#khepri_machine{emitted_triggers = EmittedTriggers}) ->
+    EmittedTriggers.
+
+-spec set_emitted_triggers(State, EmittedTriggers) -> NewState when
+      State :: khepri_machine_v0:state(),
+      EmittedTriggers :: [khepri_machine:triggered()],
+      NewState :: khepri_machine_v0:state().
+%% @doc Sets the emitted_triggers in the given state.
+%%
+%% @private
+
+set_emitted_triggers(#khepri_machine{} = State, EmittedTriggers) ->
+    State#khepri_machine{emitted_triggers = EmittedTriggers}.
+
+-spec get_projections(State) -> Projections when
+      State :: khepri_machine_v0:state(),
+      Projections :: khepri_machine:projection_tree().
+%% @doc Returns the projections from the given state.
+%%
+%% @private
+
+get_projections(#khepri_machine{projections = Projections}) ->
+    Projections.
+
+-spec set_projections(State, Projections) -> NewState when
+      State :: khepri_machine_v0:state(),
+      Projections :: khepri_machine:projection_tree(),
+      NewState :: khepri_machine_v0:state().
+%% @doc Sets the projections in the given state.
+%%
+%% @private
+
+set_projections(#khepri_machine{} = State, Projections) ->
+    State#khepri_machine{projections = Projections}.
+
+-spec get_metrics(State) -> Metrics when
+      State :: khepri_machine_v0:state(),
+      Metrics :: khepri_machine:metrics().
+%% @doc Returns the metrics from the given state.
+%%
+%% @private
+
+get_metrics(#khepri_machine{metrics = Metrics}) ->
+    Metrics.
+
+-spec set_metrics(State, Metrics) -> NewState when
+      State :: khepri_machine_v0:state(),
+      Metrics :: khepri_machine:metrics(),
+      NewState :: khepri_machine_v0:state().
+%% @doc Sets the metrics in the given state.
+%%
+%% @private
+
+set_metrics(#khepri_machine{} = State, Metrics) ->
+    State#khepri_machine{metrics = Metrics}.
+
+-spec state_to_list(State) -> Fields when
+      State :: khepri_machine_v0:state(),
+      Fields :: [any()].
+%% @doc Returns the fields of the state as a list.
+%%
+%% @private
+
+state_to_list(#khepri_machine{} = State) ->
+    tuple_to_list(State).

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -982,7 +982,7 @@ run(State, StandaloneFun, Args, AllowUpdates)
 
         {NewState, NewSideEffects} = erlang:erase(?TX_STATE_KEY),
         NewTxProps = erlang:erase(?TX_PROPS),
-        ?assert(khepri_machine:is_state(NewState)),
+        khepri_machine:ensure_is_state(NewState),
         ?assertEqual(TxProps, NewTxProps),
         {NewState, Ret, NewSideEffects}
     catch

--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -9,7 +9,8 @@
 
 -include_lib("stdlib/include/assert.hrl").
 
--export([init_list_of_modules_to_skip/0,
+-export([start_epmd/0,
+         init_list_of_modules_to_skip/0,
          start_ra_system/1,
          stop_ra_system/1,
          store_dir_name/1,
@@ -23,6 +24,21 @@
          format/2]).
 
 -define(CAPTURE_LOGGER_ID, capture_logger).
+
+start_epmd() ->
+    RootDir = code:root_dir(),
+    ErtsVersion = erlang:system_info(version),
+    ErtsDir = lists:flatten(io_lib:format("erts-~ts", [ErtsVersion])),
+    EpmdPath0 = filename:join([RootDir, ErtsDir, "bin", "epmd"]),
+    EpmdPath = case os:type() of
+                   {win32, _} -> EpmdPath0 ++ ".exe";
+                   _          -> EpmdPath0
+               end,
+    Port = erlang:open_port(
+             {spawn_executable, EpmdPath},
+             [{args, ["-daemon"]}]),
+    erlang:port_close(Port),
+    ok.
 
 init_list_of_modules_to_skip() ->
     _ = application:load(khepri),

--- a/test/protect_against_dups_option.erl
+++ b/test/protect_against_dups_option.erl
@@ -1,0 +1,274 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(protect_against_dups_option).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/khepri_machine.hrl").
+-include("src/khepri_error.hrl").
+-include("test/helpers.hrl").
+
+%% khepri:get_root/1 is unexported when compiled without `-DTEST'.
+-dialyzer(no_missing_calls).
+
+multiple_dedup_commands_test() ->
+    S00 = khepri_machine:init(?MACH_PARAMS()),
+    S0 = khepri_machine:convert_state(S00, 0, 1),
+
+    Command = #put{path = [foo],
+                   payload = khepri_payload:data(value),
+                   options = #{expect_specific_node => true,
+                               props_to_return => [payload,
+                                                   payload_version]}},
+    CommandRef = make_ref(),
+    Expiry = erlang:system_time(millisecond) + 5000,
+    DedupCommand = #dedup{ref = CommandRef,
+                          expiry = Expiry,
+                          command = Command},
+    {S1, Ret1, SE1} = khepri_machine:apply(?META, DedupCommand, S0),
+    ExpectedRet = {ok, #{[foo] => #{payload_version => 1}}},
+
+    Dedups1 = khepri_machine:get_dedups(S1),
+    ?assertEqual(#{CommandRef => {ExpectedRet, Expiry}}, Dedups1),
+
+    Root1 = khepri_machine:get_root(S1),
+    ?assertEqual(
+       #node{
+          props =
+          #{payload_version => 1,
+            child_list_version => 2},
+          child_nodes =
+          #{foo =>
+            #node{
+               props = ?INIT_NODE_PROPS,
+               payload = khepri_payload:data(value)}}},
+       Root1),
+    ?assertEqual(ExpectedRet, Ret1),
+    ?assertEqual([], SE1),
+
+    %% The put command is idempotent, so not really ideal to test
+    %% deduplication. Instead, we mess up with the state and silently restore
+    %% the initial empty tree. If the dedup mechanism works, the returned
+    %% state shouldn't have the `foo' node either because it didn't process
+    %% the command.
+    PatchedS1 = khepri_machine:set_tree(S1, khepri_machine:get_tree(S0)),
+    {S2, Ret2, SE2} = khepri_machine:apply(?META, DedupCommand, PatchedS1),
+
+    Dedups2 = khepri_machine:get_dedups(S2),
+    ?assertEqual(#{CommandRef => {ExpectedRet, Expiry}}, Dedups2),
+
+    Root0 = khepri_machine:get_root(S0),
+    Root2 = khepri_machine:get_root(S2),
+    ?assertEqual(Root0, Root2),
+
+    ?assertEqual(ExpectedRet, Ret2),
+    ?assertEqual([], SE2).
+
+dedup_and_dedup_ack_test() ->
+    S00 = khepri_machine:init(?MACH_PARAMS()),
+    S0 = khepri_machine:convert_state(S00, 0, 1),
+
+    Command = #put{path = [foo],
+                   payload = khepri_payload:data(value),
+                   options = #{expect_specific_node => true,
+                               props_to_return => [payload,
+                                                   payload_version]}},
+    CommandRef = make_ref(),
+    Expiry = erlang:system_time(millisecond) + 5000,
+    DedupCommand = #dedup{ref = CommandRef,
+                          expiry = Expiry,
+                          command = Command},
+    {S1, Ret1, SE1} = khepri_machine:apply(?META, DedupCommand, S0),
+    ExpectedRet = {ok, #{[foo] => #{payload_version => 1}}},
+
+    Dedups1 = khepri_machine:get_dedups(S1),
+    ?assertEqual(#{CommandRef => {ExpectedRet, Expiry}}, Dedups1),
+
+    Root1 = khepri_machine:get_root(S1),
+    ?assertEqual(
+       #node{
+          props =
+          #{payload_version => 1,
+            child_list_version => 2},
+          child_nodes =
+          #{foo =>
+            #node{
+               props = ?INIT_NODE_PROPS,
+               payload = khepri_payload:data(value)}}},
+       Root1),
+    ?assertEqual(ExpectedRet, Ret1),
+    ?assertEqual([], SE1),
+
+    DedupAck = #dedup_ack{ref = CommandRef},
+    {S2, Ret2, SE2} = khepri_machine:apply(?META, DedupAck, S1),
+
+    Dedups2 = khepri_machine:get_dedups(S2),
+    ?assertEqual(#{}, Dedups2),
+
+    Root2 = khepri_machine:get_root(S2),
+    ?assertEqual(
+       #node{
+          props =
+          #{payload_version => 1,
+            child_list_version => 2},
+          child_nodes =
+          #{foo =>
+            #node{
+               props = ?INIT_NODE_PROPS,
+               payload = khepri_payload:data(value)}}},
+       Root2),
+    ?assertEqual(ok, Ret2),
+    ?assertEqual([], SE2).
+
+dedup_expiry_test() ->
+    S00 = khepri_machine:init(?MACH_PARAMS()),
+    S0 = khepri_machine:convert_state(S00, 0, 1),
+
+    Command = #put{path = [foo],
+                   payload = khepri_payload:data(value),
+                   options = #{expect_specific_node => true,
+                               props_to_return => [payload,
+                                                   payload_version]}},
+    CommandRef = make_ref(),
+    Delay = 2000,
+    Expiry = erlang:system_time(millisecond) + Delay,
+    DedupCommand = #dedup{ref = CommandRef,
+                          expiry = Expiry,
+                          command = Command},
+    {S1, Ret1, SE1} = khepri_machine:apply(?META, DedupCommand, S0),
+    ExpectedRet = {ok, #{[foo] => #{payload_version => 1}}},
+
+    Dedups1 = khepri_machine:get_dedups(S1),
+    ?assertEqual(#{CommandRef => {ExpectedRet, Expiry}}, Dedups1),
+
+    Root1 = khepri_machine:get_root(S1),
+    ?assertEqual(
+       #node{
+          props =
+          #{payload_version => 1,
+            child_list_version => 2},
+          child_nodes =
+          #{foo =>
+            #node{
+               props = ?INIT_NODE_PROPS,
+               payload = khepri_payload:data(value)}}},
+       Root1),
+    ?assertEqual(ExpectedRet, Ret1),
+    ?assertEqual([], SE1),
+
+    timer:sleep(Delay + 1000),
+
+    %% The put command is idempotent, so not really ideal to test
+    %% deduplication. Instead, we mess up with the state and silently restore
+    %% the initial empty tree. If the dedup mechanism works, the returned
+    %% state shouldn't have the `foo' node either because it didn't process
+    %% the command.
+    PatchedS1 = khepri_machine:set_tree(S1, khepri_machine:get_tree(S0)),
+    {S2, Ret2, SE2} = khepri_machine:apply(?META, DedupCommand, PatchedS1),
+
+    %% The dedups entry was dropped at the end of apply because it expired.
+    Dedups2 = khepri_machine:get_dedups(S2),
+    ?assertEqual(#{}, Dedups2),
+
+    Root0 = khepri_machine:get_root(S0),
+    Root2 = khepri_machine:get_root(S2),
+    ?assertEqual(Root0, Root2),
+
+    ?assertEqual(ExpectedRet, Ret2),
+    ?assertEqual([], SE2).
+
+dedup_ack_after_no_dedup_test() ->
+    S00 = khepri_machine:init(?MACH_PARAMS()),
+    S0 = khepri_machine:convert_state(S00, 0, 1),
+
+    CommandRef = make_ref(),
+    DedupAck = #dedup_ack{ref = CommandRef},
+    {S1, Ret1, SE1} = khepri_machine:apply(?META, DedupAck, S0),
+
+    Dedups1 = khepri_machine:get_dedups(S1),
+    ?assertEqual(#{}, Dedups1),
+
+    Root1 = khepri_machine:get_root(S1),
+    ?assertEqual(
+       #node{
+          props =
+          #{payload_version => 1,
+            child_list_version => 1},
+          child_nodes = #{}},
+       Root1),
+    ?assertEqual(ok, Ret1),
+    ?assertEqual([], SE1).
+
+dedup_on_old_machine_test() ->
+    S00 = khepri_machine:init(?MACH_PARAMS()),
+    S0 = khepri_machine:convert_state(S00, 0, 1),
+
+    Command = #put{path = [foo],
+                   payload = khepri_payload:data(value),
+                   options = #{expect_specific_node => true,
+                               props_to_return => [payload,
+                                                   payload_version]}},
+    CommandRef = make_ref(),
+    Expiry = erlang:system_time(millisecond) + 5000,
+    DedupCommand = #dedup{ref = CommandRef,
+                          expiry = Expiry,
+                          command = Command},
+    MacVer = 0,
+
+    Meta0 = ?META,
+    Meta = Meta0#{machine_version => MacVer},
+    {S1, Ret1, _SE1} = khepri_machine:apply(Meta, DedupCommand, S0),
+
+    Dedups1 = khepri_machine:get_dedups(S1),
+    ?assertEqual(#{}, Dedups1),
+
+    Root1 = khepri_machine:get_root(S1),
+    ?assertEqual(
+       #node{
+          props =
+          #{payload_version => 1,
+            child_list_version => 1},
+          child_nodes = #{}},
+       Root1),
+    ?assertEqual(
+       {error, ?khepri_exception(
+                  unknown_khepri_state_machine_command,
+                  #{command => DedupCommand,
+                    machine_version => MacVer})},
+       Ret1).
+
+dedup_ack_on_old_machine_test() ->
+    S00 = khepri_machine:init(?MACH_PARAMS()),
+    S0 = khepri_machine:convert_state(S00, 0, 1),
+
+    CommandRef = make_ref(),
+    DedupAck = #dedup_ack{ref = CommandRef},
+    MacVer = 0,
+
+    Meta0 = ?META,
+    Meta = Meta0#{machine_version => MacVer},
+    {S1, Ret1, _SE1} = khepri_machine:apply(Meta, DedupAck, S0),
+
+    Dedups1 = khepri_machine:get_dedups(S1),
+    ?assertEqual(#{}, Dedups1),
+
+    Root1 = khepri_machine:get_root(S1),
+    ?assertEqual(
+       #node{
+          props =
+          #{payload_version => 1,
+            child_list_version => 1},
+          child_nodes = #{}},
+       Root1),
+    ?assertEqual(
+       {error, ?khepri_exception(
+                  unknown_khepri_state_machine_command,
+                  #{command => DedupAck,
+                    machine_version => MacVer})},
+       Ret1).

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -55,9 +55,9 @@ allowed_khepri_tx_api_test() ->
        end).
 
 denied_khepri_tx_adv_run_4_test() ->
-    Config = #config{store_id = ?FUNCTION_NAME,
-                     member = {?FUNCTION_NAME, node()}},
-    MachineState = khepri_machine:make_virgin_state(Config),
+    Params = #{store_id => ?FUNCTION_NAME,
+               member => {?FUNCTION_NAME, node()}},
+    MachineState = khepri_machine:make_virgin_state(Params),
     ?assertToFunError(
        ?khepri_exception(
           failed_to_prepare_tx_fun,


### PR DESCRIPTION
## Why

The "client" side of `khepri_machine` implemented in `process_sync_command/3` have a retry mechanism if `ra:process_command/3` returns an error such as `noproc`, `nodedown` or `shutdown`.

However, this retry mechanism can't tell if the state machine already received the command and just couldn't reply, for instance because there is a node stopping or a change of leadership.

Therefore, it's possible that the same command is submitted twice and thus processed twice.

That's ok for idempotent commands, but it may not be alright for all transactions for example. That's why we need a deduplication mechanism that ensures the same command is not applied multiple times.

## How

Two new commands are introduced to implement the deduplication system:
* `#dedup{}` which is used to wrap the command to protect and assign a unique reference to it
* `#dedup_ack{}` which is used at the end of the retry loop to let the state machine know that the "client" side received the reply

When the state machine receives a command wrapped into a `#dedup{}` command, it will remember the reply for the initial processing of that command. For any subsequent copies of the same `#dedup{}` (based on the unique reference), the state machine will not apply the wrapped command and will simply returned the reply it remembered from the first application.

Later when the state machine receives a `#dedup_ack{}`, it will drop the cached reply for that reference.

Just in case the client never sends a `#dedup_ack{}`, the state machine will drop any expired cached entries. The expiration time is based on the command timeout. If it's infinity, it defaults to 15 minutes.

This whole deduplication mechanism can be enabled or disabled through the new `protect_against_dups` command option which takes a boolean. This option is off by default, except for R/W transactions.

Thus if the caller knows the transation is idempotent, it can decide to turn the dedup mechanism off.

**V2**: We now use the `effective_machine_version` counter provided by `ra_counters:counters/2` if it is available as it is faster than querying the Ra server. If the counter is unavailable, we fall back to the query. The new counter is added by rabbitmq/ra#426 and will be used once a Ra release contains this change.