### PR TITLE
Rename `?NOPROC_RETRY_INTERVAL` to `?TRANSIENT_ERROR_RETRY_INTERVAL`

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1226,7 +1226,8 @@ do_query_members(StoreId, RaServer, QueryType, Timeout) ->
                 true ->
                     NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),
                     NewTimeout = khepri_utils:sleep(
-                                   ?NOPROC_RETRY_INTERVAL, NewTimeout0),
+                                   ?TRANSIENT_ERROR_RETRY_INTERVAL,
+                                   NewTimeout0),
                     do_query_members(
                       StoreId, RaServer, QueryType, NewTimeout);
                 false ->
@@ -1243,7 +1244,7 @@ do_query_members(StoreId, RaServer, QueryType, Timeout) ->
                 Reason == shutdown) ->
             NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),
             NewTimeout = khepri_utils:sleep(
-                           ?NOPROC_RETRY_INTERVAL, NewTimeout0),
+                           ?TRANSIENT_ERROR_RETRY_INTERVAL, NewTimeout0),
             do_query_members(
               StoreId, RaServer, QueryType, NewTimeout);
         {timeout, _} ->

--- a/src/khepri_cluster.hrl
+++ b/src/khepri_cluster.hrl
@@ -9,9 +9,9 @@
 -define(DEFAULT_RA_SYSTEM_NAME, khepri).
 -define(DEFAULT_STORE_ID, khepri).
 
-%% timer:sleep/1 time used as a retry interval when the local Ra server is
-%% unaware of a leader exit.
--define(NOPROC_RETRY_INTERVAL, 200).
+%% timer:sleep/1 time used as a retry interval when we get errors such as
+%% `noproc' or `noconnection'.
+-define(TRANSIENT_ERROR_RETRY_INTERVAL, 200).
 
 -define(IS_TIMEOUT(Timeout), (Timeout =:= infinity orelse
                               (is_integer(Timeout) andalso Timeout >= 0))).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -908,7 +908,8 @@ do_process_sync_command(StoreId, Command, Options) ->
                     %% Retry again after waiting a bit.
                     NewTimeout0 = khepri_utils:end_timeout_window(Timeout, T0),
                     NewTimeout = khepri_utils:sleep(
-                                   ?NOPROC_RETRY_INTERVAL, NewTimeout0),
+                                   ?TRANSIENT_ERROR_RETRY_INTERVAL,
+                                   NewTimeout0),
                     Options1 = Options#{timeout => NewTimeout},
                     do_process_sync_command(StoreId, Command, Options1);
                 false ->


### PR DESCRIPTION
## Why

This constant is used for retries after other errors than `noproc`, for example `noconnection`.