### PR TITLE
khepri_machine: Request `delete_reason` if effective machine version >= 2 only

### DIFF
--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -466,9 +466,11 @@ count(PathPattern) ->
 count(PathPattern, Options) ->
     PathPattern1 = khepri_tx_adv:path_from_string(PathPattern),
     {State, _SideEffects} = khepri_tx_adv:get_tx_state(),
+    StoreId = khepri_machine:get_store_id(State),
     Tree = khepri_machine:get_tree(State),
     Fun = fun khepri_tree:count_node_cb/3,
-    {_QueryOptions, TreeOptions} = khepri_machine:split_query_options(Options),
+    {_QueryOptions, TreeOptions} =
+    khepri_machine:split_query_options(StoreId, Options),
     TreeOptions1 = TreeOptions#{expect_specific_node => false},
     Ret = khepri_tree:fold(Tree, PathPattern1, Fun, 0, TreeOptions1),
     case Ret of
@@ -517,8 +519,10 @@ fold(PathPattern, Fun, Acc) ->
 fold(PathPattern, Fun, Acc, Options) ->
     PathPattern1 = khepri_tx_adv:path_from_string(PathPattern),
     {State, _SideEffects} = khepri_tx_adv:get_tx_state(),
+    StoreId = khepri_machine:get_store_id(State),
     Tree = khepri_machine:get_tree(State),
-    {_QueryOptions, TreeOptions} = khepri_machine:split_query_options(Options),
+    {_QueryOptions, TreeOptions} =
+    khepri_machine:split_query_options(StoreId, Options),
     TreeOptions1 = TreeOptions#{expect_specific_node => false},
     Ret = khepri_tree:fold(Tree, PathPattern1, Fun, Acc, TreeOptions1),
     case Ret of


### PR DESCRIPTION
## Why

The `delete_reason` property to return was introduced with machine version 2. Older versions have two issues:
* They don't know this property
* They crash on unknown properties

## How


We request this new property only if the effective machine version is greater or equal to 2 to avoid the issues listed above.

Future unknown properties are ignored since commit 257cf328110a69618ad0cf35e3ea1c5bb2a40e4c merged in the previous pull request #308.