### PR TITLE
khepri_export_erlang: Accept atoms and binaries as filenames

### DIFF
--- a/src/khepri_export_erlang.erl
+++ b/src/khepri_export_erlang.erl
@@ -39,6 +39,12 @@
 %% read the next batch.
 -define(IMPORT_APPROX_LIMIT_PER_CALL, 100 * 1024). %% In bytes.
 
+%% This macro should match all the types that are accepted for
+%% `file:name_all/0'.
+-define(IS_FILENAME(Filename), (is_list(Filename) orelse
+                                is_atom(Filename) orelse
+                                is_binary(Filename))).
+
 -export([open_write/1,
          write/2,
          commit_write/1,
@@ -64,7 +70,7 @@
       WriteState :: write_state().
 %% @private
 
-open_write(Filename) when is_list(Filename) ->
+open_write(Filename) when ?IS_FILENAME(Filename) ->
     ?LOG_DEBUG(
        "~s: opening file \"~ts\" for export",
        [?MODULE, Filename],
@@ -156,7 +162,7 @@ abort_write(#{fd := Fd}) ->
       ReadState :: read_state().
 %% @private
 
-open_read(Filename) when is_list(Filename) ->
+open_read(Filename) when ?IS_FILENAME(Filename) ->
     ?LOG_DEBUG(
        "~s: opening file \"~ts\" for import",
        [?MODULE, Filename],

--- a/test/export_erlang.erl
+++ b/test/export_erlang.erl
@@ -35,6 +35,38 @@ export_import_empty_store_to_file_test_() ->
       ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Filename)),
       ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**"))]}.
 
+export_import_empty_store_to_file_using_atom_filename_test_() ->
+    Module = khepri_export_erlang,
+    Filename = list_to_atom(?FILENAME),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual({ok, []}, file:consult(Filename)),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**"))]}.
+
+export_import_empty_store_to_file_using_binary_filename_test_() ->
+    Module = khepri_export_erlang,
+    Filename = list_to_binary(?FILENAME),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) ->
+             test_ra_server_helpers:cleanup(Priv),
+             ok = file:delete(Filename)
+     end,
+     [?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**")),
+      ?_assertEqual(ok, khepri:export(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual({ok, []}, file:consult(Filename)),
+
+      ?_assertEqual(ok, khepri:import(?FUNCTION_NAME, Module, Filename)),
+      ?_assertEqual({ok, #{}}, khepri:get_many(?FUNCTION_NAME, "**"))]}.
+
 export_import_full_store_to_file_test_() ->
     Module = khepri_export_erlang,
     Filename = ?FILENAME,


### PR DESCRIPTION
## Why

The `file:name_all()` type accepts atoms and binaries in its definition.

Also, Elixir strings are binaries really, so using `"filename.erl"` as the filename would break because the module would consider that binary filename as an already opened file descriptor.

## How

The guard expression is expanded to accept atoms and binaries.

Fixes #278.