### PR TITLE
Replace `unregister_projection` command with `unregister_projections`

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -2978,7 +2978,7 @@ register_projection(StoreId, PathPattern, Projection, Options) ->
 %% -------------------------------------------------------------------
 
 -spec unregister_projection(ProjectionName) -> Ret when
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Ret :: ok | khepri:error().
 %% @doc Removes a projection from the store by name.
 %%
@@ -2995,10 +2995,10 @@ unregister_projection(ProjectionName) when is_atom(ProjectionName) ->
 -spec unregister_projection
 (StoreId, ProjectionName) -> Ret when
       StoreId :: khepri:store_id(),
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Ret :: ok | khepri:error();
 (ProjectionName, Options) -> Ret when
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Options :: khepri:command_options(),
       Ret :: ok | khepri:error().
 %% @doc Removes a projection from the store by name.
@@ -3026,7 +3026,7 @@ unregister_projection(ProjectionName, Options)
 -spec unregister_projection(StoreId, ProjectionName, Options) ->
     Ret when
       StoreId :: khepri:store_id(),
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Options :: khepri:command_options(),
       Ret :: ok | khepri:error().
 %% @doc Removes a projection from the store by name.
@@ -3048,7 +3048,7 @@ unregister_projection(StoreId, ProjectionName, Options)
 %% -------------------------------------------------------------------
 
 -spec has_projection(ProjectionName) -> Ret when
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Ret :: boolean() | khepri:error().
 %% @doc Determines whether the store has a projection registered with the given
 %% name.
@@ -3066,10 +3066,10 @@ has_projection(ProjectionName) when is_atom(ProjectionName) ->
 -spec has_projection
 (StoreId, ProjectionName) -> Ret when
       StoreId :: khepri:store_id(),
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Ret :: boolean() | khepri:error();
 (ProjectionName, Options) -> Ret when
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Options :: khepri:query_options(),
       Ret :: boolean() | khepri:error().
 %% @doc Determines whether the store has a projection registered with the given
@@ -3098,7 +3098,7 @@ has_projection(ProjectionName, Options)
 -spec has_projection(StoreId, ProjectionName, Options) ->
     Ret when
       StoreId :: khepri:store_id(),
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Options :: khepri:query_options(),
       Ret :: boolean() | khepri:error().
 %% @doc Determines whether the store has a projection registered with the given

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -118,8 +118,8 @@
          register_trigger/3, register_trigger/4, register_trigger/5,
 
          register_projection/2, register_projection/3, register_projection/4,
