### PR TITLE
khepri_cluster: Don't cache the `not_known` "leader"

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -141,6 +141,10 @@
                            wait_for_remote_cluster_readiness/3]}).
 
 -define(IS_RA_SYSTEM(RaSystem), is_atom(RaSystem)).
+-define(IS_RA_SERVER(RaServer), (is_tuple(RaServer) andalso
+                                 size(RaServer) =:= 2 andalso
+                                 is_atom(element(1, RaServer)) andalso
+                                 is_atom(element(2, RaServer)))).
 -define(IS_DATA_DIR(DataDir), (is_list(DataDir) orelse is_binary(DataDir))).
 
 -type incomplete_ra_server_config() :: map().
@@ -1527,15 +1531,17 @@ get_cached_leader(StoreId) ->
 
 -spec cache_leader(StoreId, LeaderId) -> ok when
       StoreId :: khepri:store_id(),
-      LeaderId :: ra:server_id().
+      LeaderId :: ra:server_id() | not_known.
 
-cache_leader(StoreId, LeaderId) ->
-    ok = persistent_term:put(?RA_LEADER_CACHE_KEY(StoreId), LeaderId).
+cache_leader(StoreId, LeaderId) when ?IS_RA_SERVER(LeaderId) ->
+    ok = persistent_term:put(?RA_LEADER_CACHE_KEY(StoreId), LeaderId);
+cache_leader(_StoreId, not_known) ->
+    ok.
 
 -spec cache_leader_if_changed(StoreId, LeaderId, NewLeaderId) -> ok when
       StoreId :: khepri:store_id(),
-      LeaderId :: ra:server_id(),
-      NewLeaderId :: ra:server_id().
+      LeaderId :: ra:server_id() | undefined,
+      NewLeaderId :: ra:server_id() | not_known.
 
 cache_leader_if_changed(_StoreId, LeaderId, LeaderId) ->
     ok;

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1546,7 +1546,7 @@ cache_leader(_StoreId, not_known) ->
 cache_leader_if_changed(_StoreId, LeaderId, LeaderId) ->
     ok;
 cache_leader_if_changed(StoreId, undefined, NewLeaderId) ->
-    case persistent_term:get(?RA_LEADER_CACHE_KEY(StoreId), undefined) of
+    case get_cached_leader(StoreId) of
         LeaderId when LeaderId =/= undefined ->
             cache_leader_if_changed(StoreId, LeaderId, NewLeaderId);
         undefined ->

--- a/test/cached_leader.erl
+++ b/test/cached_leader.erl
@@ -1,0 +1,55 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers
+%% to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(cached_leader).
+
+-include_lib("eunit/include/eunit.hrl").
+
+cache_leader_test() ->
+    StoreId = ?FUNCTION_NAME,
+    LeaderId = {name, node},
+    ?assertEqual(
+       undefined,
+       khepri_cluster:get_cached_leader(StoreId)),
+    ?assertEqual(
+       ok,
+       khepri_cluster:cache_leader(StoreId, LeaderId)),
+    ?assertEqual(
+       LeaderId,
+       khepri_cluster:get_cached_leader(StoreId)),
+    ?assertEqual(
+       ok,
+       khepri_cluster:clear_cached_leader(StoreId)).
+
+cache_unknown_leader_test() ->
+    StoreId = ?FUNCTION_NAME,
+    ?assertEqual(
+       undefined,
+       khepri_cluster:get_cached_leader(StoreId)),
+    ?assertEqual(
+       ok,
+       khepri_cluster:cache_leader(StoreId, not_known)),
+    ?assertEqual(
+       undefined,
+       khepri_cluster:get_cached_leader(StoreId)).
+
+clear_cached_leader_test() ->
+    StoreId = ?FUNCTION_NAME,
+    LeaderId = {name, node},
+    ?assertEqual(
+       ok,
+       khepri_cluster:cache_leader(StoreId, LeaderId)),
+    ?assertEqual(
+       LeaderId,
+       khepri_cluster:get_cached_leader(StoreId)),
+    ?assertEqual(
+       ok,
+       khepri_cluster:clear_cached_leader(StoreId)),
+    ?assertEqual(
+       undefined,
+       khepri_cluster:get_cached_leader(StoreId)).


### PR DESCRIPTION
## Why

Local or leader queries may return `not_known` instead of the leader ID if this one isn't known as part of the query.

So far, we cached that value and this value was used as the leader ID in follow-up calls to Khepri... This is incorrect as this is clearly not a valid Ra server ID.

## How

If the passed "leader" ID is `not_known`, we ignore it and don't cache anything.

We don't clear the cached leader either because we lack context to take that decision.