### PR TITLE
Make `#khepri_machine{}` private

### DIFF
--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -208,10 +208,9 @@ export(StoreId, PathPattern, Module, ModulePriv)
       Ret :: ok | {ok, ModulePriv} | {error, any()}.
 %% @private
 
-do_export(
-  #khepri_machine{tree = Tree} = State,
-  PathPattern, Module, ModulePriv) ->
+do_export(State, PathPattern, Module, ModulePriv) ->
     %% Initialize export using the callback module.
+    Tree = khepri_machine:get_tree(State),
     case open_write(Module, ModulePriv) of
         {ok, ModulePriv1} ->
             %% Prepare the traversal.
@@ -274,10 +273,8 @@ open_write(Module, ModulePriv) ->
       Ret :: {ok, ModulePriv} | {error, any()}.
 %% @private
 
-write(
-  #khepri_machine{tree = #tree{keep_while_conds = KeepWhileConds}},
-  Path, #node{payload = Payload},
-  Module, ModulePriv) ->
+write(State, Path, #node{payload = Payload}, Module, ModulePriv) ->
+    #tree{keep_while_conds = KeepWhileConds} = khepri_machine:get_tree(State),
     PutOptions = case KeepWhileConds of
                      #{Path := KeepWhile} -> #{keep_while => KeepWhile};
                      _                    -> #{}

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -16,19 +16,6 @@
          member :: ra:server_id(),
          snapshot_interval = ?SNAPSHOT_INTERVAL :: non_neg_integer()}).
 
-%% State machine's internal state record.
--record(khepri_machine,
-        {config = #config{} :: khepri_machine:machine_config(),
-         tree = #tree{} :: khepri_tree:tree(),
-         triggers = #{} ::
-           #{khepri:trigger_id() =>
-             #{sproc := khepri_path:native_path(),
-               event_filter := khepri_evf:event_filter()}},
-         emitted_triggers = [] :: [khepri_machine:triggered()],
-         projections = khepri_pattern_tree:empty() ::
-                       khepri_machine:projection_tree(),
-         metrics = #{} :: #{applied_command_count => non_neg_integer()}}).
-
 -record(khepri_machine_aux,
         {store_id :: khepri:store_id()}).
 

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -459,8 +459,8 @@ count(PathPattern) ->
 
 count(PathPattern, Options) ->
     PathPattern1 = khepri_tx_adv:path_from_string(PathPattern),
-    {#khepri_machine{tree = Tree},
-     _SideEffects} = khepri_tx_adv:get_tx_state(),
+    {State, _SideEffects} = khepri_tx_adv:get_tx_state(),
+    Tree = khepri_machine:get_tree(State),
     Fun = fun khepri_tree:count_node_cb/3,
     {_QueryOptions, TreeOptions} = khepri_machine:split_query_options(Options),
     TreeOptions1 = TreeOptions#{expect_specific_node => false},
@@ -510,8 +510,8 @@ fold(PathPattern, Fun, Acc) ->
 
 fold(PathPattern, Fun, Acc, Options) ->
     PathPattern1 = khepri_tx_adv:path_from_string(PathPattern),
-    {#khepri_machine{tree = Tree},
-     _SideEffects} = khepri_tx_adv:get_tx_state(),
+    {State, _SideEffects} = khepri_tx_adv:get_tx_state(),
+    Tree = khepri_machine:get_tree(State),
     {_QueryOptions, TreeOptions} = khepri_machine:split_query_options(Options),
     TreeOptions1 = TreeOptions#{expect_specific_node => false},
     Ret = khepri_tree:fold(Tree, PathPattern1, Fun, Acc, TreeOptions1),
@@ -996,6 +996,6 @@ abort(Reason) ->
 is_transaction() ->
     StateAndSideEffects = erlang:get(?TX_STATE_KEY),
     case StateAndSideEffects of
-        {#khepri_machine{}, _SideEffects} -> true;
-        _                                 -> false
+        {_State, _SideEffects} -> true;
+        _                      -> false
     end.

--- a/src/khepri_utils.erl
+++ b/src/khepri_utils.erl
@@ -43,6 +43,8 @@
                           child_nodes => #{khepri_path:node_id() =>
                                            display_tree()}}.
 
