### PR TITLE
khepri_tx: Export the transaction API version

### DIFF
--- a/src/khepri_tx.erl
+++ b/src/khepri_tx.erl
@@ -86,9 +86,12 @@
          clear_many_payloads/1, clear_many_payloads/2,
 
          abort/1,
-         is_transaction/0]).
+         is_transaction/0,
+         api_version/0]).
 
 -compile({no_auto_import, [get/1, put/2, erase/1]}).
+
+-define(TX_API_VERSION, 1).
 
 %% FIXME: Dialyzer complains about several functions with "optional" arguments
 %% (but not all). I believe the specs are correct, but can't figure out how to
@@ -106,9 +109,13 @@
 -type tx_abort() :: khepri:error(any()).
 %% Return value after a transaction function aborted.
 
+-type api_version() :: pos_integer().
+%% Version of the transaction API.
+
 -export_type([tx_fun/0,
               tx_fun_result/0,
-              tx_abort/0]).
+              tx_abort/0,
+              api_version/0]).
 
 %% -------------------------------------------------------------------
 %% is_empty().
@@ -1009,3 +1016,26 @@ is_transaction() ->
         {_State, _SideEffects} -> true;
         _                      -> false
     end.
+
+%% -------------------------------------------------------------------
+%% api_version().
+%% -------------------------------------------------------------------
+
+-spec api_version() -> khepri_tx:api_version().
+%% @doc Returns the version of the transaction API for the Khepri instance
+%% that execute the transaction.
+%%
+%% The transaction code is compiled on one Erlang node with a specific version
+%% of Khepri. However, it is executed on all members of the Khepri cluster.
+%% Some Erlang nodes might use another version of Khepri, newer or older, and
+%% the transaction API may differ.
+%%
+%% For instance in Khepri 0.17.x, the return values of the {@link
+%% khepri_tx_adv} functions changed. The transaction code will have to handle
+%% voth versions of the API to work correctly. Thus it can use this function
+%% to adapt its behaviour.
+%%
+%% @returns the version of the Khepri transaction API.
+
+api_version() ->
+    ?TX_API_VERSION.

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -751,6 +751,7 @@ is_remote_call_valid(khepri_tx, clear_payload, _) -> true;
 is_remote_call_valid(khepri_tx, clear_many_payloads, _) -> true;
 is_remote_call_valid(khepri_tx, abort, _) -> true;
 is_remote_call_valid(khepri_tx, is_transaction, _) -> true;
+is_remote_call_valid(khepri_tx, api_version, _) -> true;
 
 is_remote_call_valid(khepri_tx_adv, get, _) -> true;
 is_remote_call_valid(khepri_tx_adv, get_many, _) -> true;

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1721,6 +1721,9 @@ can_use_default_store_on_single_node(_Config) ->
        {error, ?khepri_error(node_not_found, _)},
        khepri:get([foo])),
 
+    ?assert(is_integer(khepri_tx:api_version())),
+    ?assert(khepri_tx:api_version() > 0),
+
     ?assertEqual(ok, khepri:stop()),
     ?assertEqual(ok, application:stop(khepri)),
     ?assertEqual(ok, application:stop(ra)),

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -52,7 +52,8 @@ allowed_khepri_tx_api_test() ->
            _ = khepri_tx:has_data([foo]),
            _ = khepri_tx:delete([foo]),
            _ = khepri_tx:abort(error),
-           _ = khepri_tx:is_transaction()
+           _ = khepri_tx:is_transaction(),
+           _ = khepri_tx:api_version()
        end).
 
 denied_khepri_tx_adv_run_4_test() ->


### PR DESCRIPTION
## Why

The transaction code is compiled on one Erlang node with a specific version of Khepri. However, it is executed on all members of the Khepri cluster. Some Erlang nodes might use another version of Khepri, newer or older, and the transaction API may differ there.

For instance in Khepri 0.17.x, the return values of the `khepri_tx_adv` functions changed. The transaction code will have to handle voth versions of the API to work correctly. Thus it can use this function to adapt its behaviour.

## How

The first transaction version is set to 1 and is exported as a public API.

A transaction use can use it it determine how to use the `khepri_tx` and `khepri_tx_adv` modules and what to expect in terms of behaviour and return values.