### PR TITLE
khepri_adv: Add `delete_reason` prop, accumulate keep-while expirations

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -203,6 +203,22 @@
 -type child_list_length() :: non_neg_integer().
 %% Number of direct child nodes under a tree node.
 
+-type delete_reason() :: explicit | keep_while.
+%% The reason why a tree node was removed from the store.
+%%
+%% <ul>
+%% <li>`explicit' means that the tree node was removed from the store because a
+%% deletion command targeted that tree node or its ancestor. This reason is
+%% used when a tree node's path is provided to {@link khepri_adv:delete/3} for
+%% example.</li>
+%% <li>`keep_while': the tree node was removed because the keep-while condition
+%% set when the node was created became unsatisfied. Note that adding or
+%% updating a tree node can cause a keep-while condition to become unsatisfied,
+%% so a put operation may result in a tree node being deleted with this delete
+%% reason. See {@link khepri_condition:keep_while()} and {@link
+%% khepri:put_options()}.</li>
+%% </ul>
+
 -type node_props() ::
     #{data => khepri:data(),
       has_data => boolean(),
@@ -211,7 +227,8 @@
       payload_version => khepri:payload_version(),
       child_list_version => khepri:child_list_version(),
       child_list_length => khepri:child_list_length(),
-      child_names => [khepri_path:node_id()]}.
+      child_names => [khepri_path:node_id()],
+      delete_reason => khepri:delete_reason()}.
 %% Structure used to return properties, payload and child nodes for a specific
 %% tree node.
 %%
@@ -337,7 +354,8 @@
                                               child_names |
                                               payload |
                                               has_payload |
-                                              raw_payload],
+                                              raw_payload |
+                                              delete_reason],
                           include_root_props => boolean()}.
 %% Options used during tree traversal.
 %%
@@ -460,6 +478,7 @@
               payload_version/0,
               child_list_version/0,
               child_list_length/0,
+              delete_reason/0,
               node_props/0,
               trigger_id/0,
 