-         unregister_projection/1, unregister_projection/2,
-         unregister_projection/3,
+         unregister_projections/1, unregister_projections/2,
+         unregister_projections/3,
          has_projection/1, has_projection/2, has_projection/3,
 
          %% Transactions; `khepri_tx' provides the API to use inside
@@ -2974,74 +2974,82 @@ register_projection(StoreId, PathPattern, Projection, Options) ->
       StoreId, PathPattern, Projection, Options).
 
 %% -------------------------------------------------------------------
-%% unregister_projection().
+%% unregister_projections().
 %% -------------------------------------------------------------------
 
--spec unregister_projection(ProjectionName) -> Ret when
-      ProjectionName :: khepri_projection:name(),
+-spec unregister_projections(Names) -> Ret when
+      Names :: all | [khepri_projection:name()],
       Ret :: ok | khepri:error().
-%% @doc Removes a projection from the store by name.
+%% @doc Removes the given projections from the store.
 %%
 %% Calling this function is the same as calling
-%% `unregister_projection(StoreId, ProjectionName)' with the default store ID
-%% (see {@link khepri_cluster:get_default_store_id/0}).
+%% `unregister_projections(StoreId, Names)' with the default store ID (see
+%% {@link khepri_cluster:get_default_store_id/0}).
 %%
-%% @see unregister_projection/2.
+%% @see unregister_projections/2.
 
-unregister_projection(ProjectionName) when is_atom(ProjectionName) ->
+unregister_projections(Names) when Names =:= all orelse is_list(Names) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    unregister_projection(StoreId, ProjectionName).
+    unregister_projections(StoreId, Names).
 
--spec unregister_projection
-(StoreId, ProjectionName) -> Ret when
+-spec unregister_projections
+(StoreId, Names) -> Ret when
       StoreId :: khepri:store_id(),
-      ProjectionName :: khepri_projection:name(),
+      Names :: all | [khepri_projection:name()],
       Ret :: ok | khepri:error();
-(ProjectionName, Options) -> Ret when
-      ProjectionName :: khepri_projection:name(),
+(Names, Options) -> Ret when
+      Names :: all | [khepri_projection:name()],
       Options :: khepri:command_options(),
       Ret :: ok | khepri:error().
-%% @doc Removes a projection from the store by name.
+%% @doc Removes the given projections from the store.
 %%
 %% This function accepts the following two forms:
 %% <ul>
-%% <li>`unregister_projection(StoreId, ProjectionName)'. Calling it is the same
-%% as calling `unregister_projection(StoreId, ProjectionName, #{})'.</li>
-%% <li>`unregister_projection(ProjectionName, Options)'. Calling it is the same
-%% as calling `unregister_projection(StoreId, ProjectionName, Options)' with
+%% <li>`unregister_projections(StoreId, Names)'. Calling it is the same as
+%% calling `unregister_projections(StoreId, Names, #{})'.</li>
+%% <li>`unregister_projections(Names, Options)'. Calling it is the same as
+%% calling `unregister_projections(StoreId, Names, Options)' with
 %% the default store ID (see {@link khepri_cluster:get_default_store_id/0}).
 %% </li>
 %% </ul>
 %%
-%% @see unregister_projection/3.
+%% @see unregister_projections/3.
 
-unregister_projection(StoreId, ProjectionName)
-  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(ProjectionName) ->
-    unregister_projection(StoreId, ProjectionName, #{});
-unregister_projection(ProjectionName, Options)
-  when is_atom(ProjectionName) andalso is_map(Options) ->
+unregister_projections(StoreId, Names)
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
+       (Names =:= all orelse is_list(Names)) ->
+    unregister_projections(StoreId, Names, #{});
+unregister_projections(Names, Options)
+  when (Names =:= all orelse is_list(Names)) andalso is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    unregister_projection(StoreId, ProjectionName, Options).
+    unregister_projections(StoreId, Names, Options).
 
--spec unregister_projection(StoreId, ProjectionName, Options) ->
+-spec unregister_projections(StoreId, Names, Options) ->
     Ret when
       StoreId :: khepri:store_id(),
-      ProjectionName :: khepri_projection:name(),
+      Names :: all | [khepri_projection:name()],
       Options :: khepri:command_options(),
       Ret :: ok | khepri:error().
-%% @doc Removes a projection from the store by name.
+%% @doc Removes the given projections from the store.
+%%
+%% `Names' may either be a list of projection names to remove or the atom
+%% `all'. When `all' is passed, every projection in the store is removed.
 %%
 %% @param StoreId the name of the Khepri store.
-%% @param ProjectionName the name of the projection to unregister as passed to
-%%        {@link khepri_projection:new/3}.
-%% @param Options command options for unregistering the projection.
-%% @returns `ok' if the projection was unregistered, an `{error, Reason}' tuple
-%% otherwise.
+%% @param Names the names of projections to unregister or the atom `all' to
+%%        remove all projections.
+%% @param Options command options for unregistering the projections.
+%% @returns `ok' if the projections were unregistered, an `{error, Reason}'
+%% tuple otherwise.
+%%
+%% @see khepri_adv:unregister_projections/3.
 
-unregister_projection(StoreId, ProjectionName, Options)
-  when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(ProjectionName) andalso
+unregister_projections(StoreId, Names, Options)
+  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
+       (Names =:= all orelse is_list(Names)) andalso
        is_map(Options) ->
