### PR TITLE
Simplify `{error,timeout}` error type

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -765,8 +765,8 @@ reset_remotely_and_join_locked(
                 Error ->
                     Error
             end;
-        {timeout, _} = TimedOut ->
-            {error, TimedOut};
+        {timeout, _} ->
+            {error, timeout};
         {error, _} = Error ->
             Error
     end;
@@ -867,8 +867,8 @@ do_join_locked(StoreId, ThisMember, RemoteNode, Timeout) ->
             %% point.
             _ = trigger_election(ThisMember, Timeout1),
             case Error of
-                {timeout, _} = TimedOut -> {error, TimedOut};
-                {error, _}              -> Error
+                {timeout, _} -> {error, timeout};
+                {error, _}   -> Error
             end
     end.
 
@@ -993,8 +993,8 @@ do_reset(RaSystem, StoreId, ThisMember, Timeout) ->
                     forget_store(StoreId),
                     ok
             end;
-        {timeout, _} = TimedOut ->
-            {error, TimedOut};
+        {timeout, _} ->
+            {error, timeout};
         {error, _} = Error ->
             Error
     end.

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -738,8 +738,8 @@ process_sync_command(StoreId, Command, Options) ->
               StoreId, LeaderId, NewLeaderId),
             just_did_consistent_call(StoreId),
             ?raise_exception_if_any(Ret);
-        {timeout, _} = TimedOut ->
-            {error, TimedOut};
+        {timeout, _LeaderId} ->
+            {error, timeout};
         {error, Reason}
           when LeaderId =/= undefined andalso ?HAS_TIME_LEFT(Timeout) andalso
                (Reason == noproc orelse Reason == nodedown orelse
@@ -916,8 +916,8 @@ process_query_response(
     ?raise_exception_if_any(Ret);
 process_query_response(
   _StoreId, _RaServer, _IsLeader, _QueryFun, _QueryType, _Timeout,
-  {timeout, _} = TimedOut) ->
-    {error, TimedOut};
+  {timeout, _LeaderId}) ->
+    {error, timeout};
 process_query_response(
   StoreId, _RaServer, true = _IsLeader, QueryFun, QueryType, Timeout,
   {error, Reason})

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -550,9 +550,8 @@ can_start_a_three_node_cluster(Config) ->
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri:get() from node ~s", [Node]),
-              Member = khepri_cluster:node_to_member(StoreId, Node),
               ?assertEqual(
-                 {error, {timeout, Member}},
+                 {error, timeout},
                  rpc:call(Node, khepri, get, [StoreId, [foo]]))
       end, RunningNodes2),
 


### PR DESCRIPTION
Previously this return value was '{error,{timeout,RaLeaderId}}'. Leader information is generally not useful to Khepri API consumers though since Khepri covers leader redirection. So this change removes the leader ID from the error type and returns '{error,timeout}' instead.