### PR TITLE
Use effects to initialize new projections

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -76,6 +76,7 @@
          get_triggers/1,
          get_emitted_triggers/1,
          get_projections/1,
+         has_projection/2,
          get_metrics/1]).
 -ifdef(TEST).
 -export([make_virgin_state/1]).
@@ -1906,6 +1907,25 @@ set_emitted_triggers(#khepri_machine{} = State, EmittedTriggers) ->
 
 get_projections(#khepri_machine{projections = Projections}) ->
     Projections.
+
+-spec has_projection(ProjectionTree, ProjectionName) -> boolean() when
+      ProjectionTree :: khepri_machine:projection_tree(),
+      ProjectionName :: atom().
+%% @doc Determines if the given projection tree contains a projection.
+%%
+%% Two projections are considered equal if they have the same name.
+%%
+%% @private
+
+has_projection(ProjectionTree, Name) when is_atom(Name) ->
+    khepri_pattern_tree:any(
+      ProjectionTree,
+      fun(Projections) ->
+              lists:any(
+                fun(#khepri_projection{name = N}) ->
+                        N =:= Name
+                end, Projections)
+      end).
 
 -spec set_projections(State, Projections) -> NewState when
       State :: khepri_machine:state(),

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -53,3 +53,6 @@
                              old_props :: khepri:node_props(),
                              new_props :: khepri:node_props(),
                              projection :: khepri_projection:projection()}).
+
+-record(restore_projection, {pattern :: khepri_path:native_pattern(),
+                             projection :: khepri_projection:projection()}).

--- a/src/khepri_pattern_tree.erl
+++ b/src/khepri_pattern_tree.erl
@@ -42,6 +42,8 @@
 
 -type update_fun(Payload) :: fun((Payload) -> Payload).
 
+-type find_fun(Payload) :: fun((Payload) -> boolean()).
+
 -export_type([tree_node/1,
               tree/1]).
 
@@ -51,7 +53,8 @@
          fold/5,
          foreach/2,
          compile/1,
-         filtermap/2]).
+         filtermap/2,
+         any/2]).
 
 -spec empty() -> TreeNode when
       TreeNode :: khepri_pattern_tree:tree(Payload),
@@ -331,3 +334,21 @@ filtermap1(
                            end
                    end, ChildNodes0),
     #pattern_node{payload = Payload, child_nodes = ChildNodes}.
+
+-spec any(PatternTree, FindFun) -> Ret when
+      PatternTree :: khepri_pattern_tree:tree(Payload),
+      FindFun :: find_fun(Payload),
+      Ret :: payload() | undefined,
+      Payload :: payload().
+%% @doc Determines whether the pattern tree contains a tree node with a payload
+%% that matches the given predicate.
+%%
+%% @param PatternTree the tree to search.
+%% @param FindFun the predicate with which to evaluate tree nodes.
+%% @returns `true' if the predicate evaluates as `true' for any payload,
+%%          `false' otherwise.
+
+any(#pattern_node{payload = Payload, child_nodes = Children}, FindFun) ->
+    (Payload =/= ?NO_PAYLOAD andalso FindFun(Payload)) orelse
+        lists:any(
+          fun(Child) -> any(Child, FindFun) end, maps:values(Children)).

--- a/test/projections.erl
+++ b/test/projections.erl
@@ -33,6 +33,11 @@ trigger_simple_projection_on_path_test_() ->
                       ?FUNCTION_NAME, PathPattern, Projection))
               end)},
 
+         {"The store contains the projection",
+          ?_assertEqual(
+            true,
+            khepri:has_projection(?FUNCTION_NAME, ?MODULE))},
+
          {"Trigger the projection",
           ?_assertEqual(
             ok,
@@ -618,6 +623,11 @@ unregister_projection_test_() ->
           ?_assertEqual(
             ok,
             khepri:unregister_projection(?FUNCTION_NAME, ?MODULE))},
+
+         {"The store no longer contains the projection",
+          ?_assertEqual(
+            false,
+            khepri:has_projection(?FUNCTION_NAME, ?MODULE))},
 
          {"The projection table no longer exists",
           ?_assertEqual(undefined, ets:info(?MODULE))},

--- a/test/projections.erl
+++ b/test/projections.erl
@@ -288,7 +288,8 @@ duplicate_registrations_give_an_error_test_() ->
               begin
                   Projection = khepri_projection:new(?MODULE, ProjectFun),
                   ?assertEqual(
-                    {error, exists},
+                    {error, ?khepri_error(projection_already_exists,
+                                          #{name => ?MODULE})},
                     khepri:register_projection(
                       ?FUNCTION_NAME, PathPattern, Projection))
               end)}]


### PR DESCRIPTION
`khepri_machine` shouldn't initialize projections in its `apply/3` callback. That function might be called by Ra when recovering and folding through the log from a snapshot. If the log contains a `#register_projection{}` command then Khepri will mistakenly create the ETS table and fill it with whatever is in the tree at that moment. Effects like `#trigger_projection{}` are discarded during recovery, so restarting a server could lead to inconsistencies in projection tables between cluster members.

Instead we can use an aux effect to perform the side effects like we do already for `restore_projections` and `#trigger_projection{}` effects. This will be correctly discarded when Khepri is recovering. Then projections will be correctly restored once the machine is recovered with the existing `state_enter(recovered, State)` callback implementation.

To make the `#register_projection{}` `apply/3` clause pure I've added a helper `khepri_machine:has_projection/2`. Exposing it as `khepri:has_projection/2` isn't strictly necessary for this fix but it could be a nice win to take advantage of in the server. Currently we submit `#register_projection{}` commands every time the broker starts and rely on idempotency. A large projection function could be a non-trivial amount of data to store in the log though, so it would be nice to skip the command if we can detect that the projection is already registered.