### PR TITLE
GitHub Actions: Skip Erlang/OTP 26.2.5.2 on Windows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 25
+          otp-version: 26
           rebar3-version: '3.23.0'
 
       - name: Change doc version to "Development branch"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: 25
-          rebar3-version: '3.22.1'
+          rebar3-version: '3.23.0'
 
       - name: Change doc version to "Development branch"
         run: sed -E -i -e 's/^@version.*/@version Development branch/' doc/overview.edoc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
           # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.
           - otp_version: 24
             os: windows-latest
+          # Erlang 26.2.5.2 Windows installer fails to work in CI.
+          - otp_version: 26
+            os: windows-latest
 
     env:
       RUN_DIALYZER_ON_OTP_RELEASE: 26

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
         id: install-erlang
         with:
           otp-version: ${{matrix.otp_version}}
-          rebar3-version: '3.22.1'
+          rebar3-version: '3.23.0'
 
       - name: Restore Dialyzer PLT files from cache
         uses: actions/cache@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,12 +11,9 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [24, 25, 26]
+        otp_version: [25, 26]
         os: [ubuntu-latest, windows-latest]
         exclude:
-          # `ct_slave` fails to start Erlang nodes on Windows with Erlang 24.
-          - otp_version: 24
-            os: windows-latest
           # Erlang 26.2.5.2 Windows installer fails to work in CI.
           - otp_version: 26
             os: windows-latest


### PR DESCRIPTION
## Why

The installer fails to work or the way `setup-beam` uses is incorrect.

```
Installing Erlang/OTP 26.2.5.2 - built on amd64/windows-2022
  D:\a\_temp\.setup-beam\otp\otp.exe /S /D=D:\a\_temp\.setup-beam\otp
  Action install Erlang/OTP 26.2.5.2 failed for mirror https://builds.hex.pm, with Error: The process 'D:\a\_temp\.setup-beam\otp\otp.exe' failed with exit code 2
```

While here, stop testing against Erlang/OTP 24 to save ressources.