### PR TITLE
khepri_cluster: Fix race condition in the reset code

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -957,13 +957,20 @@ do_reset(RaSystem, StoreId, ThisMember, Timeout) ->
                     ?LOG_DEBUG(
                        "The local Ra server exited while we were waiting "
                        "for it to be ready for a membership change. It "
-                       "means it was removed from the cluster by the remote "
-                       "cluster; we can proceed with the reset."),
+                       "means it was removed from the cluster by another "
+                       "member; we can proceed with the reset."),
                     forget_store(StoreId),
                     ok
             end;
         {timeout, _} ->
             {error, timeout};
+        {error, noproc} ->
+            ?LOG_DEBUG(
+               "The local Ra server exited while we tried to detach it from "
+               "its cluster. It means it was removed from the cluster by "
+               "another member; we can proceed with the reset."),
+            forget_store(StoreId),
+            ok;
         {error, _} = Error ->
             Error
     end.


### PR DESCRIPTION
## Why

The `khepri_cluster:reset()` function is mainly used to uncluster a node. To make sure that both parties (the leaving node and the rest of the cluster) see the same cluster membership in the end, we perform two resets:

1. We remove the leaving member from a remote member (if the node is clustered).
2. We remove the leaving member from its own view of the cluster.

This way, if the leaving node was out-of-sync about the cluster membership because it lost its state for instance, we are sure that at the end, everyone agrees.

However, when the leaving node is removed using a remote member, that member will stop the leaving Ra server. Therefore, when we try the second remove on the leaving node, we might get a `{error, noproc}` error because the Ra process already exited.

## How

We adopt the same solution as the error handling done with `wait_for_leader()`: if `ra:remove_member()` returns the `noproc` error, we consider that's ok and proceed with the reset.

This should fix a rare transient failure that I saw in CI but was never able to reproduce locally.