--- a/src/khepri_node.hrl
+++ b/src/khepri_node.hrl
@@ -16,7 +16,8 @@
                            child_list_version => ?INIT_CHILD_LIST_VERSION}).
 
 -define(DEFAULT_PROPS_TO_RETURN, [payload,
-                                  payload_version]).
+                                  payload_version,
+                                  delete_reason]).
 
 -record(node, {props = ?INIT_NODE_PROPS :: khepri_machine:props(),
                payload = ?NO_PAYLOAD :: khepri_payload:payload(),

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -1343,7 +1343,9 @@ handle_keep_while_for_parent_update(
 handle_keep_while_for_parent_update(
   #walk{tree = Tree,
         node = ParentNode,
-        reversed_path = ReversedPath} = Walk,
+        reversed_path = ReversedPath,
+        tree_options = TreeOptions,
+        fun_acc = Acc} = Walk,
   AppliedChangesAcc) ->
     ParentPath = lists:reverse(ReversedPath),
     IsMet = is_keep_while_condition_met_on_self(
@@ -1356,7 +1358,11 @@ handle_keep_while_for_parent_update(
             %% This parent node must be removed because it doesn't meet its
             %% own keep_while condition. keep_while conditions for nodes
             %% depending on this one will be evaluated with the recursion.
-            Walk1 = Walk#walk{node = delete},
+            {ok, delete, Acc1} = delete_matching_nodes_cb(
+                                   ParentPath, ParentNode,
+                                   TreeOptions, keep_while, Acc),
+            Walk1 = Walk#walk{node = delete,
+                              fun_acc = Acc1},
             walk_back_up_the_tree(Walk1, AppliedChangesAcc)
     end.
 
@@ -1540,14 +1546,27 @@ remove_expired_nodes([], Walk) ->
     {ok, Walk};
 remove_expired_nodes(
   [PathToDelete | Rest],
-  #walk{tree = Tree, applied_changes = AppliedChanges} = Walk) ->
-    case delete_matching_nodes(Tree, PathToDelete, AppliedChanges, #{}) of
-        {ok, Tree1, AppliedChanges1, _Acc} ->
+  #walk{tree = Tree,
+        applied_changes = AppliedChanges,
+        tree_options = TreeOptions,
+        fun_acc = Acc} = Walk) ->
+    %% See `delete_matching_nodes/4'. This is the same except that the
+    %% accumulator is passed through and the `DeleteReason' is provided as
+    %% `keep_while'.
+    Fun = fun(Path, Node, Result) ->
+                  delete_matching_nodes_cb(
+                    Path, Node, TreeOptions, keep_while, Result)
+          end,
+    Result = walk_down_the_tree(
+               Tree, PathToDelete, TreeOptions, AppliedChanges, Fun, Acc),
+    case Result of
+        {ok, Tree1, AppliedChanges1, Acc1} ->
             AppliedChanges2 = merge_applied_changes(
                                 AppliedChanges, AppliedChanges1),
             Walk1 = Walk#walk{tree = Tree1,
                               node = Tree1#tree.root,
-                              applied_changes = AppliedChanges2},
+                              applied_changes = AppliedChanges2,
+                              fun_acc = Acc1},
             remove_expired_nodes(Rest, Walk1)
     end.
 

--- a/test/advanced_delete.erl
+++ b/test/advanced_delete.erl
@@ -36,7 +36,8 @@ delete_existing_node_test_() ->
          khepri_adv:create(?FUNCTION_NAME, [foo], foo_value)),
       ?_assertEqual(
          {ok, #{[foo] => #{data => foo_value,
-                           payload_version => 1}}},
+                           payload_version => 1,
+                           delete_reason => explicit}}},
          khepri_adv:delete(?FUNCTION_NAME, [foo])),
       ?_assertEqual(
          {error, ?khepri_error(node_not_found, #{node_name => foo,
@@ -77,7 +78,8 @@ delete_many_on_existing_node_with_condition_true_test_() ->
          khepri_adv:create(?FUNCTION_NAME, [foo], foo_value)),
       ?_assertEqual(
          {ok, #{[foo] => #{data => foo_value,
-                           payload_version => 1}}},
+                           payload_version => 1,
+                           delete_reason => explicit}}},
          khepri_adv:delete_many(
            ?FUNCTION_NAME, [#if_name_matches{regex = "foo"}])),
       ?_assertEqual(

--- a/test/advanced_tx_delete.erl
+++ b/test/advanced_tx_delete.erl
@@ -50,7 +50,8 @@ delete_existing_node_test_() ->
       ?_assertEqual(
          {ok,
           {ok, #{[foo] => #{data => foo_value,
-                            payload_version => 1}}}},
+                            payload_version => 1,
+                            delete_reason => explicit}}}},
          begin
              Fun = fun() ->
                            khepri_tx_adv:delete([foo])
@@ -116,7 +117,8 @@ delete_many_on_existing_node_with_condition_true_test_() ->
       ?_assertEqual(
          {ok,
           {ok, #{[foo] => #{data => foo_value,
-                            payload_version => 1}}}},
+                            payload_version => 1,
+                            delete_reason => explicit}}}},
          begin
              Fun = fun() ->
                            khepri_tx_adv:delete_many(

--- a/test/async_option.erl
+++ b/test/async_option.erl
@@ -289,7 +289,8 @@ async_with_correlation_and_priority_in_delete_test_() ->
              RaEvent = receive {ra_event, _, _} = Event -> Event end,
              ?assertEqual(
                [{Correlation, {ok, #{[foo] =>
-                                     #{payload_version => 1}}}}],
+                                     #{payload_version => 1,
+                                       delete_reason => explicit}}}}],
                khepri:handle_async_ret(?FUNCTION_NAME, RaEvent)),
              ?assertEqual(
                 {error,

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1693,7 +1693,8 @@ can_use_default_store_on_single_node(_Config) ->
        {ok, #{[bar] => #{payload_version => 2}}},
        khepri_adv:clear_many_payloads([bar])),
     ?assertEqual(
-       {ok, #{[bar] => #{payload_version => 2}}},
+       {ok, #{[bar] => #{payload_version => 2,
+                         delete_reason => explicit}}},
        khepri_adv:delete([bar])),
     ?assertMatch(
        {ok, #{}},

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -139,12 +139,18 @@ delete_a_node_deep_into_the_tree_test() ->
             child_list_version => 3},
           child_nodes = #{}},
        Root),
-    ?assertEqual(
-      {ok, #{[foo, bar, baz] => #{payload_version => 1,
-                                  child_list_version => 1,
-                                  child_list_length => 1,
-                                  delete_reason => explicit}}},
-      Ret),
+    ?assertEqual({ok, #{[foo, bar, baz] => #{payload_version => 1,
+                                             child_list_version => 1,
+                                             child_list_length => 1,
+                                             delete_reason => explicit},
+                        [foo, bar] => #{payload_version => 1,
+                                        child_list_version => 2,
+                                        child_list_length => 0,
+                                        delete_reason => keep_while},
+                        [foo] => #{payload_version => 1,
+                                   child_list_version => 2,
+                                   child_list_length => 0,
+                                   delete_reason => keep_while}}}, Ret),
     ?assertEqual([], SE).
 
 delete_existing_node_with_condition_true_test() ->

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -127,7 +127,8 @@ delete_a_node_deep_into_the_tree_test() ->
                       options = #{props_to_return => [payload,
                                                       payload_version,
                                                       child_list_version,
-                                                      child_list_length]}},
+                                                      child_list_length,
+                                                      delete_reason]}},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -138,9 +139,12 @@ delete_a_node_deep_into_the_tree_test() ->
             child_list_version => 3},
           child_nodes = #{}},
        Root),
-    ?assertEqual({ok, #{[foo, bar, baz] => #{payload_version => 1,
-                                             child_list_version => 1,
-                                             child_list_length => 1}}}, Ret),
+    ?assertEqual(
+      {ok, #{[foo, bar, baz] => #{payload_version => 1,
+                                  child_list_version => 1,
+                                  child_list_length => 1,
+                                  delete_reason => explicit}}},
+      Ret),
     ?assertEqual([], SE).
 
 delete_existing_node_with_condition_true_test() ->
@@ -275,7 +279,8 @@ delete_many_nodes_at_once_test() ->
                       options = #{props_to_return => [payload,
                                                       payload_version,
                                                       child_list_version,
-                                                      child_list_length]}},
+                                                      child_list_length,
+                                                      delete_reason]}},
     {S1, Ret, SE} = khepri_machine:apply(?META, Command, S0),
     Root = khepri_machine:get_root(S1),
 
@@ -292,11 +297,13 @@ delete_many_nodes_at_once_test() ->
     ?assertEqual({ok, #{[bar] => #{data => bar_value,
                                    payload_version => 1,
                                    child_list_version => 1,
-                                   child_list_length => 0},
+                                   child_list_length => 0,
+                                   delete_reason => explicit},
                         [baz] => #{data => baz_value,
                                    payload_version => 1,
                                    child_list_version => 1,
-                                   child_list_length => 0}}}, Ret),
+                                   child_list_length => 0,
+                                   delete_reason => explicit}}}, Ret),
     ?assertEqual([], SE).
 
 delete_command_bumps_applied_command_count_test() ->

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -260,7 +260,8 @@ keep_while_now_false_after_command_test() ->
                  #node{props = ?INIT_NODE_PROPS,
                        payload = khepri_payload:data(bar_value)}}}}},
        Root),
-    ?assertEqual({ok, #{[foo, bar] => #{}}}, Ret),
+    ?assertEqual({ok, #{[foo, bar] => #{},
+                        [baz] => #{delete_reason => keep_while}}}, Ret),
     ?assertEqual([], SE).
 
 recursive_automatic_cleanup_test() ->
@@ -292,13 +293,21 @@ recursive_automatic_cleanup_test() ->
             child_list_version => 3},
           child_nodes = #{}},
        Root),
-    ?assertEqual(
-      {ok, #{[foo, bar, baz] => #{data => baz_value,
-                                  payload_version => 1,
-                                  child_list_version => 1,
-                                  child_list_length => 0,
-                                  delete_reason => explicit}}},
-      Ret),
+    ?assertEqual({ok, #{[foo, bar, baz] => #{data => baz_value,
+                                             payload_version => 1,
+                                             child_list_version => 1,
+                                             child_list_length => 0,
+                                             delete_reason => explicit},
+                        [foo, bar] => #{data => bar_value,
+                                        payload_version => 1,
+                                        child_list_version => 3,
+                                        child_list_length => 0,
+                                        delete_reason => keep_while},
+                        [foo] => #{data => foo_value,
+                                   payload_version => 1,
+                                   child_list_version => 3,
+                                   child_list_length => 0,
+                                   delete_reason => keep_while}}}, Ret),
     ?assertEqual([], SE).
 
 keep_while_now_false_after_delete_command_test() ->
@@ -330,7 +339,12 @@ keep_while_now_false_after_delete_command_test() ->
                                    payload_version => 1,
                                    child_list_version => 1,
                                    child_list_length => 0,
-                                   delete_reason => explicit}}}, Ret),
+                                   delete_reason => explicit},
+                        [baz] => #{data => baz_value,
+                                   payload_version => 1,
+                                   child_list_version => 1,
+                                   child_list_length => 0,
+                                   delete_reason => keep_while}}}, Ret),
     ?assertEqual([], SE).
 
 automatic_reclaim_of_useless_nodes_works_test() ->
@@ -349,8 +363,9 @@ automatic_reclaim_of_useless_nodes_works_test() ->
             child_list_version => 3},
           child_nodes = #{}},
        Root),
-    ?assertEqual(
-      {ok, #{[foo, bar, baz] => #{delete_reason => explicit}}}, Ret),
+    ?assertEqual({ok, #{[foo, bar, baz] => #{delete_reason => explicit},
+                        [foo, bar] => #{delete_reason => keep_while},
+                        [foo] => #{delete_reason => keep_while}}}, Ret),
     ?assertEqual([], SE).
 
 automatic_reclaim_keeps_relevant_nodes_1_test() ->
@@ -379,8 +394,8 @@ automatic_reclaim_keeps_relevant_nodes_1_test() ->
                   payload = khepri_payload:data(relevant),
                   child_nodes = #{}}}},
        Root),
-    ?assertEqual(
-      {ok, #{[foo, bar, baz] => #{delete_reason => explicit}}}, Ret),
+    ?assertEqual({ok, #{[foo, bar, baz] => #{delete_reason => explicit},
+                        [foo, bar] => #{delete_reason => keep_while}}}, Ret),
     ?assertEqual([], SE).
 
 automatic_reclaim_keeps_relevant_nodes_2_test() ->
@@ -415,6 +430,7 @@ automatic_reclaim_keeps_relevant_nodes_2_test() ->
                           child_nodes = #{}}}}}},
        Root),
     ?assertEqual(
-      {ok, #{[foo, bar, baz, qux] => #{delete_reason => explicit}}},
+      {ok, #{[foo, bar, baz, qux] => #{delete_reason => explicit},
+             [foo, bar, baz] => #{delete_reason => keep_while}}},
       Ret),
     ?assertEqual([], SE).

--- a/test/prop_state_machine.erl
+++ b/test/prop_state_machine.erl
@@ -102,7 +102,7 @@ postcondition(
   #state{entries = Entries},
   {call, khepri_adv, delete_many, [_StoreId, Path, _Options]},
   Result) ->
-    result_is_ok(Result, Entries, Path, {ok, #{}}).
+    result_is_ok_after_delete(Result, Entries, Path).
 
 add_entry(Entries, Path, Payload) ->
     {Entry1, New} = case Entries of
@@ -182,6 +182,18 @@ result_is_ok(Result, Entries, Path, Default) ->
         _ ->
             Default =:= Result
     end.
+
+result_is_ok_after_delete({ok, NodePropsMap}, Entries, Path) ->
+    case Entries of
+        #{Path := NodeProps} ->
+            DeletedProps = maps:get(Path, NodePropsMap, #{}),
+            DeletedProps1 = maps:remove(delete_reason, DeletedProps),
+            DeletedProps1 =:= NodeProps;
+        _ ->
+            NodePropsMap =:= #{}
+    end;
+result_is_ok_after_delete(_, _Entries, _Path) ->
+    false.
 
 result_is_ok_after_put(Result, Entries, Path, Payload, Default) ->
     case Entries of


### PR DESCRIPTION
This change adds a `delete_reason` prop to the props map for nodes deleted with a function from the adv APIs `khepri_adv` and `khepri_adv_tx`. Tree nodes which are the target of deletion commands gain a `delete_reason` property set to `direct`. This change also includes any tree nodes which were deleted because of an expired keep-while condition in the node props map. These expired nodes have a `delete_reason` property set to `keep_while` instead. The `delete_reason` property lets callers filter on whether a change was a deletion and distinguish nodes deleted directly or indirectly.