### PR TITLE
khepri_cluster: Restore the use of `ra_leaderboard` in `members/2`

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -1152,7 +1152,17 @@ members(StoreId, Options) when is_map(Options) ->
                     consistency -> leader;
                     low_latency -> local
                 end,
-    do_query_members(StoreId, ThisMember, QueryType, Timeout).
+    case QueryType of
+        local ->
+            case ra_leaderboard:lookup_members(StoreId) of
+                Members when is_list(Members) ->
+                    {ok, lists:sort(Members)};
+                undefined ->
+                    do_query_members(StoreId, ThisMember, QueryType, Timeout)
+            end;
+        leader ->
+            do_query_members(StoreId, ThisMember, QueryType, Timeout)
+    end.
 
 -spec do_query_members(StoreId, RaServer, QueryType, Timeout) -> Ret when
       StoreId :: khepri:store_id(),


### PR DESCRIPTION
## Why

The rework of the `khepri_cluster:members/2` to make the API close to other functions saw the drop of the call to the `ra_leaderboard`. This call was an optimization.

## How

The function is simply modified to restore the call to `ra_leaderboard` if the query is a local one.