### PR TITLE
Fix generation of docs with Erlang 27

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -104,6 +104,9 @@ jobs:
       - name: Generate
         run: rebar3 edoc
 
+      - name: Ensure HTML files are there
+        run: ls -l doc && test -f doc/index.html
+
       - name: Upload docs for next job
         uses: actions/upload-artifact@v4
         with:
@@ -123,6 +126,9 @@ jobs:
         with:
           name: docs_dir
           path: ./doc
+
+      - name: Ensure HTML files are there
+        run: ls -l doc && test -f doc/index.html
 
       - name: Publish
         uses: peaceiris/actions-gh-pages@v4

--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {project_plugins, [rebar3_proper,
                    covertool,
                    rebar3_hex,
-                   {rebar3_edoc_extensions, "1.5.0"}]}.
+                   {rebar3_edoc_extensions, "1.6.1"}]}.
 
 {erl_opts, [debug_info,
             warn_export_vars,


### PR DESCRIPTION
Khepri docs fail to build with Erlang/OTP 27.1. This came from a new callback expected by xmerl that rebar3_edoc_extensions did not define. This was fixed in vkatsuba/rebar3_edoc_extensions#28 and released in rebar3_edoc_extensions 1.6.1.

While here, add new CI steps to detect `rebar3 edoc` early (it doesn’t exit with an error…).