### PR TITLE
khepri_machine: Handle unknown state machine commands

### DIFF
--- a/test/helpers.hrl
+++ b/test/helpers.hrl
@@ -5,9 +5,10 @@
 %% Copyright © 2021-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 %%
 
--define(META, #{index => ?LINE,
-                term => 1,
-                system_time => ?LINE}).
+-define(META, #{term => 1,
+                index => ?LINE,
+                system_time => erlang:system_time(millisecond),
+                machine_version => khepri_machine:version()}).
 
 -define(MACH_PARAMS(),
         #{store_id => ?FUNCTION_NAME,

--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -16,7 +16,8 @@
 
 -dialyzer([{nowarn_function,
             [use_an_invalid_path_test_/0,
-             use_an_invalid_payload_test_/0]}]).
+             use_an_invalid_payload_test_/0,
+             submit_unknown_command_test_/0]}]).
 
 insert_a_node_test_() ->
     {setup,
@@ -156,3 +157,17 @@ use_an_invalid_payload_test_() ->
            [foo],
            {invalid_payload, in_a_tuple},
            #{}))]}.
+
+submit_unknown_command_test_() ->
+    UnknownCommand = unknown_command,
+    MacVer = khepri_machine:version(),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertError(
+         ?khepri_exception(
+            unknown_khepri_state_machine_command,
+            #{command := UnknownCommand,
+              machine_version := MacVer}),
+         khepri_machine:process_command(
+           ?FUNCTION_NAME, unknown_command, #{}))]}.


### PR DESCRIPTION
## Why

In the future, we will introduce new commands that older versions of the state machine won't know about.

Before this commit, the state machine would crash with a function clause exception. This could be lead to a Ra cluster having a hard time to recover if all Ra servers crash.

## How

If the machine is asked to apply an unknown command, it returns an error. This error is converted to an exception in
`khepri_machine:process_command()`.

While here:
* Add `machine_version` and a valid `system_time` value to the `?META` macro used by tests.
* Fix an invalid log message where arguments to `?LOG_DEBUG()` were incorrect.

**V2**: Log an error using a `mod_call` side effect, not directly from the state machine process using `?LOG_ERROR`. The former solution would log on all Ra cluster members and even during recovery. The `mod_call` side effect is only processed by the leader.