### PR TITLE
Use `erlang:whereis/1` for checking if a store is running

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1576,11 +1576,12 @@ get_store_ids() ->
 %% @doc Indicates if `StoreId' is running or not.
 
 is_store_running(StoreId) ->
-    ThisNode = node(),
-    RaServer = khepri_cluster:node_to_member(StoreId, ThisNode),
-    Timeout = khepri_app:get_default_timeout(),
-    KeyMetrics = ra:key_metrics(RaServer, Timeout),
-    Runs = maps:get(state, KeyMetrics) =/= noproc,
+    %% FIXME: Ra has no API to know if a Ra server is running or not. We could
+    %% use a public API such as `ra:key_metrics/2', but unfortunately, it is
+    %% not as efficient as querying the process directly. Therefore, we bypass
+    %% Ra and rely on the fact that the server ID is internally a registered
+    %% process name and resolve it to determine if it is running.
+    Runs = erlang:whereis(StoreId) =/= undefined,
 
     %% We know the real state of the Ra server. In the case the Ra server
     %% stopped behind the back of Khepri, we update the cached list of running


### PR DESCRIPTION
A store's process uses its `StoreId` as its registered name. This is a public interface of Ra so we can depend on it. Reading from key metrics counters is already very fast but switching to `whereis/1` eliminates basically all overhead of this function. When used heavily (for example in RabbitMQ while publishing and consuming rapidly) the CPU time spent on `is_store_running/1` disappears from the output of a perf recording and a flamegraph.

This is a follow-up to https://github.com/rabbitmq/khepri/pull/292 based on the post-merge discussion.