-    khepri_machine:unregister_projection(StoreId, ProjectionName, Options).
+    Ret = khepri_adv:unregister_projections(StoreId, Names, Options),
+    ?result_ret_to_minimal_ret(Ret).
 
 %% -------------------------------------------------------------------
 %% has_projection().

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -183,7 +183,7 @@
 -type async_ret() :: ok.
 
 -type projection_tree() :: khepri_pattern_tree:tree(
-                             khepri_projection:projection()).
+                             [khepri_projection:projection()]).
 %% A pattern tree that holds all registered projections in the machine's state.
 
 -export_type([common_ret/0,

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -595,7 +595,7 @@ register_projection(
 
 -spec unregister_projection(StoreId, ProjectionName, Options) -> Ret when
       StoreId :: khepri:store_id(),
-      ProjectionName :: atom(),
+      ProjectionName :: khepri_projection:name(),
       Options :: khepri:command_options(),
       Ret :: ok | khepri:error().
 %% @doc Unregisters a projection by name.
@@ -2092,7 +2092,7 @@ get_projections(State) ->
 
 -spec has_projection(ProjectionTree, ProjectionName) -> boolean() when
       ProjectionTree :: khepri_machine:projection_tree(),
-      ProjectionName :: atom().
+      ProjectionName :: khepri_projection:name().
 %% @doc Determines if the given projection tree contains a projection.
 %%
 %% Two projections are considered equal if they have the same name.

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -48,7 +48,7 @@
 -record(register_projection, {pattern :: khepri_path:native_pattern(),
                               projection :: khepri_projection:projection()}).
 
--record(unregister_projection, {name :: khepri_projection:name()}).
+-record(unregister_projections, {names :: all | [khepri_projection:name()]}).
 
 -record(trigger_projection, {path :: khepri_path:native_path(),
                              old_props :: khepri:node_props(),

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -48,7 +48,7 @@
 -record(register_projection, {pattern :: khepri_path:native_pattern(),
                               projection :: khepri_projection:projection()}).
 
--record(unregister_projection, {name :: atom()}).
+-record(unregister_projection, {name :: khepri_projection:name()}).
 
 -record(trigger_projection, {path :: khepri_path:native_path(),
                              old_props :: khepri:node_props(),

--- a/src/khepri_projection.erl
+++ b/src/khepri_projection.erl
@@ -263,9 +263,23 @@ init(#khepri_projection{name = Name, ets_options = EtsOptions}) ->
             {error, exists}
     end.
 
+-spec delete(Projection) -> Ret when
+      Projection :: projection(),
+      Ret :: ok | {error, does_not_exist}.
+%% @hidden
+%% Deletes the ETS table for the given projection.
+%%
+%% @returns `ok' if the table is successfully deleted or `{error,
+%% does_not_exist}' if the table does not exist.
+
 delete(#khepri_projection{name = Name}) ->
-    _ = ets:delete(Name),
-    ok.
+    try
+        ets:delete(Name),
+        ok
+    catch
+        error:badarg:_Stacktrace ->
+            {error, does_not_exist}
+    end.
 
 -spec trigger(Projection, Path, OldProps, NewProps) -> Ret when
       Projection :: projection(),

--- a/src/khepri_projection.erl
+++ b/src/khepri_projection.erl
@@ -132,6 +132,15 @@ fun((Table :: ets:tid(),
               projection_fun/0,
               options/0]).
 
+-ifdef(TEST).
+%% In testing we will cover failure scenarios like an ETS table being deleted
+%% so we need the table to be public. In normal operation though, the ETS table
+%% is protected and belongs to the Ra server process.
+-define(DEFAULT_ETS_OPTS, [public, named_table]).
+-else.
+-define(DEFAULT_ETS_OPTS, [protected, named_table]).
+-endif.
+
 -spec new(Name, ProjectionFun) -> Projection when
       Name :: khepri_projection:name(),
       ProjectionFun :: khepri_projection:projection_fun(),
@@ -165,7 +174,7 @@ new(Name, ProjectionFun) ->
 %% @returns a {@link projection()} resource.
 
 new(Name, copy, Options) when is_map(Options) ->
-    EtsOptions = maps:fold(fun to_ets_options/3, [named_table], Options),
+    EtsOptions = maps:fold(fun to_ets_options/3, ?DEFAULT_ETS_OPTS, Options),
     #khepri_projection{name = Name,
                        projection_fun = copy,
                        ets_options = EtsOptions};
@@ -180,7 +189,7 @@ new(Name, ProjectionFun, Options)
         {_CustomFunOptions, _EtsOptions} = Value ->
             Value
     end,
-    EtsOptions1 = maps:fold(fun to_ets_options/3, [named_table], EtsOptions),
+    EtsOptions1 = maps:fold(fun to_ets_options/3, ?DEFAULT_ETS_OPTS, EtsOptions),
     ShouldProcessFunction =
     if
         is_function(ProjectionFun, 2) ->

--- a/src/khepri_projection.erl
+++ b/src/khepri_projection.erl
@@ -42,6 +42,11 @@
  %% For internal use only
 -export([init/1, trigger/4, delete/1]).
 
+-type name() :: atom().
+%% The name of a projection.
+%%
+%% @see khepri_projection:new/3.
+
 -type projection() :: #khepri_projection{}.
 %% A projection resource.
 %%
@@ -122,12 +127,13 @@ fun((Table :: ets:tid(),
 %% allowed. {@link extended_projection_fun()}s may use any valid {@link
 %% ets:table_type()}.
 
--export_type([projection/0,
+-export_type([name/0,
+              projection/0,
               projection_fun/0,
               options/0]).
 
 -spec new(Name, ProjectionFun) -> Projection when
-      Name :: atom(),
+      Name :: khepri_projection:name(),
       ProjectionFun :: khepri_projection:projection_fun(),
       Projection :: khepri_projection:projection().
 %% Creates a new projection data structure with default options.
@@ -137,7 +143,7 @@ new(Name, ProjectionFun) ->
     new(Name, ProjectionFun, #{}).
 
 -spec new(Name, ProjectionFun, Options) -> Projection when
-      Name :: atom(),
+      Name :: khepri_projection:name(),
       ProjectionFun :: khepri_projection:projection_fun(),
       Options :: khepri_projection:options(),
       Projection :: khepri_projection:projection().
@@ -235,7 +241,7 @@ to_ets_options(Key, Value, _Acc) ->
 
 -spec name(Projection) -> Name when
       Projection :: projection(),
-      Name :: atom().
+      Name :: khepri_projection:name().
 %% @doc Returns the name of the given `Projection'.
 
 name(#khepri_projection{name = Name}) ->
@@ -293,7 +299,7 @@ trigger(
         Table, Name, StandaloneFun, Path, OldProps, NewProps) ->
     Ret when
       Table :: ets:tid(),
-      Name :: atom(),
+      Name :: khepri_projection:name(),
       StandaloneFun :: horus:horus_fun(),
       Path :: khepri_path:native_path(),
       OldProps :: khepri:node_props(),
@@ -330,7 +336,7 @@ trigger_extended_projection(
         Table, Name, StandaloneFun, Path, OldProps, NewProps) ->
     Ret when
       Table :: ets:tid(),
-      Name :: atom(),
+      Name :: khepri_projection:name(),
       StandaloneFun :: horus:horus_fun(),
       Path :: khepri_path:native_path(),
       OldProps :: khepri:node_props(),
@@ -390,7 +396,7 @@ trigger_simple_projection(
     ok.
 
 -spec trigger_copy_projection(Name, Table, OldProps, NewProps) -> Ret when
-      Name :: atom(),
+      Name :: khepri_projection:name(),
       Table :: ets:tid(),
       OldProps :: khepri:node_props(),
       NewProps :: khepri:node_props(),
@@ -407,7 +413,7 @@ trigger_copy_projection(_Name, _Table, _OldProps, _NewProps) ->
     ok.
 
 -spec try_ets_insert(Name, Table, Record) -> ok when
-      Name :: atom(),
+      Name :: khepri_projection:name(),
       Table :: ets:tid(),
       Record :: term().
 %% @hidden
@@ -431,7 +437,7 @@ try_ets_insert(Name, Table, Record) ->
     ok.
 
 -spec try_ets_delete_object(Name, Table, Record) -> ok when
-      Name :: atom(),
+      Name :: khepri_projection:name(),
       Table :: ets:tid(),
       Record :: term().
 %% @hidden

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1520,13 +1520,14 @@ can_use_default_store_on_single_node(_Config) ->
     ?assertEqual(ok, khepri:register_projection("/**", Projection2, #{})),
     ?assertEqual(true, khepri:has_projection(ProjectionName2)),
 
-    ?assertEqual(ok, khepri:unregister_projection(ProjectionName1)),
+    ?assertEqual(ok, khepri:unregister_projections([ProjectionName1])),
     ?assertEqual(
-       {error, ?khepri_error(
-                 projection_not_found,
-                 #{name => ProjectionName1})},
-       khepri:unregister_projection(ProjectionName1)),
-    ?assertEqual(ok, khepri:unregister_projection(ProjectionName2, #{})),
+       {ok, #{}},
+       khepri_adv:unregister_projections([ProjectionName1])),
+    ?assertEqual(ok, khepri:unregister_projections([ProjectionName2], #{})),
+    ?assertEqual(
+       {ok, #{}},
+       khepri_adv:unregister_projections([ProjectionName2], #{})),
 
     ?assertEqual({ok, ok}, khepri:transaction(fun() -> ok end)),
     ?assertEqual({ok, ok}, khepri:transaction(fun() -> ok end, ro)),

--- a/test/projections.erl
+++ b/test/projections.erl
@@ -694,7 +694,25 @@ unregister_projection_test_() ->
          {"The store still contains the other projection",
           ?_assertEqual(
             true,
-            khepri:has_projection(?FUNCTION_NAME, ProjectionName2))}]
+            khepri:has_projection(?FUNCTION_NAME, ProjectionName2))},
+
+         {"Unregistering a projection without an ETS table is ok",
+          ?_test(
+              begin
+                  true = ets:delete(ProjectionName2),
+                  ?assertEqual(
+                    {ok, #{ProjectionName2 => PathPattern}},
+                    khepri_adv:unregister_projections(
+                      ?FUNCTION_NAME, [ProjectionName2]))
+              end)},
+
+         {"The store no longer contains that projection",
+          ?_assertEqual(
+            false,
+            khepri:has_projection(?FUNCTION_NAME, ProjectionName1))},
+
+         {"That projection table no longer exists",
+          ?_assertEqual(undefined, ets:info(ProjectionName2))}]
       }]}.
 
 unregister_all_projections_test_() ->

--- a/test/projections.erl
+++ b/test/projections.erl
@@ -625,18 +625,28 @@ unregister_projection_test_() ->
     ProjectFun = fun(Path, Payload) -> {Path, Payload} end,
     PathPattern = [stock, wood, <<"oak">>],
     Data = 100,
+    ProjectionName1 = projection_1,
+    ProjectionName2 = projection_2,
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
      fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
      [{inorder,
-        [{"Register the projection",
+        [{"Register projections",
           ?_test(
               begin
-                  Projection = khepri_projection:new(?MODULE, ProjectFun),
+                  Projection1 = khepri_projection:new(
+                                  ProjectionName1, ProjectFun),
                   ?assertEqual(
                     ok,
                     khepri:register_projection(
-                      ?FUNCTION_NAME, PathPattern, Projection))
+                      ?FUNCTION_NAME, PathPattern, Projection1)),
+
+                  Projection2 = khepri_projection:new(
+                                  ProjectionName2, ProjectFun),
+                  ?assertEqual(
+                    ok,
+                    khepri:register_projection(
+                      ?FUNCTION_NAME, PathPattern, Projection2))
               end)},
 
          {"Trigger the projection",
@@ -645,29 +655,123 @@ unregister_projection_test_() ->
             khepri:put(
               ?FUNCTION_NAME, PathPattern, Data))},
 
-         {"The projection contains the triggered change",
-          ?_assertEqual(Data, ets:lookup_element(?MODULE, PathPattern, 2))},
+         {"The projections contain the triggered change",
+          ?_test(
+              begin
+                  ?assertEqual(
+                    Data,
+                    ets:lookup_element(ProjectionName1, PathPattern, 2)),
+                  ?assertEqual(
+                    Data,
+                    ets:lookup_element(ProjectionName2, PathPattern, 2))
+              end)},
 
          {"Unregister an unknown projection",
           ?_assertEqual(
-            {error, {khepri, projection_not_found, #{name => undefined}}},
-            khepri:unregister_projection(?FUNCTION_NAME, undefined))},
+            {ok, #{}},
+            khepri_adv:unregister_projections(?FUNCTION_NAME, [undefined]))},
 
-         {"Unregister the projection",
+         {"Unregister one of the projections",
           ?_assertEqual(
-            ok,
-            khepri:unregister_projection(?FUNCTION_NAME, ?MODULE))},
+            {ok, #{ProjectionName1 => PathPattern}},
+            khepri_adv:unregister_projections(
+              ?FUNCTION_NAME, [ProjectionName1]))},
 
-         {"The store no longer contains the projection",
+         {"The store no longer contains that projection",
           ?_assertEqual(
             false,
-            khepri:has_projection(?FUNCTION_NAME, ?MODULE))},
+            khepri:has_projection(?FUNCTION_NAME, ProjectionName1))},
 
          {"The projection table no longer exists",
-          ?_assertEqual(undefined, ets:info(?MODULE))},
+          ?_assertEqual(undefined, ets:info(ProjectionName1))},
 
-         {"Unregistering the projection again fails",
-          ?_assertMatch(
-            {error, ?khepri_error(projection_not_found, _Info)},
-            khepri:unregister_projection(?FUNCTION_NAME, ?MODULE))}]
+         {"Unregistering the projection again is a no-op",
+          ?_assertEqual(
+            {ok, #{}},
+            khepri_adv:unregister_projections(
+              ?FUNCTION_NAME, [ProjectionName1]))},
+
+         {"The store still contains the other projection",
+          ?_assertEqual(
+            true,
+            khepri:has_projection(?FUNCTION_NAME, ProjectionName2))}]
+      }]}.
+
+unregister_all_projections_test_() ->
+    ProjectFun = fun(Path, Payload) -> {Path, Payload} end,
+    PathPattern = [stock, wood, <<"oak">>],
+    Data = 100,
+    ProjectionName1 = projection_1,
+    ProjectionName2 = projection_2,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+        [{"Unregister all projections",
+          ?_assertEqual(
+            {ok, #{}},
+            khepri_adv:unregister_projections(?FUNCTION_NAME, all))},
+
+         {"Register projections",
+          ?_test(
+              begin
+                  Projection1 = khepri_projection:new(
+                                  ProjectionName1, ProjectFun),
+                  ?assertEqual(
+                    ok,
+                    khepri:register_projection(
+                      ?FUNCTION_NAME, PathPattern, Projection1)),
+
+                  Projection2 = khepri_projection:new(
+                                  ProjectionName2, ProjectFun),
+                  ?assertEqual(
+                    ok,
+                    khepri:register_projection(
+                      ?FUNCTION_NAME, PathPattern, Projection2))
+              end)},
+
+         {"Trigger the projections",
+          ?_assertEqual(
+            ok,
+            khepri:put(?FUNCTION_NAME, PathPattern, Data))},
+
+         {"The projections contain the triggered change",
+          ?_test(
+              begin
+                  ?assertEqual(
+                    Data,
+                    ets:lookup_element(ProjectionName1, PathPattern, 2)),
+                  ?assertEqual(
+                    Data,
+                    ets:lookup_element(ProjectionName2, PathPattern, 2))
+              end)},
+
+         {"Unregister the projections",
+          ?_assertEqual(
+            {ok, #{ProjectionName1 => PathPattern,
+                   ProjectionName2 => PathPattern}},
+            khepri_adv:unregister_projections(?FUNCTION_NAME, all))},
+
+         {"The store no longer contains the projections",
+          ?_test(
+              begin
+                  ?assertEqual(
+                      false,
+                      khepri:has_projection(?FUNCTION_NAME, ProjectionName1)),
+                  ?assertEqual(
+                      false,
+                      khepri:has_projection(?FUNCTION_NAME, ProjectionName2))
+              end)},
+
+         {"The projection tables no longer exist",
+          ?_test(
+              begin
+                  ?assertEqual(undefined, ets:info(ProjectionName1)),
+                  ?assertEqual(undefined, ets:info(ProjectionName2))
+              end)},
+
+         {"Unregistering the projections again is ok",
+          ?_assertEqual(
+            {ok, #{}},
+            khepri_adv:unregister_projections(?FUNCTION_NAME, all))}]
       }]}.


### PR DESCRIPTION
The motivation for this in RabbitMQ is that we currently mistakenly register projections even when using mnesia as the metadata store in 3.13.x. It's a benign mistake - it shouldn't have much impact on those running 3.13.x - but it will be a potential headache for upgrading to 4.0.x since we also plan on reorganizing the tree layout (see https://github.com/rabbitmq/rabbitmq-server/pull/11225). With this change we will be able to use `khepri:unregister_all_projections/0` as we enable the `khepri_db` flag to remove those projections and add fresh definitions.

Implementation-wise the change is very straightforward: it's a new `#unregister_all_projections{}` command which calls `khepri_projection:delete/1` for each deleted projections and returns a map of the deleted projections (for `khepri_adv`). `khepri:unregister_all_projections/0,1,2` discards this map and returns the simple `ok | khepri:error()`.