### PR TITLE
cluster_SUITE: Fix remaining consistency issues

### DIFF
--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -504,16 +504,25 @@ can_start_a_three_node_cluster(Config) ->
       end, Nodes),
 
     ct:pal("Use database after starting it"),
-    ?assertEqual(ok, rpc:call(Node1, khepri, put, [StoreId, [foo], value2])),
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, LeaderNode} = LeaderId1,
+    [FollowerNode | _] = Nodes -- [LeaderNode],
+    ct:pal("- khepri:put() from node ~s", [FollowerNode]),
+    ?assertEqual(ok, rpc:call(FollowerNode, khepri, put, [StoreId, [foo], value2])),
     lists:foreach(
       fun(Node) ->
-              ct:pal("- khepri:get() from node ~s", [Node]),
+              Options = case Node of
+                            LeaderNode -> #{};
+                            FollowerNode -> #{};
+                            _            -> #{favor => consistency}
+                        end,
+              ct:pal(
+                "- khepri:get() from node ~s; options: ~0p", [Node, Options]),
               ?assertEqual(
                  {ok, value2},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(Node, khepri, get, [StoreId, [foo], Options]))
       end, Nodes),
 
-    LeaderId1 = get_leader_in_store(StoreId, Nodes),
     {StoreId, StoppedLeaderNode1} = LeaderId1,
     RunningNodes1 = Nodes -- [StoppedLeaderNode1],
 
@@ -615,16 +624,25 @@ can_join_several_times_a_three_node_cluster(Config) ->
       end, [Node1, Node2]),
 
     ct:pal("Use database after starting it"),
-    ?assertEqual(ok, rpc:call(Node1, khepri, put, [StoreId, [foo], value1])),
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, LeaderNode} = LeaderId1,
+    [FollowerNode | _] = Nodes -- [LeaderNode],
+    ct:pal("- khepri:put() from node ~s", [FollowerNode]),
+    ?assertEqual(ok, rpc:call(FollowerNode, khepri, put, [StoreId, [foo], value1])),
     lists:foreach(
       fun(Node) ->
-              ct:pal("- khepri:get() from node ~s", [Node]),
+              Options = case Node of
+                            LeaderNode -> #{};
+                            FollowerNode -> #{};
+                            _            -> #{favor => consistency}
+                        end,
+              ct:pal(
+                "- khepri:get() from node ~s; options: ~0p", [Node, Options]),
               ?assertEqual(
                  {ok, value1},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(Node, khepri, get, [StoreId, [foo], Options]))
       end, Nodes),
 
-    LeaderId1 = get_leader_in_store(StoreId, Nodes),
     {StoreId, LeaderNode1} = LeaderId1,
     OtherNodes1 = Nodes -- [LeaderNode1],
 
@@ -673,16 +691,25 @@ can_rejoin_after_a_reset_in_a_three_node_cluster(Config) ->
       end, [Node1, Node2]),
 
     ct:pal("Use database after starting it"),
-    ?assertEqual(ok, rpc:call(Node1, khepri, put, [StoreId, [foo], value1])),
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, LeaderNode} = LeaderId1,
+    [FollowerNode | _] = Nodes -- [LeaderNode],
+    ct:pal("- khepri:put() from node ~s", [FollowerNode]),
+    ?assertEqual(ok, rpc:call(FollowerNode, khepri, put, [StoreId, [foo], value1])),
     lists:foreach(
       fun(Node) ->
-              ct:pal("- khepri:get() from node ~s", [Node]),
+              Options = case Node of
+                            LeaderNode -> #{};
+                            FollowerNode -> #{};
+                            _            -> #{favor => consistency}
+                        end,
+              ct:pal(
+                "- khepri:get() from node ~s; options: ~0p", [Node, Options]),
               ?assertEqual(
                  {ok, value1},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(Node, khepri, get, [StoreId, [foo], Options]))
       end, Nodes),
 
-    LeaderId1 = get_leader_in_store(StoreId, Nodes),
     {StoreId, LeaderNode1} = LeaderId1,
     OtherNodes1 = Nodes -- [LeaderNode1],
 
@@ -768,17 +795,26 @@ can_restart_nodes_in_a_three_node_cluster(Config) ->
       end, [Node1, Node2]),
 
     ct:pal("Use database after starting it"),
-    ?assertEqual(ok, rpc:call(Node1, khepri, put, [StoreId, [foo], value1])),
+    LeaderId1 = get_leader_in_store(StoreId, Nodes),
+    {StoreId, LeaderNode} = LeaderId1,
+    [FollowerNode | _] = Nodes -- [LeaderNode],
+    ct:pal("- khepri:put() from node ~s", [FollowerNode]),
+    ?assertEqual(ok, rpc:call(FollowerNode, khepri, put, [StoreId, [foo], value1])),
     lists:foreach(
       fun(Node) ->
-              ct:pal("- khepri:get() from node ~s", [Node]),
+              Options = case Node of
+                            LeaderNode -> #{};
+                            FollowerNode -> #{};
+                            _            -> #{favor => consistency}
+                        end,
+              ct:pal(
+                "- khepri:get() from node ~s; options: ~0p", [Node, Options]),
               ?assertEqual(
                  {ok, value1},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(Node, khepri, get, [StoreId, [foo], Options]))
       end, Nodes),
 
     %% Stop the current leader.
-    LeaderId1 = get_leader_in_store(StoreId, Nodes),
     {StoreId, StoppedLeaderNode1} = LeaderId1,
     RunningNodes1 = Nodes -- [StoppedLeaderNode1],
 


### PR DESCRIPTION
## Why

The testcases were issueing a put on node 1, then a get on all nodes. From time to time, one of the gets would fail because the queried node didn't see the put yet.

## How

Now, we use the `#{favor => consistency}` option for gets on nodes that are neither the leader, nor the follower that issued the put.

Indeed, to increase the testing of consistency, we also perform the put from a follower instead of node 1.

This is the same fix as committed in commit a076a83 (#269) for another testcase.