+-export_type([display_tree/0]).
+
 -spec start_timeout_window(Timeout) -> Timestamp | none when
       Timeout :: timeout(),
       Timestamp :: integer().

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1536,7 +1536,7 @@ can_set_snapshot_interval(Config) ->
        #{},
        khepri_machine:process_query(
          StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
+         fun khepri_machine:get_metrics/1,
          #{})),
 
     ct:pal("Use database after starting it"),
@@ -1547,7 +1547,7 @@ can_set_snapshot_interval(Config) ->
        #{applied_command_count => 1},
        khepri_machine:process_query(
          StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
+         fun khepri_machine:get_metrics/1,
          #{})),
 
     ct:pal("Use database after starting it"),
@@ -1558,7 +1558,7 @@ can_set_snapshot_interval(Config) ->
        #{applied_command_count => 2},
        khepri_machine:process_query(
          StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
+         fun khepri_machine:get_metrics/1,
          #{})),
 
     ct:pal("Use database after starting it"),
@@ -1569,7 +1569,7 @@ can_set_snapshot_interval(Config) ->
        #{},
        khepri_machine:process_query(
          StoreId,
-         fun(#khepri_machine{metrics = Metrics}) -> Metrics end,
+         fun khepri_machine:get_metrics/1,
          #{})),
 
     ct:pal("Stop database"),

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -22,9 +22,11 @@ delete_non_existing_node_test() ->
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({ok, #{}}, Ret),
     ?assertEqual([], SE).
 
@@ -34,9 +36,11 @@ delete_non_existing_node_under_non_existing_parent_test() ->
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({ok, #{}}, Ret),
     ?assertEqual([], SE).
 
@@ -302,23 +306,27 @@ delete_command_bumps_applied_command_count_test() ->
                                snapshot_interval => 3,
                                commands => Commands}),
 
-    ?assertEqual(#{}, S0#khepri_machine.metrics),
+    ?assertEqual(#{}, khepri_machine:get_metrics(S0)),
 
     Command1 = #delete{path = [bar]},
     {S1, _, SE1} = khepri_machine:apply(?META, Command1, S0),
 
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual([], SE1),
 
     Command2 = #delete{path = [baz]},
     {S2, _, SE2} = khepri_machine:apply(?META, Command2, S1),
 
-    ?assertEqual(#{applied_command_count => 2}, S2#khepri_machine.metrics),
+    ?assertEqual(
+       #{applied_command_count => 2},
+       khepri_machine:get_metrics(S2)),
     ?assertEqual([], SE2),
 
     Command3 = #delete{path = [qux]},
     Meta = ?META,
     {S3, _, SE3} = khepri_machine:apply(Meta, Command3, S2),
 
-    ?assertEqual(#{}, S3#khepri_machine.metrics),
+    ?assertEqual(#{}, khepri_machine:get_metrics(S3)),
     ?assertEqual([{release_cursor, maps:get(index, Meta), S3}], SE3).

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -108,9 +108,11 @@ insert_when_keep_while_false_test() ->
     {S1, Ret1, SE1} = khepri_machine:apply(?META, Command1, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({error,
                   ?khepri_error(
                      keep_while_conditions_not_met,
@@ -129,9 +131,11 @@ insert_when_keep_while_false_test() ->
     {S2, Ret2, SE2} = khepri_machine:apply(?META, Command2, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S2#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S2)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S2)),
     ?assertEqual({error,
                   ?khepri_error(
                      keep_while_conditions_not_met,

--- a/test/put_command.erl
+++ b/test/put_command.erl
@@ -244,9 +244,11 @@ insert_a_node_with_condition_false_on_self_test() ->
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({error,
                   ?khepri_error(
                      mismatching_node,
@@ -309,9 +311,11 @@ insert_a_node_with_condition_false_on_self_using_dot_test() ->
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({error,
                   ?khepri_error(
                      mismatching_node,
@@ -374,9 +378,11 @@ insert_a_node_with_condition_false_on_parent_test() ->
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({error,
                   ?khepri_error(
                      mismatching_node,
@@ -409,7 +415,9 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
     {S1, Ret1, SE1} = khepri_machine:apply(?META, Command1, S0),
     Root = khepri_machine:get_root(S1),
 
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual(
        #node{
           props = #{payload_version => 1,
@@ -439,9 +447,11 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
     {S2, Ret2, SE2} = khepri_machine:apply(?META, Command2, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S2#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S2#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S2)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S2)),
     ?assertEqual({error,
                   ?khepri_error(
                      node_not_found,
@@ -466,9 +476,11 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
     {S1, Ret1, SE1} = khepri_machine:apply(?META, Command1, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({error,
                   ?khepri_error(
                      mismatching_node,
@@ -490,7 +502,9 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
     {S2, Ret2, SE2} = khepri_machine:apply(?META, Command2, S0),
     Root = khepri_machine:get_root(S2),
 
-    ?assertEqual(#{applied_command_count => 1}, S2#khepri_machine.metrics),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S2)),
     ?assertEqual(
        #node{
           props = #{payload_version => 1,
@@ -556,9 +570,11 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
     {S2, Ret2, SE2} = khepri_machine:apply(?META, Command2, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S2#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S2#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S2)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S2)),
     ?assertEqual({error,
                   ?khepri_error(
                      node_not_found,
@@ -584,9 +600,11 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
     {S1, Ret1, SE1} = khepri_machine:apply(?META, Command1, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual({error,
                   ?khepri_error(
                      mismatching_node,
@@ -609,7 +627,9 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
     {S2, Ret2, SE2} = khepri_machine:apply(?META, Command2, S0),
     Root = khepri_machine:get_root(S2),
 
-    ?assertEqual(#{applied_command_count => 1}, S2#khepri_machine.metrics),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S2)),
     ?assertEqual(
        #node{
           props = #{payload_version => 1,
@@ -646,9 +666,11 @@ insert_with_a_path_matching_many_nodes_test() ->
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
 
     ?assertEqual(
-      S0#khepri_machine.tree#tree.root,
-      S1#khepri_machine.tree#tree.root),
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+      khepri_machine:get_root(S0),
+      khepri_machine:get_root(S1)),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual(
        {error,
         ?khepri_exception(
@@ -698,20 +720,24 @@ put_command_bumps_applied_command_count_test() ->
                                snapshot_interval => 3,
                                commands => Commands}),
 
-    ?assertEqual(#{}, S0#khepri_machine.metrics),
+    ?assertEqual(#{}, khepri_machine:get_metrics(S0)),
 
     Command1 = #put{path = [bar],
                     payload = ?NO_PAYLOAD},
     {S1, _, SE1} = khepri_machine:apply(?META, Command1, S0),
 
-    ?assertEqual(#{applied_command_count => 1}, S1#khepri_machine.metrics),
+    ?assertEqual(
+       #{applied_command_count => 1},
+       khepri_machine:get_metrics(S1)),
     ?assertEqual([], SE1),
 
     Command2 = #put{path = [baz],
                     payload = ?NO_PAYLOAD},
     {S2, _, SE2} = khepri_machine:apply(?META, Command2, S1),
 
-    ?assertEqual(#{applied_command_count => 2}, S2#khepri_machine.metrics),
+    ?assertEqual(
+       #{applied_command_count => 2},
+       khepri_machine:get_metrics(S2)),
     ?assertEqual([], SE2),
 
     Command3 = #put{path = [qux],
@@ -719,5 +745,5 @@ put_command_bumps_applied_command_count_test() ->
     Meta = ?META,
     {S3, _, SE3} = khepri_machine:apply(Meta, Command3, S2),
 
-    ?assertEqual(#{}, S3#khepri_machine.metrics),
+    ?assertEqual(#{}, khepri_machine:get_metrics(S3)),
     ?assertEqual([{release_cursor, maps:get(index, Meta), S3}], SE3).

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -55,10 +55,9 @@ allowed_khepri_tx_api_test() ->
        end).
 
 denied_khepri_tx_adv_run_4_test() ->
-    MachineState = #khepri_machine{
-                      config = #config{store_id = ?FUNCTION_NAME,
-                                       member = {?FUNCTION_NAME, node()}}
-                     },
+    Config = #config{store_id = ?FUNCTION_NAME,
+                     member = {?FUNCTION_NAME, node()}},
+    MachineState = khepri_machine:make_virgin_state(Config),
     ?assertToFunError(
        ?khepri_exception(
           failed_to_prepare_tx_fun,


### PR DESCRIPTION
## Why

With the upcoming need to add a field to implement command deduplication, we will have two versions of the record for the machine state.

If we expose the definition, it will be more complicate to track which one we are using.

## How

The record definition is moved to `src/khepri_machine.erl` and made an opaque type.

The module exports functions to access the fields of the record without ever exposing the record itself. Most of these functions were already exported if `TEST` was defined at compile-time. This is no longer needed.