### PR TITLE
Replace keep-while cond reverse index with a prefix tree

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -101,7 +101,6 @@
          get_tree/1,
          get_root/1,
          get_keep_while_conds/1,
-         get_keep_while_conds_revidx/1,
          get_triggers/1,
          get_emitted_triggers/1,
          get_projections/1,
@@ -156,7 +155,7 @@
 %% State machine's internal state record.
 -record(khepri_machine,
         {config = #config{} :: khepri_machine:machine_config(),
-         tree = #tree{} :: khepri_tree:tree(),
+         tree = khepri_tree:new() :: khepri_tree:tree(),
          triggers = #{} :: khepri_machine:triggers_map(),
          emitted_triggers = [] :: [khepri_machine:triggered()],
          projections = khepri_pattern_tree:empty() ::
@@ -2159,18 +2158,6 @@ get_root(State) ->
 get_keep_while_conds(State) ->
     #tree{keep_while_conds = KeepWhileConds} = get_tree(State),
     KeepWhileConds.
-
--spec get_keep_while_conds_revidx(State) -> KeepWhileCondsRevIdx when
-      State :: khepri_machine:state(),
-      KeepWhileCondsRevIdx :: khepri_tree:keep_while_conds_revidx().
-%% @doc Returns the `keep_while' conditions reverse index in the tree from the
-%% given state.
-%%
-%% @private
-
-get_keep_while_conds_revidx(State) ->
-    #tree{keep_while_conds_revidx = KeepWhileCondsRevIdx} = get_tree(State),
-    KeepWhileCondsRevIdx.
 
 -spec get_triggers(State) -> Triggers when
       State :: khepri_machine:state(),

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -2334,9 +2334,17 @@ make_virgin_state(Params) ->
 %%
 %% @private
 
-convert_state(State, MacVer, MacVer) ->
+convert_state(State, OldMacVer, NewMacVer) ->
+    lists:foldl(
+      fun(N, State1) ->
+              OldMacVer1 = N,
+              NewMacVer1 = erlang:min(N + 1, NewMacVer),
+              convert_state1(State1, OldMacVer1, NewMacVer1)
+      end, State, lists:seq(OldMacVer, NewMacVer)).
+
+convert_state1(State, MacVer, MacVer) ->
     State;
-convert_state(State, 0, 1) ->
+convert_state1(State, 0, 1) ->
     %% To go from version 0 to version 1, we add the `dedups' fields at the
     %% end of the record. The default value is an empty map.
     ?assert(khepri_machine_v0:is_state(State)),

--- a/src/khepri_machine_v0.erl
+++ b/src/khepri_machine_v0.erl
@@ -29,7 +29,7 @@
 
 -record(khepri_machine,
         {config = #config{} :: khepri_machine:machine_config(),
-         tree = #tree{} :: khepri_tree:tree(),
+         tree = khepri_tree:new() :: khepri_tree:tree(),
          triggers = #{} ::
            #{khepri:trigger_id() =>
              #{sproc := khepri_path:native_path(),

--- a/src/khepri_machine_v0.erl
+++ b/src/khepri_machine_v0.erl
@@ -29,7 +29,7 @@
 
 -record(khepri_machine,
         {config = #config{} :: khepri_machine:machine_config(),
-         tree = khepri_tree:new() :: khepri_tree:tree(),
+         tree = khepri_tree:new() :: khepri_tree:tree_v0(),
          triggers = #{} ::
            #{khepri:trigger_id() =>
              #{sproc := khepri_path:native_path(),

--- a/src/khepri_prefix_tree.erl
+++ b/src/khepri_prefix_tree.erl
@@ -1,0 +1,179 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers
+%% to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(khepri_prefix_tree).
+
+%% This module defines a tree that associates paths with optional payloads and
+%% specializes in lookup of tree nodes by a prefixing path.
+%%
+%% This tree is similar to {@link khepri_pattern_tree} but the path components
+%% in this tree must be {@link khepri_path:node_id()}s rather than pattern
+%% components.
+%%
+%% This tree is also similar to the main tree type {@link khepri_tree} but it
+%% is simpler: it does not support keep-while conditions or properties for
+%% tree nodes. This type is used within {@link khepri_tree} for the reverse
+%% index of keep-while conditions.
+%%
+%% See https://en.wikipedia.org/wiki/Trie.
+
+-include_lib("stdlib/include/assert.hrl").
+
+-include("src/khepri_payload.hrl").
+
+-type child_nodes(Payload) :: #{khepri_path:node_id() => tree(Payload)}.
+
+-record(prefix_tree, {payload = ?NO_PAYLOAD,
+                      child_nodes = #{}}).
+
+-opaque tree(Payload) :: #prefix_tree{payload :: Payload | ?NO_PAYLOAD,
+                                      child_nodes :: child_nodes(Payload)}.
+
+-export_type([tree/1]).
+
+-export([empty/0,
+         is_prefix_tree/1,
+         from_map/1,
+         fold_prefixes_of/4,
+         find_path/2,
+         update/3]).
+
+-spec empty() -> tree(_).
+%% @doc Returns a new empty tree.
+%%
+%% @see tree().
+
+empty() ->
+    #prefix_tree{}.
+
+-spec is_prefix_tree(tree(_)) -> true;
+                    (term()) -> false.
+%% @doc Determines whether the given term is a prefix tree.
+
+is_prefix_tree(#prefix_tree{}) ->
+    true;
+is_prefix_tree(_) ->
+    false.
+
+-spec from_map(Map) -> Tree when
+      Map :: #{khepri_path:native_path() => Payload},
+      Tree :: khepri_prefix_tree:tree(Payload),
+      Payload :: term().
+%% @doc Converts a map of paths to payloads into a prefix tree.
+
+from_map(Map) when is_map(Map) ->
+    maps:fold(
+      fun(Path, Payload, Tree) ->
+              update(
+                fun(Payload0) ->
+                        %% Map keys are unique so this node in the prefix
+                        %% tree must have no payload.
+                        ?assertEqual(?NO_PAYLOAD, Payload0),
+                        Payload
+                end, Path, Tree)
+      end, empty(), Map).
+
+-spec fold_prefixes_of(Fun, Acc, Path, Tree) -> Ret when
+      Fun :: fun((Payload, Acc) -> Acc1),
+      Acc :: term(),
+      Acc1 :: term(),
+      Path :: khepri_path:native_path(),
+      Tree :: khepri_prefix_tree:tree(Payload),
+      Payload :: term(),
+      Ret :: Acc1.
+%% @doc Folds over all nodes in the tree which are prefixed by the given `Path'
+%% building an accumulated value with the given fold function and initial
+%% accumulator.
+
+fold_prefixes_of(Fun, Acc, Path, Tree) when is_function(Fun, 2) ->
+    fold_prefixes_of1(Fun, Acc, Path, Tree).
+
+fold_prefixes_of1(
+  Fun, Acc, [], #prefix_tree{payload = Payload, child_nodes = ChildNodes}) ->
+    Acc1 = case Payload of
+               ?NO_PAYLOAD ->
+                   Acc;
+               _ ->
+                   Fun(Payload, Acc)
+           end,
+    maps:fold(
+      fun(_Component, Subtree, Acc2) ->
+              fold_prefixes_of1(Fun, Acc2, [], Subtree)
+      end, Acc1, ChildNodes);
+fold_prefixes_of1(
+  Fun, Acc, [Component | Rest], #prefix_tree{child_nodes = ChildNodes}) ->
+    case maps:find(Component, ChildNodes) of
+        {ok, Subtree} ->
+            fold_prefixes_of1(Fun, Acc, Rest, Subtree);
+        error ->
+            Acc
+    end.
+
+-spec find_path(Path, Tree) -> Ret when
+      Path :: khepri_path:native_path(),
+      Tree :: khepri_prefix_tree:tree(Payload),
+      Payload :: term(),
+      Ret :: {ok, Payload} | error.
+%% @doc Returns the payload associated with a path in the tree.
+%%
+%% @returns `{ok, Payload}' where `Payload' is associated with the given path
+%% or `error' if the path is not associated with a payload in the given tree.
+
+find_path(Path, Tree) ->
+    find_path1(Path, Tree).
+
+find_path1([], #prefix_tree{payload = Payload}) ->
+    case Payload of
+        ?NO_PAYLOAD ->
+            error;
+        _ ->
+            {ok, Payload}
+    end;
+find_path1([Component | Rest], #prefix_tree{child_nodes = ChildNodes}) ->
+    case maps:find(Component, ChildNodes) of
+        {ok, Subtree} ->
+            find_path1(Rest, Subtree);
+        error ->
+            error
+    end.
+
+-spec update(Fun, Path, Tree) -> Ret when
+      Fun :: fun((Payload | ?NO_PAYLOAD) -> Payload | ?NO_PAYLOAD),
+      Path :: khepri_path:native_path(),
+      Tree :: khepri_prefix_tree:tree(Payload),
+      Payload :: term(),
+      Ret :: khepri_prefix_tree:tree(Payload).
+%% @doc Updates a given path in the tree.
+%%
+%% This function can be used to create, update or delete tree nodes. If the
+%% tree node does not exist for the given path, the update function is passed
+%% `?NO_PAYLOAD'. If the update function returns `?NO_PAYLOAD' then the tree
+%% node and all of its ancestors which do not have a payload or children are
+%% removed.
+%%
+%% The update function is also be passed `?NO_PAYLOAD' if a tree node exists
+%% but does not have a payload: being passed `?NO_PAYLOAD' is not a reliable
+%% sign that a tree node did not exist prior to an update.
+
+update(Fun, Path, Tree) ->
+    update1(Fun, Path, Tree).
+
+update1(Fun, [], #prefix_tree{payload = Payload} = Tree) ->
+    Tree#prefix_tree{payload = Fun(Payload)};
+update1(
+  Fun, [Component | Rest], #prefix_tree{child_nodes = ChildNodes} = Tree) ->
+    Subtree = maps:get(Component, ChildNodes, khepri_prefix_tree:empty()),
+    ChildNodes1 = case update1(Fun, Rest, Subtree) of
+                      #prefix_tree{payload = ?NO_PAYLOAD, child_nodes = C}
+                        when C =:= #{} ->
+                          %% Drop unused branches.
+                          maps:remove(Component, ChildNodes);
+                      Subtree1 ->
+                          maps:put(Component, Subtree1, ChildNodes)
+                  end,
+    Tree#prefix_tree{child_nodes = ChildNodes1}.

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -19,7 +19,9 @@
 -include("src/khepri_error.hrl").
 -include("src/khepri_tree.hrl").
 
--export([are_keep_while_conditions_met/2,
+-export([new/0,
+
+         are_keep_while_conditions_met/2,
 
          collect_node_props_cb/3,
          count_node_cb/3,
@@ -73,6 +75,11 @@
 %% -------------------------------------------------------------------
 %% Tree node functions.
 %% -------------------------------------------------------------------
+
+-spec new() -> tree().
+
+new() ->
+    #tree{}.
 
 -spec create_node_record(Payload) -> Node when
       Payload :: khepri_payload:payload(),

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -18,7 +18,6 @@
 %% khepri:get_root/1 is unexported when compiled without `-DTEST'. Likewise
 %% for:
 %%   - `khepri_machine:get_keep_while_conds/1'
-%%   - `khepri_machine:get_keep_while_conds_revidx/1'
 -dialyzer(no_missing_calls).
 
 are_keep_while_conditions_met_test() ->
@@ -70,7 +69,6 @@ insert_when_keep_while_true_test() ->
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
     KeepWhileConds = khepri_machine:get_keep_while_conds(S1),
-    KeepWhileCondsRevIdx = khepri_machine:get_keep_while_conds_revidx(S1),
 
     ?assertEqual(
        #node{
@@ -90,9 +88,6 @@ insert_when_keep_while_true_test() ->
     ?assertEqual(
        #{[baz] => KeepWhile},
        KeepWhileConds),
-    ?assertEqual(
-       #{[foo] => #{[baz] => ok}},
-       KeepWhileCondsRevIdx),
     ?assertEqual({ok, #{[baz] => #{}}}, Ret),
     ?assertEqual([], SE).
 

--- a/test/pattern_tree.erl
+++ b/test/pattern_tree.erl
@@ -70,10 +70,10 @@ fold_finds_all_patterns_matching_a_path_test() ->
                  khepri_tree:insert_or_update_node(
                    Tree0, Path, TreePayload, #{}, #{}),
                  Tree
-             end, #tree{}, [[stock, wood, <<"oak">>],
-                            [stock, wood, <<"birch">>],
-                            [stock, metal, <<"iron">>],
-                            []]),
+             end, khepri_tree:new(), [[stock, wood, <<"oak">>],
+                                      [stock, wood, <<"birch">>],
+                                      [stock, metal, <<"iron">>],
+                                      []]),
     PathPatterns =
     [[stock, wood, <<"oak">>],                               %% 1
      [stock, wood, <<"birch">>],                             %% 2

--- a/test/prefix_tree.erl
+++ b/test/prefix_tree.erl
@@ -1,0 +1,109 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2024 Broadcom. All Rights Reserved. The term "Broadcom" refers
+%% to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(prefix_tree).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("src/khepri_payload.hrl").
+
+update_passes_current_payload_test() ->
+    Path = [stock, wood, <<"oak">>],
+    Payload = 100,
+    Tree0 = khepri_prefix_tree:empty(),
+    Tree1 = khepri_prefix_tree:update(
+              fun(Payload0) ->
+                      ?assertEqual(Payload0, ?NO_PAYLOAD),
+                      Payload
+              end, Path, Tree0),
+    _ = khepri_prefix_tree:update(
+          fun(Payload1) ->
+                  ?assertEqual(Payload, Payload1),
+                  ?NO_PAYLOAD
+          end, Path, Tree1),
+    ok.
+
+deletion_prunes_empty_branches_test() ->
+    %% When deleting a node in the tree, the branch leading to that node is
+    %% removed while non-empty.
+    Path = [stock, wood, <<"oak">>],
+    Payload = 100,
+    Tree0 = khepri_prefix_tree:from_map(#{Path => Payload}),
+
+    %% This branch has a child (`<<"oak">>') so it will not be pruned.
+    Tree1 = khepri_prefix_tree:update(
+              fun(Payload0) ->
+                      ?assertEqual(Payload0, ?NO_PAYLOAD),
+                      ?NO_PAYLOAD
+              end, [stock, wood], Tree0),
+    ?assertNotEqual(Tree1, khepri_prefix_tree:empty()),
+
+    Tree2 = khepri_prefix_tree:update(
+              fun(Payload0) ->
+                      ?assertEqual(Payload0, Payload),
+                      ?NO_PAYLOAD
+              end, Path, Tree1),
+    ?assertEqual(Tree2, khepri_prefix_tree:empty()),
+
+    %% If an update doesn't store a payload then the branch is pruned. So this
+    %% update acts as a no-op and the tree remains empty:
+    Tree3 = khepri_prefix_tree:update(
+              fun(Payload0) ->
+                      ?assertEqual(Payload0, ?NO_PAYLOAD),
+                      ?NO_PAYLOAD
+              end, Path, Tree2),
+    ?assertEqual(Tree3, khepri_prefix_tree:empty()),
+
+    ok.
+
+find_path_test() ->
+    Path1 = [stock, wood, <<"oak">>],
+    Path2 = [stock, wood, <<"birch">>],
+    Path3 = [stock, metal, <<"iron">>],
+    Tree = khepri_prefix_tree:from_map(
+             #{Path1 => 100, Path2 => 150, Path3 => 10}),
+
+    ?assertEqual({ok, 100}, khepri_prefix_tree:find_path(Path1, Tree)),
+    ?assertEqual({ok, 150}, khepri_prefix_tree:find_path(Path2, Tree)),
+    ?assertEqual({ok, 10}, khepri_prefix_tree:find_path(Path3, Tree)),
+
+    ?assertEqual(
+      error,
+      khepri_prefix_tree:find_path(
+        [stock, wood, <<"oak">>, <<"leaves">>], Tree)),
+    ?assertEqual(error, khepri_prefix_tree:find_path([stock, wood], Tree)),
+    ?assertEqual(error, khepri_prefix_tree:find_path([stock, metal], Tree)),
+
+    ?assertEqual(
+      error,
+      khepri_prefix_tree:find_path(Path1, khepri_prefix_tree:empty())),
+
+    ok.
+
+fold_prefixes_of_test() ->
+    Path1 = [stock, wood, <<"oak">>],
+    Path2 = [stock, wood, <<"birch">>],
+    Path3 = [stock, metal, <<"iron">>],
+    Tree = khepri_prefix_tree:from_map(
+             #{Path1 => 100, Path2 => 150, Path3 => 10}),
+
+    ?assertEqual([100], collect_prefixes_of(Path1, Tree)),
+    ?assertEqual([100, 150], collect_prefixes_of([stock, wood], Tree)),
+    ?assertEqual([10], collect_prefixes_of([stock, metal], Tree)),
+    ?assertEqual([10, 100, 150], collect_prefixes_of([stock], Tree)),
+    ?assertEqual([10, 100, 150], collect_prefixes_of([], Tree)),
+
+    ?assertEqual(
+      [],
+      collect_prefixes_of([stock, wood, <<"oak">>, <<"leaves">>], Tree)),
+
+    ok.
+
+collect_prefixes_of(Path, Tree) ->
+    Payloads = khepri_prefix_tree:fold_prefixes_of(
+                 fun(Payload, Acc) -> [Payload | Acc] end, [], Path, Tree),
+    lists:sort(Payloads).


### PR DESCRIPTION
When handling a deletion, `khepri_tree:eval_keep_while_conditions/2` folded over the reverse index of keep while conditions and evaluated any for which the removed path was a prefix. This meant folding over each non-leaf node in the tree. We can eliminate nodes very quickly though to limit the impact of this search by using a prefix tree instead.

This change switches out the `keep_while_conds_revidx` field in `#khepri_tree{}` to a new `khepri_prefix_tree` type when the Khepri cluster reaches the new effective machine version of 2.