### PR TITLE
khepri_machine: Fix dedup mechanism support check

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -863,9 +863,10 @@ process_command(StoreId, Command, Options) ->
 
 process_sync_command(
   StoreId, Command, #{protect_against_dups := true} = Options) ->
-    MacVer = version(),
+    %% The deduplication mechanism was added to machine version 1.
+    DedupMacVer = 1,
     case effective_version(StoreId) of
-        {ok, EffectiveMacVer} when EffectiveMacVer >= MacVer ->
+        {ok, EffectiveMacVer} when EffectiveMacVer >= DedupMacVer ->
             %% When `protect_against_dups' is true, we wrap the command inside
             %% a #dedup{} one to give it a unique reference. This is used for
             %% non-idempotent commands which could be replayed when there is a


### PR DESCRIPTION
## Why

It is based on the machine version but it used the latest supported one. The problem is that the dedup mechanism was added to version 1, not necessarily the latest.

Therefore, the existing check would skip the use of the dedup mechanism just because the effective machine version was not the latest one.

## How

We check that the effective version is at least 1, the version where the deduplication mechanism was added.