### PR TITLE
test: Don't set `consistent_query_interval_in_compromise`

### DIFF
--- a/test/test_ra_server_helpers.erl
+++ b/test/test_ra_server_helpers.erl
@@ -16,10 +16,6 @@
 setup(Testcase) ->
     _ = logger:set_primary_config(level, warning),
     {ok, _} = application:ensure_all_started(khepri),
-    ok = application:set_env(
-           khepri,
-           consistent_query_interval_in_compromise,
-           2),
     khepri_utils:init_list_of_modules_to_skip(),
 
     #{ra_system := RaSystem} = Props = helpers:start_ra_system(Testcase),


### PR DESCRIPTION
## Why

The parameter was removed in commit 982f17d326514fc144ed67257e846b578e440c9f (as part of #260).