### PR TITLE
include/khepri.hrl: Export `?khepri_error/2` and `?khepri_exception/2`

### DIFF
--- a/include/khepri.hrl
+++ b/include/khepri.hrl
@@ -6,6 +6,9 @@
 %% refers to Broadcom Inc. and/or its subsidiaries.
 %%
 
+-ifndef(KHEPRI_HRL).
+-define(KHEPRI_HRL, true).
+
 -define(IS_KHEPRI_STORE_ID(StoreId), is_atom(StoreId)).
 
 -define(IS_KHEPRI_NODE_ID(PathComponent),
@@ -106,3 +109,17 @@
 
 -record(if_any,
         {conditions = [] :: [khepri_path:pattern_component()]}).
+
+%% -------------------------------------------------------------------
+%% Error tuple format.
+%% -------------------------------------------------------------------
+
+-define(
+   khepri_error(Name, Props),
+   {khepri, Name, Props}).
+
+-define(
+   khepri_exception(Name, Props),
+   {khepri_ex, Name, Props}).
+
+-endif.

--- a/src/khepri_error.hrl
+++ b/src/khepri_error.hrl
@@ -6,13 +6,7 @@
 %% refers to Broadcom Inc. and/or its subsidiaries.
 %%
 
--define(
-   khepri_error(Name, Props),
-   {khepri, Name, Props}).
-
--define(
-   khepri_exception(Name, Props),
-   {khepri_ex, Name, Props}).
+-include("include/khepri.hrl").
 
 -define(
    khepri_misuse(Exception),


### PR DESCRIPTION
## Why
They are useful for users of Khepri to match return values and exceptions.

## How

The macro definitions are moved from `src/khepri_error.hrl` to `include/khepri.hrl`.

`src/khepri_error.hrl` now includes `include/khepri.hrl` to get the definitions it uses. `include/khepri.hrl` is protected against multiple inclusions in the process.