### PR TITLE
khepri_bang: `unwrapped_minimnal_ret()` can be `ok` only

### DIFF
--- a/src/khepri_bang.hrl
+++ b/src/khepri_bang.hrl
@@ -10,7 +10,7 @@
 %% "Bang functions", mostly an Elixir convention.
 %% -------------------------------------------------------------------
 
--type unwrapped_minimal_ret() :: khepri:minimal_ret().
+-type unwrapped_minimal_ret() :: ok.
 
 -type unwrapped_payload_ret(Default) :: khepri:data() |
                                         horus:horus_fun() |


### PR DESCRIPTION
## Why

It can't have an error, that's the point of the bang functions.