### PR TITLE
khepri_tx_adv: Allow calls to `khepri_path` in transactions

### DIFF
--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -707,6 +707,20 @@ ensure_bif_is_valid(Bif, Arity) ->
 is_remote_call_valid(khepri_payload, no_payload, 0) -> true;
 is_remote_call_valid(khepri_payload, data, 1) -> true;
 
+is_remote_call_valid(khepri_path, compile, _) -> true;
+is_remote_call_valid(khepri_path, from_string, _) -> true;
+is_remote_call_valid(khepri_path, from_binary, _) -> true;
+is_remote_call_valid(khepri_path, to_string, _) -> true;
+is_remote_call_valid(khepri_path, to_binary, _) -> true;
+is_remote_call_valid(khepri_path, combine_with_conditions, _) -> true;
+is_remote_call_valid(khepri_path, targets_specific_node, _) -> true;
+is_remote_call_valid(khepri_path, component_targets_specific_node, _) -> true;
+is_remote_call_valid(khepri_path, is_valid, _) -> true;
+is_remote_call_valid(khepri_path, ensure_is_valid, _) -> true;
+is_remote_call_valid(khepri_path, abspath, _) -> true;
+is_remote_call_valid(khepri_path, realpath, _) -> true;
+is_remote_call_valid(khepri_path, pattern_includes_root_node, _) -> true;
+
 is_remote_call_valid(khepri_tx, is_empty, _) -> true;
 is_remote_call_valid(khepri_tx, get, _) -> true;
 is_remote_call_valid(khepri_tx, get_or, _) -> true;


### PR DESCRIPTION
Transactions might use functions like `khepri_path:combine_with_conditions/2` to modify a path from the env with extra conditions like checking the version. `khepri_path` functions are all pure - with the exception of `compile/1`, but compiling regexes within a transaction for example should be harmless - so we should allow these within transactions.