### PR TITLE
khepri_tree: Add an option to accumulate keep-while expirations

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -362,6 +362,16 @@
 %% created/updated tree node.</li>
 %% </ul>
 
+-type delete_options() :: #{return_keep_while_expirations => boolean()}.
+%% Options specific to deletions.
+%%
+%% <ul>
+%% <li>`return_keep_while_expirations' allows accumulating all Khepri tree
+%% nodes deleted because of expired keep-while conditions in the return of
+%% {@link khepri_adv:delete_many/3} and {@link khepri_tx_adv:delete_many/2}.
+%% </li>
+%% </ul>
+
 -type fold_fun() :: fun((khepri_path:native_path(),
                          khepri:node_props(),
                          khepri:fold_acc()) -> khepri:fold_acc()).
@@ -472,6 +482,7 @@
               query_options/0,
               tree_options/0,
               put_options/0,
+              delete_options/0,
 
               fold_fun/0,
               fold_acc/0,
@@ -2575,7 +2586,9 @@ delete_many(PathPattern) ->
       Ret :: khepri:minimal_ret();
 (PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Options :: khepri:command_options() | khepri:tree_options(),
+      Options :: khepri:command_options() |
+                 khepri:tree_options() |
+                 khepri:delete_options(),
       Ret :: khepri:minimal_ret().
 
 %% @doc Deletes all tree nodes matching the given path pattern.
@@ -2600,7 +2613,9 @@ delete_many(PathPattern, Options) when is_map(Options) ->
 -spec delete_many(StoreId, PathPattern, Options) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
-      Options :: khepri:command_options() | khepri:tree_options(),
+      Options :: khepri:command_options() |
+                 khepri:tree_options() |
+                 khepri:delete_options(),
       Ret :: khepri:minimal_ret() | khepri_machine:async_ret().
 %% @doc Deletes all tree nodes matching the given path pattern.
 %%

--- a/src/khepri_adv.erl
+++ b/src/khepri_adv.erl
@@ -917,7 +917,9 @@ delete_many(PathPattern) ->
       Ret :: khepri_adv:many_results();
 (PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Options :: khepri:command_options() | khepri:tree_options(),
+      Options :: khepri:command_options() |
+                 khepri:tree_options() |
+                 khepri:delete_options(),
       Ret :: khepri_adv:many_results().
 
 %% @doc Deletes all tree nodes matching the given path pattern.
@@ -942,7 +944,9 @@ delete_many(PathPattern, Options) when is_map(Options) ->
 -spec delete_many(StoreId, PathPattern, Options) -> Ret when
       StoreId :: khepri:store_id(),
       PathPattern :: khepri_path:pattern(),
-      Options :: khepri:command_options() | khepri:tree_options(),
+      Options :: khepri:command_options() |
+                 khepri:tree_options() |
+                 khepri:delete_options(),
       Ret :: khepri_adv:many_results() | khepri_machine:async_ret().
 %% @doc Deletes all tree nodes matching the given path pattern.
 %%
@@ -957,6 +961,9 @@ delete_many(PathPattern, Options) when is_map(Options) ->
 %%
 %% When doing an asynchronous update, the {@link handle_async_ret/1}
 %% function should be used to handle the message received from Ra.
+%%
+%% The `return_keep_while_expirations' option may be used with this command to
+%% return all tree nodes which were removed by expired keep-while conditions.
 %%
 %% Example:
 %% ```

--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -884,7 +884,7 @@ delete_many(PathPattern) ->
 
 -spec delete_many(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Options :: khepri:tree_options(),
+      Options :: khepri:tree_options() | khepri:delete_options(),
       Ret :: khepri:minimal_ret().
 %% @doc Deletes all tree nodes matching the given path pattern.
 %%

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -406,7 +406,7 @@ delete_many(PathPattern) ->
 
 -spec delete_many(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Options :: khepri:tree_options(),
+      Options :: khepri:tree_options() | khepri:delete_options(),
       Ret :: khepri_adv:many_results().
 %% @doc Deletes all tree nodes matching the given path pattern.
 %%


### PR DESCRIPTION
This change adds a type `khepri:delete_options()` similar to `khepri:put_options()` which includes a new option `return_keep_while_expirations`. Setting this option in a call to `khepri_adv:delete_many/3` or `khepri_tx_adv:delete_many/2` will include any tree nodes deleted because of expired keep-while conditions in the `khepri_adv:many_results()` return value.

In order to accumulate these deletions we need to modify `khepri_machine:remove_expired_nodes/2` slightly to pass the fold function and accumulator for the current `#walk{..}`.

This option is useful for callers if they need to do something with any tree nodes which were deleted by keep-while conditions. For example in RabbitMQ we currently delete all bindings which are associated with a queue in a transaction. Bindings should always be removed when their associated queue is removed so they seem like an ideal case to use a keep-while condition. We send notifications and invoke callbacks with the set of bindings which were deleted though, so we need to return these deleted records. With this change we can avoid performing binding deletion in a transaction and instead only delete the queue record while providing the new option. This is significantly more efficient because of the way the Khepri store is organized in RabbitMQ.