### PR TITLE
Fixes to `khepri_cluster` member queries

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1236,6 +1236,16 @@ do_query_members(StoreId, RaServer, QueryType, Timeout) ->
                        [StoreId]),
                     Error
             end;
+        {error, Reason}
+          when ?HAS_TIME_LEFT(Timeout) andalso
+               (Reason == noconnection orelse
+                Reason == nodedown orelse
+                Reason == shutdown) ->
+            NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),
+            NewTimeout = khepri_utils:sleep(
+                           ?NOPROC_RETRY_INTERVAL, NewTimeout0),
+            do_query_members(
+              StoreId, RaServer, QueryType, NewTimeout);
         {timeout, _} ->
             ?LOG_WARNING(
                "Timeout while querying members in store \"~s\"",

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1235,6 +1235,11 @@ do_query_members(StoreId, RaServer, QueryType, Timeout) ->
                        [StoreId]),
                     Error
             end;
+        {timeout, _} ->
+            ?LOG_WARNING(
+               "Timeout while querying members in store \"~s\"",
+               [StoreId]),
+            {error, timeout};
         Error ->
             ?LOG_WARNING(
                "Failed to query members in store \"~s\": ~p",

--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1220,7 +1220,8 @@ do_query_members(StoreId, RaServer, QueryType, Timeout) ->
     case ra:members(Arg, Timeout) of
         {ok, Members, _} ->
             {ok, lists:sort(Members)};
-        {error, noproc} = Error ->
+        {error, noproc} = Error
+          when ?HAS_TIME_LEFT(Timeout) ->
             case khepri_utils:is_ra_server_alive(RaServer) of
                 true ->
                     NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),

--- a/src/khepri_cluster.hrl
+++ b/src/khepri_cluster.hrl
@@ -15,3 +15,5 @@
 
 -define(IS_TIMEOUT(Timeout), (Timeout =:= infinity orelse
                               (is_integer(Timeout) andalso Timeout >= 0))).
+
+-define(HAS_TIME_LEFT(Timeout), (Timeout =:= infinity orelse Timeout > 0)).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -224,8 +224,6 @@
               command/0,
               old_command/0]).
 
--define(HAS_TIME_LEFT(Timeout), (Timeout =:= infinity orelse Timeout > 0)).
-
 -define(PROJECTION_PROPS_TO_RETURN, [payload_version,
                                      child_list_version,
                                      child_list_length,


### PR DESCRIPTION
This pull request contains a set of patches to fix the functions to query Ra members and nodes in `khepri_cluster`:
* The return value in case of a timeout was not aligned with the type spec and inconsistent with what other functions do.
* The timeout argument may not have been honored in the case of a `noproc`.
* The query was not retried after a `noconnection` error and a few other related errors.