### PR TITLE
khepri_machine: Use process dict instead of `persistent_term` to track the need for a fence preliminary query

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1161,9 +1161,6 @@ get_timeout(_)                     -> khepri_app:get_default_timeout().
 clear_cache(_StoreId) ->
     ok.
 
--define(CAN_SKIP_FENCE_PRELIMINARY_QUERY_KEY(StoreId),
-        {?MODULE, can_skip_fence_preliminary_query, StoreId}).
-
 -spec sending_sync_command_locally(StoreId) -> ok when
       StoreId :: khepri:store_id().
 %% @doc Records that a synchronous command is about to be sent locally.
@@ -1171,7 +1168,7 @@ clear_cache(_StoreId) ->
 %% After that, we know we don't need a fence preliminary query.
 
 sending_sync_command_locally(StoreId) ->
-    Key = ?CAN_SKIP_FENCE_PRELIMINARY_QUERY_KEY(StoreId),
+    Key = {khepri, can_skip_fence_preliminary_query, StoreId},
     _ = erlang:put(Key, true),
     ok.
 
@@ -1190,7 +1187,7 @@ sending_query_locally(StoreId) ->
 %% @doc Records that an asynchronous command is about to be sent locally.
 
 sending_async_command_locally(StoreId) ->
-    Key = ?CAN_SKIP_FENCE_PRELIMINARY_QUERY_KEY(StoreId),
+    Key = {khepri, can_skip_fence_preliminary_query, StoreId},
     _ = erlang:erase(Key),
     ok.
 
@@ -1217,13 +1214,22 @@ ask_fence_preliminary_query(StoreId) ->
 %% @doc Indicates if the calling process sent a synchronous command or a query
 %% before this call.
 %%
+%% The need for a preliminary query is tracked using a process dictionary
+%% entry. The process dictionary is used because that property is specific to
+%% a calling process. Alternatives were explored: a persistent_term was used
+%% initially but it is not meant for frequent writes, and an ETS table is
+%% unpracticle because if Khepri is not running on the calling process node,
+%% it won't be able to create that table.
+%%
+%% The need is updated with calls to the `sending_*/1' functions above.
+%%
 %% @returns `true' if the calling process sent a synchrorous command or a query
 %% to the given store before this call, `false' if the calling process never
 %% sent anything to the given store, if the last message was an asynchrorous
 %% command, or if the last message was sent to a remote store.
 
 can_skip_fence_preliminary_query(StoreId) ->
-    Key = ?CAN_SKIP_FENCE_PRELIMINARY_QUERY_KEY(StoreId),
+    Key = {khepri, can_skip_fence_preliminary_query, StoreId},
     erlang:get(Key) =:= true.
 
 %% -------------------------------------------------------------------

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1089,12 +1089,12 @@ add_applied_condition1(StoreId, Options, Timeout) ->
             add_applied_condition2(StoreId, Options, Timeout);
         false ->
             T0 = khepri_utils:start_timeout_window(Timeout),
-            QueryFun = fun erlang:is_tuple/1,
+            QueryFun = fun erlang:is_integer/1,
             case process_query1(StoreId, QueryFun, Timeout) of
-                true ->
+                false ->
                     NewTimeout = khepri_utils:end_timeout_window(Timeout, T0),
                     add_applied_condition2(StoreId, Options, NewTimeout);
-                Other when Other =/= false ->
+                Other when Other =/= true ->
                     Other
             end
     end.


### PR DESCRIPTION
## Why

There was a small bug with our use of the persistent_term: it should have been a key per store ID and process PID combination, not just per store ID.

But anyway, a persistent_term is designed for a value that is mostly read, rarely written to. This was not the case here.

## How

I thought about using an ETS table instead but it had a problem: if the calling process is on a different node that the one running Khepri, Khepri can't create an ETS table on that remote node. Each call could initialize that table if it didn’t exist, but this would be too much overhead in that code path to my taste. Moreover, we would have to put in place a cleaning mechanism for processes that exited if they still had an entry in that ETS table.

The solution retained is the use of the calling process dictionary. It is fast, can handle frequent updates and will be automatically cleaned up when the process exits. It also does not need an initial setup.