### PR TITLE
khepri_machine: Restore `#unregister_projection{}` for backward-compatibility

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -127,6 +127,15 @@
                    #dedup_ack{}.
 %% Commands specific to this Ra machine.
 
+-type old_command() :: #unregister_projection{}.
+%% Old commands that are still accepted by the Ra machine but never created.
+%%
+%% Even though Khepri no longer creates these commands, they may still be
+%% present in existing Ra log files and thus be applied after an ugprade of
+%% Khepri.
+%%
+%% We keep them supported for backward-compatibility.
+
 -type machine_init_args() :: #{store_id := khepri:store_id(),
                                member := ra:server_id(),
                                snapshot_interval => non_neg_integer(),
@@ -205,7 +214,8 @@
               triggered/0,
               projection_tree/0,
               projection_map/0,
-              command/0]).
+              command/0,
+              old_command/0]).
 
 -define(HAS_TIME_LEFT(Timeout), (Timeout =:= infinity orelse Timeout > 0)).
 
@@ -1267,7 +1277,7 @@ restore_projection(Projection, Tree, PathPattern) ->
 
 -spec apply(Meta, Command, State) -> {State, Ret, SideEffects} when
       Meta :: ra_machine:command_meta_data(),
-      Command :: command(),
+      Command :: command() | old_command(),
       State :: state(),
       Ret :: any(),
       SideEffects :: ra_machine:effects().
@@ -1398,6 +1408,16 @@ apply(
     Reply = {ok, RemovedProjectionsMap},
     Ret = {State1, Reply},
     post_apply(Ret, Meta);
+apply(
+  Meta,
+  #unregister_projection{name = Name},
+  State) ->
+    %% This command was replaced by `#unregister_projections{}'. Therefore,
+    %% convert it and recurse.
+    %%
+    %% For backward-compatibility; see {@link old_command()}.
+    NewCommand = #unregister_projections{names = [Name]},
+    apply(Meta, NewCommand, State);
 apply(
   #{machine_version := MacVer} = Meta,
   #dedup{ref = CommandRef, expiry = Expiry, command = Command},

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -28,12 +28,19 @@
 %% </tr>
 %% <tr>
 %% <td style="text-align: right; vertical-align: top;">1</td>
-%% <td>Added deduplication mechanism:
+%% <td>
+%% <ul>
+%% <li>Added deduplication mechanism:
 %% <ul>
 %% <li>new command option `protect_against_dups'</li>
 %% <li>new commands `#dedup{}' and `#dedup_ack{}'</li>
 %% <li>new state field `dedups'</li>
-%% </ul></td>
+%% </ul></li>
+%% <li>Added command `#unregister_projections{}'. The previous
+%% `#unregister_projection{}' is still supported for backward-compatibility but
+%% it is no longer created.</li>
+%% </ul>
+%% </td>
 %% </tr>
 %% </table>
 

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -63,3 +63,7 @@
                 command :: khepri_machine:command()}).
 
 -record(dedup_ack, {ref :: reference()}).
+
+%% Old commands, kept for backward-compatibility.
+
+-record(unregister_projection, {name :: khepri_projection:name()}).

--- a/test/projections.erl
+++ b/test/projections.erl
@@ -11,6 +11,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -include("include/khepri.hrl").
+-include("src/khepri_machine.hrl").
 -include("src/khepri_error.hrl").
 -include("test/helpers.hrl").
 
@@ -793,3 +794,10 @@ unregister_all_projections_test_() ->
             {ok, #{}},
             khepri_adv:unregister_projections(?FUNCTION_NAME, all))}]
       }]}.
+
+old_unregister_projection_command_accepted_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS([])),
+    Command = #unregister_projection{name = ?FUNCTION_NAME},
+    ?assertMatch(
+       {_S1, {ok, #{}}, _SE},
+       khepri_machine:apply(?META, Command, S0)).


### PR DESCRIPTION
## Why

Even though this version of Khepri never emits `#unregister_projection{}`, existing WAL files may still contain that command.

## How

To not break these existing deployment, `apply/3` accepts `#unregister_projection{}` again. It converts it to the new `#unregister_projections{}` command and recurses.