### PR TITLE
Fix transactions backward compatibility with older Khepri

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -357,7 +357,8 @@
 -type tree_options() :: #{expect_specific_node => boolean(),
                           props_to_return => [known_prop_to_return() |
                                               unknown_prop_to_return()],
-                          include_root_props => boolean()}.
+                          include_root_props => boolean(),
+                          return_indirect_deletes => boolean()}.
 %% Options used during tree traversal.
 %%
 %% <ul>
@@ -371,6 +372,10 @@
 %% only.</li>
 %% <li>`include_root_props' indicates if root properties and payload should be
 %% returned as well.</li>
+%% <li>`return_indirect_deletes' indicates if tree nodes deleted as a
+%% byproduct of another put or delete should be part of the returned tree node
+%% properties map. The default is to include them, except in transactions when
+%% the effective machine version is too old.</li>
 %% </ul>
 %%
 %% NOTE: When this list of tree options is modified, {@link

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -510,7 +510,8 @@ readonly_transaction(StoreId, Fun, Args, Options)
                     %% the state is unchanged and that there are no side
                     %% effects.
                     {State, Ret, []} = khepri_tx_adv:run(
-                                         State, Fun, Args, false),
+                                         State, Fun, Args, false,
+                                         undefined),
                     Ret
             end,
     case process_query(StoreId, Query, Options) of
@@ -526,7 +527,8 @@ readonly_transaction(StoreId, PathPattern, Args, Options)
                     %% the state is unchanged and that there are no side
                     %% effects.
                     {State, Ret, []} = locate_sproc_and_execute_tx(
-                                         State, PathPattern, Args, false),
+                                         State, PathPattern, Args, false,
+                                         undefined),
                     Ret
             end,
     case process_query(StoreId, Query, Options) of
@@ -1428,13 +1430,13 @@ apply(
   Meta,
   #tx{'fun' = StandaloneFun, args = Args},
   State) when ?IS_HORUS_FUN(StandaloneFun) ->
-    Ret = khepri_tx_adv:run(State, StandaloneFun, Args, true),
+    Ret = khepri_tx_adv:run(State, StandaloneFun, Args, true, Meta),
     post_apply(Ret, Meta);
 apply(
   Meta,
   #tx{'fun' = PathPattern, args = Args},
   State) when ?IS_KHEPRI_PATH_PATTERN(PathPattern) ->
-    Ret = locate_sproc_and_execute_tx(State, PathPattern, Args, true),
+    Ret = locate_sproc_and_execute_tx(State, PathPattern, Args, true, Meta),
     post_apply(Ret, Meta);
 apply(
   Meta,
@@ -1878,7 +1880,7 @@ does_api_comply_with(Behaviour, StoreId)
 %% Internal functions.
 %% -------------------------------------------------------------------
 
-locate_sproc_and_execute_tx(State, PathPattern, Args, AllowUpdates) ->
+locate_sproc_and_execute_tx(State, PathPattern, Args, AllowUpdates, Meta) ->
     Tree = get_tree(State),
     TreeOptions = #{expect_specific_node => true,
                     props_to_return => [raw_payload]},
@@ -1911,7 +1913,7 @@ locate_sproc_and_execute_tx(State, PathPattern, Args, AllowUpdates) ->
         {error, Reason} ->
             {fun failed_to_locate_sproc/1, [Reason]}
     end,
-    khepri_tx_adv:run(State, StandaloneFun, Args1, AllowUpdates).
+    khepri_tx_adv:run(State, StandaloneFun, Args1, AllowUpdates, Meta).
 
 -spec failed_to_locate_sproc(Reason) -> no_return() when
       Reason :: any().

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -208,7 +208,16 @@
 -type aux_state() :: #khepri_machine_aux{}.
 %% Auxiliary state of this Ra state machine.
 
--type query_fun() :: fun((state()) -> any()).
+-type aux_query() :: {query, query_fun(), khepri:query_options()}.
+%% Query executed through the Ra aux mechanism.
+
+-type delayed_aux_query() :: {aux_query(),
+                              gen_statem:from(),
+                              ra:query_condition() | none}.
+%% Aux query that is delayed until a condition is met.
+
+-type query_fun() :: fun((state()) -> any()) |
+                     fun((ra_machine:command_meta_data(), state()) -> any()).
 %% Function representing a query and used {@link process_query/3}.
 
 -type write_ret() :: khepri:ok(khepri:node_props_map()) |
@@ -252,7 +261,8 @@
               projection_map/0,
               api_behaviour/0,
               command/0,
-              old_command/0]).
+              old_command/0,
+              delayed_aux_query/0]).
 
 -define(PROJECTION_PROPS_TO_RETURN, [payload_version,
                                      child_list_version,
@@ -329,8 +339,9 @@ fence(StoreId, Timeout) ->
     Options = #{favor => consistency,
                 timeout => Timeout},
     case process_query(StoreId, QueryFun, Options) of
-        true                       -> ok;
-        Other when Other =/= false -> Other
+        {exception, _, _, _} = Exception -> handle_tx_exception(Exception);
+        true                             -> ok;
+        Other when Other =/= false       -> Other
     end.
 
 -spec put(StoreId, PathPattern, Payload, Options) -> Ret when
@@ -505,13 +516,13 @@ transaction(StoreId, Fun, Args, ReadWrite, Options)
 
 readonly_transaction(StoreId, Fun, Args, Options)
   when is_list(Args) andalso is_function(Fun, length(Args)) ->
-    Query = fun(State) ->
+    Query = fun(Meta, State) ->
                     %% It is a read-only transaction, therefore we assert that
                     %% the state is unchanged and that there are no side
                     %% effects.
                     {State, Ret, []} = khepri_tx_adv:run(
                                          State, Fun, Args, false,
-                                         undefined),
+                                         Meta),
                     Ret
             end,
     case process_query(StoreId, Query, Options) of
@@ -522,13 +533,13 @@ readonly_transaction(StoreId, Fun, Args, Options)
     end;
 readonly_transaction(StoreId, PathPattern, Args, Options)
   when ?IS_KHEPRI_PATH_PATTERN(PathPattern) andalso is_list(Args) ->
-    Query = fun(State) ->
+    Query = fun(Meta, State) ->
                     %% It is a read-only transaction, therefore we assert that
                     %% the state is unchanged and that there are no side
                     %% effects.
                     {State, Ret, []} = locate_sproc_and_execute_tx(
                                          State, PathPattern, Args, false,
-                                         undefined),
+                                         Meta),
                     Ret
             end,
     case process_query(StoreId, Query, Options) of
@@ -1076,16 +1087,13 @@ process_query(StoreId, QueryFun, #{condition := _} = Options) ->
     process_query1(StoreId, QueryFun, Options1);
 process_query(StoreId, QueryFun, Options) ->
     Favor = maps:get(favor, Options, low_latency),
-    Timeout = get_timeout(Options),
-    Options1 = maps:remove(favor, Options),
-    Options2 = Options1#{timeout => Timeout},
     case Favor of
         low_latency ->
-            process_query1(StoreId, QueryFun, Options2);
+            process_query1(StoreId, QueryFun, Options);
         consistency ->
-            case add_applied_condition(StoreId, Options2) of
-                {ok, Options3} ->
-                    process_query1(StoreId, QueryFun, Options3);
+            case add_applied_condition(StoreId, Options) of
+                {ok, Options1} ->
+                    process_query1(StoreId, QueryFun, Options1);
                 {error, _} = Error ->
                     Error
             end
@@ -1094,13 +1102,16 @@ process_query(StoreId, QueryFun, Options) ->
 process_query1(StoreId, QueryFun, Options) ->
     sending_query_locally(StoreId),
     LocalServerId = {StoreId, node()},
-    case ra:local_query(LocalServerId, QueryFun, Options) of
-        {ok, {_RaIdxTerm, Ret}, _NewLeaderId} ->
-            ?raise_exception_if_any(Ret);
-        {timeout, _LeaderId} ->
-            {error, timeout};
-        {error, _} = Error ->
-            Error
+    Timeout = get_timeout(Options),
+    try
+        Ret = ra:aux_command(
+                LocalServerId, {query, QueryFun, Options}, Timeout),
+        ?raise_exception_if_any(Ret)
+    catch
+        exit:{noproc, _} ->
+            {error, noproc};
+        exit:{timeout, _} ->
+            {error, timeout}
     end.
 
 -spec add_applied_condition(StoreId, Options) -> NewOptions when
@@ -1329,16 +1340,38 @@ init_aux(StoreId) ->
 %% @private
 
 handle_aux(
+  _RaState, {call, From},
+  {query, _QueryFun, Options} = AuxQuery,
+  #khepri_machine_aux{delayed_aux_queries = DelayedAuxQueries} = AuxState,
+  IntState) ->
+    Condition = maps:get(condition, Options, none),
+    DelayedAuxQuery = {AuxQuery, From, Condition},
+    DelayedAuxQueries1 = DelayedAuxQueries ++ [DelayedAuxQuery],
+    AuxState1 = AuxState#khepri_machine_aux{
+                  delayed_aux_queries = DelayedAuxQueries1},
+    AuxState2 = handle_delayed_aux_queries(AuxState1, IntState),
+    {no_reply, AuxState2, IntState};
+handle_aux(
+  _RaState, cast,
+  trigger_delayed_aux_queries_eval,
+  AuxState, IntState) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+    {no_reply, AuxState1, IntState};
+handle_aux(
   _RaState, cast,
   #trigger_projection{path = Path,
                       old_props = OldProps,
                       new_props = NewProps,
                       projection = Projection},
   AuxState, IntState) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
     khepri_projection:trigger(Projection, Path, OldProps, NewProps),
-    {no_reply, AuxState, IntState};
+    {no_reply, AuxState1, IntState};
 handle_aux(
   _RaState, cast, restore_projections, AuxState, IntState) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
     State = ra_aux:machine_state(IntState),
     Tree = get_tree(State),
     ProjectionTree = get_projections(State),
@@ -1348,16 +1381,20 @@ handle_aux(
               [restore_projection(Projection, Tree, PathPattern) ||
                Projection <- Projections]
       end),
-    {no_reply, AuxState, IntState};
+    {no_reply, AuxState1, IntState};
 handle_aux(
   _RaState, cast,
   #restore_projection{projection = Projection, pattern = PathPattern},
   AuxState, IntState) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
     State = ra_aux:machine_state(IntState),
     Tree = get_tree(State),
     ok = restore_projection(Projection, Tree, PathPattern),
-    {no_reply, AuxState, IntState};
+    {no_reply, AuxState1, IntState};
 handle_aux(leader, cast, tick, AuxState, IntState) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
     %% Expiring dedups in the tick handler is only available on versions 2
     %% and greater. In versions 0 and 1, expiration of dedups is done in
     %% `drop_expired_dedups/2'. This proved to be quite expensive when handling
@@ -1384,12 +1421,70 @@ handle_aux(leader, cast, tick, AuxState, IntState) ->
                               DropDedups = #drop_dedups{refs = RefsToDrop},
                               [{append, DropDedups}]
                       end,
-            {no_reply, AuxState, IntState, Effects};
+            {no_reply, AuxState1, IntState, Effects};
         _ ->
-            {no_reply, AuxState, IntState}
+            {no_reply, AuxState1, IntState}
     end;
 handle_aux(_RaState, _Type, _Command, AuxState, IntState) ->
-    {no_reply, AuxState, IntState}.
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+    {no_reply, AuxState1, IntState}.
+
+handle_delayed_aux_queries(
+  #khepri_machine_aux{delayed_aux_queries = []} = AuxState,
+  _IntState) ->
+    AuxState;
+handle_delayed_aux_queries(
+  #khepri_machine_aux{delayed_aux_queries = DelayedAuxQueries} = AuxState,
+  IntState) ->
+    Index = ra_aux:last_applied(IntState),
+    Term = ra_aux:current_term(IntState),
+    MacVer = ra_aux:effective_machine_version(IntState),
+    Meta = #{system_time => erlang:system_time(millisecond),
+             index => Index,
+             term => Term,
+             machine_version => MacVer},
+    State = ra_aux:machine_state(IntState),
+    DelayedAuxQueries2 = eval_delayed_aux_queries_condition(
+                           Meta, DelayedAuxQueries, State, []),
+    AuxState1 = AuxState#khepri_machine_aux{
+                  delayed_aux_queries = DelayedAuxQueries2},
+    AuxState1.
+
+eval_delayed_aux_queries_condition(
+  Meta,
+  [{AuxQuery, From, none} | Rest],
+  State, Acc) ->
+    Meta1 = Meta#{from => From},
+    perform_delayed_aux_query(Meta1, AuxQuery, State),
+    eval_delayed_aux_queries_condition(Meta, Rest, State, Acc);
+eval_delayed_aux_queries_condition(
+  #{index := Index, term := Term} = Meta,
+  [{AuxQuery, From, {applied, {TargetIndex, TargetTerm}}} | Rest],
+  State, Acc)
+  when (Term =:= TargetTerm andalso Index >= TargetIndex) orelse
+       Term > TargetTerm ->
+    Meta1 = Meta#{from => From},
+    perform_delayed_aux_query(Meta1, AuxQuery, State),
+    eval_delayed_aux_queries_condition(Meta, Rest, State, Acc);
+eval_delayed_aux_queries_condition(
+  Meta,
+  [DelayedAuxQuery | Rest],
+  State, Acc) ->
+    Acc1 = [DelayedAuxQuery | Acc],
+    eval_delayed_aux_queries_condition(Meta, Rest, State, Acc1);
+eval_delayed_aux_queries_condition(
+  _Meta, [], _State, Acc) ->
+    lists:reverse(Acc).
+
+perform_delayed_aux_query(
+  #{from := From} = Meta,
+  {query, QueryFun, _Options}, State) ->
+    {arity, Arity} = erlang:fun_info(QueryFun, arity),
+    Ret = case Arity of
+              1 -> QueryFun(State);
+              2 -> QueryFun(Meta, State)
+          end,
+    gen_statem:reply(From, Ret).
 
 restore_projection(Projection, Tree, PathPattern) ->
     _ = khepri_projection:init(Projection),
@@ -1634,7 +1729,8 @@ post_apply({State, Result}, Meta) ->
 post_apply({_State, _Result, _SideEffects} = Ret, Meta) ->
     Ret1 = bump_applied_command_count(Ret, Meta),
     Ret2 = drop_expired_dedups(Ret1, Meta),
-    Ret2.
+    Ret3 = trigger_delayed_aux_queries_eval(Ret2, Meta),
+    Ret3.
 
 -spec bump_applied_command_count(ApplyRet, Meta) ->
     {State, Result, SideEffects} when
@@ -1713,6 +1809,21 @@ drop_expired_dedups(
 drop_expired_dedups({State, Result, SideEffects}, _Meta) ->
     %% No-op on versions 2 and higher.
     {State, Result, SideEffects}.
+
+-spec trigger_delayed_aux_queries_eval(ApplyRet, Meta) ->
+    {State, Result, SideEffects} when
+      ApplyRet :: {State, Result, SideEffects},
+      State :: state(),
+      Result :: any(),
+      Meta :: ra_machine:command_meta_data(),
+      SideEffects :: ra_machine:effects().
+%% @doc Add an `aux' side effect to retrigger the eval of delayed aux queries.
+%%
+%% @private
+
+trigger_delayed_aux_queries_eval({State, Result, SideEffects}, _Meta) ->
+    SideEffects1 = [{aux, trigger_delayed_aux_queries_eval} | SideEffects],
+    {State, Result, SideEffects1}.
 
 %% @private
 

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -765,7 +765,8 @@ split_query_options(StoreId, Options) ->
           (Option, Value, {Q, T}) when
                 Option =:= expect_specific_node orelse
                 Option =:= props_to_return orelse
-                Option =:= include_root_props ->
+                Option =:= include_root_props orelse
+                Option =:= return_indirect_deletes ->
               T1 = T#{Option => Value},
               {Q, T1}
       end, {#{}, #{}}, Options1).
@@ -793,7 +794,8 @@ split_command_options(StoreId, Options) ->
           (Option, Value, {C, TP}) when
                 Option =:= expect_specific_node orelse
                 Option =:= props_to_return orelse
-                Option =:= include_root_props ->
+                Option =:= include_root_props orelse
+                Option =:= return_indirect_deletes ->
               TP1 = TP#{Option => Value},
               {C, TP1};
           (keep_while, KeepWhile, {C, TP}) ->

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -18,7 +18,8 @@
          snapshot_interval = ?SNAPSHOT_INTERVAL :: non_neg_integer()}).
 
 -record(khepri_machine_aux,
-        {store_id :: khepri:store_id()}).
+        {store_id :: khepri:store_id(),
+         delayed_aux_queries = [] :: [khepri_machine:delayed_aux_query()]}).
 
 %% State machine commands and aux. effects.
 

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -573,21 +573,38 @@ delete_matching_nodes(Tree, PathPattern, AppliedChanges, TreeOptions) ->
 
 delete_matching_nodes_cb(
   [] = Path, #node{} = Node, TreeOptions, DeleteReason, Result) ->
+    Result1 = add_deleted_node_to_result(
+                Path, Node, TreeOptions, DeleteReason, Result),
     Node1 = remove_node_payload(Node),
     Node2 = remove_node_child_nodes(Node1),
-    NodeProps1 = gather_node_props(Node, TreeOptions),
-    NodeProps2 = maybe_add_delete_reason_prop(
-                   NodeProps1, TreeOptions, DeleteReason),
-    {ok, Node2, Result#{Path => NodeProps2}};
+    {ok, Node2, Result1};
 delete_matching_nodes_cb(
   Path, #node{} = Node, TreeOptions, DeleteReason, Result) ->
-    NodeProps1 = gather_node_props(Node, TreeOptions),
-    NodeProps2 = maybe_add_delete_reason_prop(
-                   NodeProps1, TreeOptions, DeleteReason),
-    {ok, delete, Result#{Path => NodeProps2}};
+    Result1 = add_deleted_node_to_result(
+                Path, Node, TreeOptions, DeleteReason, Result),
+    {ok, delete, Result1};
 delete_matching_nodes_cb(
   _, {interrupted, _, _}, _Options, _DeleteReason, Result) ->
     {ok, keep, Result}.
+
+add_deleted_node_to_result(
+  Path, Node, TreeOptions, explicit = DeleteReason, Result) ->
+    add_deleted_node_to_result1(
+      Path, Node, TreeOptions, DeleteReason, Result);
+add_deleted_node_to_result(
+  _Path, _Node, #{return_indirect_deletes := false}, _DeleteReason,
+  Result) ->
+    Result;
+add_deleted_node_to_result(
+  Path, Node, TreeOptions, DeleteReason, Result) ->
+    add_deleted_node_to_result1(
+      Path, Node, TreeOptions, DeleteReason, Result).
+
+add_deleted_node_to_result1(Path, Node, TreeOptions, DeleteReason, Result) ->
+    NodeProps1 = gather_node_props(Node, TreeOptions),
+    NodeProps2 = maybe_add_delete_reason_prop(
+                   NodeProps1, TreeOptions, DeleteReason),
+    Result#{Path => NodeProps2}.
 
 maybe_add_delete_reason_prop(
   NodeProps, #{props_to_return := WantedProps}, DeleteReason) ->

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -987,7 +987,7 @@ is_standalone_fun_still_needed(#{calls := Calls}, auto) ->
       StandaloneFun :: horus:horus_fun(),
       Args :: list(),
       AllowUpdates :: boolean(),
-      RaMeta :: ra_machine:command_meta_data() | undefined,
+      RaMeta :: ra_machine:command_meta_data(),
       Ret :: {State, khepri_tx:tx_fun_result() | Exception, SideEffects},
       Exception :: {exception, Class, Reason, Stacktrace},
       Class :: error | exit | throw,

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -47,16 +47,26 @@
 %% For internal use only.
 -export([do_get_many/4,
          to_standalone_fun/2,
-         run/4,
+         run/5,
          ensure_instruction_is_permitted/1,
          should_process_function/4,
          is_standalone_fun_still_needed/2,
          get_tx_state/0,
+         get_tx_props/0,
+         get_tx_effective_machine_version/0,
          path_from_string/1]).
 
 -compile({no_auto_import, [get/1, put/2, erase/1]}).
 
--type tx_props() :: #{allow_updates := boolean()}.
+-type tx_props() :: #{allow_updates := boolean(),
+                      ra_meta => ra_machine:command_meta_data()}.
+
+-type legacy_ret() :: khepri:ok(khepri:node_props() | #{}) |
+                      khepri:error().
+%% Return value when a single tree node could be returned. This is no longer
+%% the case with the transaction API version 1 (all functions return a tree
+%% node props map). But it can happen when the same transaction is executed on
+%% another Khepri cluster member that runs an older version of Khepri.
 
 %% -------------------------------------------------------------------
 %% get().
@@ -64,7 +74,7 @@
 
 -spec get(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Returns the payload of the tree node pointed to by the given path
 %% pattern.
 %%
@@ -79,7 +89,7 @@ get(PathPattern) ->
 -spec get(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Returns the payload of the tree node pointed to by the given path
 %% pattern.
 %%
@@ -90,7 +100,8 @@ get(PathPattern) ->
 
 get(PathPattern, Options) ->
     Options1 = Options#{expect_specific_node => true},
-    get_many(PathPattern, Options1).
+    Ret = get_many(PathPattern, Options1),
+    maybe_write_ret_to_legacy_ret(PathPattern, Ret).
 
 %% -------------------------------------------------------------------
 %% get_many().
@@ -149,7 +160,7 @@ do_get_many(PathPattern, Fun, Acc, Options) ->
 -spec put(PathPattern, Data) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Sets the payload of the tree node pointed to by the given path
 %% pattern.
 %%
@@ -165,7 +176,7 @@ put(PathPattern, Data) ->
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
       Options :: khepri:tree_options() | khepri:put_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Sets the payload of the tree node pointed to by the given path
 %% pattern.
 %%
@@ -176,7 +187,8 @@ put(PathPattern, Data) ->
 
 put(PathPattern, Data, Options) ->
     Options1 = Options#{expect_specific_node => true},
-    put_many(PathPattern, Data, Options1).
+    Ret = put_many(PathPattern, Data, Options1),
+    maybe_write_ret_to_legacy_ret(PathPattern, Ret).
 
 %% -------------------------------------------------------------------
 %% put_many().
@@ -218,10 +230,11 @@ put_many(PathPattern, Data, Options) ->
     khepri_machine:split_command_options(StoreId, Options),
     {TreeOptions, PutOptions} =
     khepri_machine:split_put_options(TreeAndPutOptions),
+    TreeOptions1 = maybe_return_indirect_deletes(TreeOptions),
     %% TODO: Ensure `CommandOptions' is unset.
     Fun = fun(State1, SideEffects) ->
                   khepri_machine:insert_or_update_node(
-                    State1, PathPattern1, Payload1, PutOptions, TreeOptions,
+                    State1, PathPattern1, Payload1, PutOptions, TreeOptions1,
                     SideEffects)
           end,
     handle_state_for_call(Fun).
@@ -233,7 +246,7 @@ put_many(PathPattern, Data, Options) ->
 -spec create(PathPattern, Data) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Creates a tree node with the given payload.
 %%
 %% This is the same as {@link khepri_adv:create/3} but inside the context of a
@@ -248,7 +261,7 @@ create(PathPattern, Data) ->
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
       Options :: khepri:tree_options() | khepri:put_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Creates a tree node with the given payload.
 %%
 %% This is the same as {@link khepri_adv:create/4} but inside the context of a
@@ -261,7 +274,8 @@ create(PathPattern, Data, Options) ->
     PathPattern2 = khepri_path:combine_with_conditions(
                      PathPattern1, [#if_node_exists{exists = false}]),
     Options1 = Options#{expect_specific_node => true},
-    put_many(PathPattern2, Data, Options1).
+    Ret = put_many(PathPattern2, Data, Options1),
+    maybe_write_ret_to_legacy_ret(PathPattern, Ret).
 
 %% -------------------------------------------------------------------
 %% update().
@@ -270,7 +284,7 @@ create(PathPattern, Data, Options) ->
 -spec update(PathPattern, Data) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Updates an existing tree node with the given payload.
 %%
 %% This is the same as {@link khepri_adv:update/3} but inside the context of a
@@ -285,7 +299,7 @@ update(PathPattern, Data) ->
       PathPattern :: khepri_path:pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
       Options :: khepri:tree_options() | khepri:put_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Updates an existing tree node with the given payload.
 %%
 %% This is the same as {@link khepri_adv:update/4} but inside the context of a
@@ -298,7 +312,8 @@ update(PathPattern, Data, Options) ->
     PathPattern2 = khepri_path:combine_with_conditions(
                      PathPattern1, [#if_node_exists{exists = true}]),
     Options1 = Options#{expect_specific_node => true},
-    put_many(PathPattern2, Data, Options1).
+    Ret = put_many(PathPattern2, Data, Options1),
+    maybe_write_ret_to_legacy_ret(PathPattern, Ret).
 
 %% -------------------------------------------------------------------
 %% compare_and_swap().
@@ -308,7 +323,7 @@ update(PathPattern, Data, Options) ->
       PathPattern :: khepri_path:pattern(),
       DataPattern :: ets:match_pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Updates an existing tree node with the given payload only if its data
 %% matches the given pattern.
 %%
@@ -326,7 +341,7 @@ compare_and_swap(PathPattern, DataPattern, Data) ->
       DataPattern :: ets:match_pattern(),
       Data :: khepri_payload:payload() | khepri:data() | fun(),
       Options :: khepri:tree_options() | khepri:put_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Updates an existing tree node with the given payload only if its data
 %% matches the given pattern.
 %%
@@ -340,7 +355,8 @@ compare_and_swap(PathPattern, DataPattern, Data, Options) ->
     PathPattern2 = khepri_path:combine_with_conditions(
                      PathPattern1, [#if_data_matches{pattern = DataPattern}]),
     Options1 = Options#{expect_specific_node => true},
-    put_many(PathPattern2, Data, Options1).
+    Ret = put_many(PathPattern2, Data, Options1),
+    maybe_write_ret_to_legacy_ret(PathPattern, Ret).
 
 %% -------------------------------------------------------------------
 %% delete().
@@ -348,7 +364,7 @@ compare_and_swap(PathPattern, DataPattern, Data, Options) ->
 
 -spec delete(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Deletes the tree node pointed to by the given path pattern.
 %%
 %% This is the same as {@link khepri_adv:delete/2} but inside the context of a
@@ -362,7 +378,7 @@ delete(PathPattern) ->
 -spec delete(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Deletes the tree node pointed to by the given path pattern.
 %%
 %% This is the same as {@link khepri_adv:delete/3} but inside the context of a
@@ -372,7 +388,8 @@ delete(PathPattern) ->
 
 delete(PathPattern, Options) ->
     Options1 = Options#{expect_specific_node => true},
-    delete_many(PathPattern, Options1).
+    Ret = delete_many(PathPattern, Options1),
+    maybe_write_ret_to_legacy_ret(PathPattern, Ret).
 
 %% -------------------------------------------------------------------
 %% delete_many().
@@ -380,7 +397,7 @@ delete(PathPattern, Options) ->
 
 -spec delete_many(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Deletes all tree nodes matching the given path pattern.
 %%
 %% This is the same as {@link khepri_adv:delete_many/2} but inside the context
@@ -394,7 +411,7 @@ delete_many(PathPattern) ->
 -spec delete_many(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Deletes all tree nodes matching the given path pattern.
 %%
 %% This is the same as {@link khepri_adv:delete_many/3} but inside the context
@@ -409,11 +426,12 @@ delete_many(PathPattern, Options) ->
     StoreId = khepri_machine:get_store_id(State),
     {_CommandOptions, TreeOptions} =
     khepri_machine:split_command_options(StoreId, Options),
+    TreeOptions1 = maybe_return_indirect_deletes(TreeOptions),
     %% TODO: Ensure `CommandOptions' is empty and `TreeOptions' doesn't
     %% contains put options.
     Fun = fun(State1, SideEffects) ->
                   khepri_machine:delete_matching_nodes(
-                    State1, PathPattern1, TreeOptions, SideEffects)
+                    State1, PathPattern1, TreeOptions1, SideEffects)
           end,
     handle_state_for_call(Fun).
 
@@ -423,7 +441,7 @@ delete_many(PathPattern, Options) ->
 
 -spec clear_payload(PathPattern) -> Ret when
       PathPattern :: khepri_path:pattern(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
@@ -438,7 +456,7 @@ clear_payload(PathPattern) ->
 -spec clear_payload(PathPattern, Options) -> Ret when
       PathPattern :: khepri_path:pattern(),
       Options :: khepri:tree_options() | khepri:put_options(),
-      Ret :: khepri_machine:write_ret().
+      Ret :: khepri_machine:write_ret() | legacy_ret().
 %% @doc Deletes the payload of the tree node pointed to by the given path
 %% pattern.
 %%
@@ -450,8 +468,10 @@ clear_payload(PathPattern) ->
 clear_payload(PathPattern, Options) ->
     Ret = update(PathPattern, khepri_payload:none(), Options),
     case Ret of
-        {error, ?khepri_error(node_not_found, _)} -> {ok, #{}};
-        _                                         -> Ret
+        {error, ?khepri_error(node_not_found, _)} ->
+            {ok, #{}};
+        _ ->
+            maybe_write_ret_to_legacy_ret(PathPattern, Ret)
     end.
 
 %% -------------------------------------------------------------------
@@ -751,7 +771,7 @@ is_remote_call_valid(khepri_tx, clear_payload, _) -> true;
 is_remote_call_valid(khepri_tx, clear_many_payloads, _) -> true;
 is_remote_call_valid(khepri_tx, abort, _) -> true;
 is_remote_call_valid(khepri_tx, is_transaction, _) -> true;
-is_remote_call_valid(khepri_tx, api_version, _) -> true;
+is_remote_call_valid(khepri_tx, does_api_comply_with, _) -> true;
 
 is_remote_call_valid(khepri_tx_adv, get, _) -> true;
 is_remote_call_valid(khepri_tx_adv, get_many, _) -> true;
@@ -962,11 +982,12 @@ is_standalone_fun_still_needed(#{calls := Calls}, auto) ->
                 end,
     ReadWrite =:= rw.
 
--spec run(State, StandaloneFun, Args, AllowUpdates) -> Ret when
+-spec run(State, StandaloneFun, Args, AllowUpdates, RaMeta) -> Ret when
       State :: khepri_machine:state(),
       StandaloneFun :: horus:horus_fun(),
       Args :: list(),
       AllowUpdates :: boolean(),
+      RaMeta :: ra_machine:command_meta_data() | undefined,
       Ret :: {State, khepri_tx:tx_fun_result() | Exception, SideEffects},
       Exception :: {exception, Class, Reason, Stacktrace},
       Class :: error | exit | throw,
@@ -975,10 +996,14 @@ is_standalone_fun_still_needed(#{calls := Calls}, auto) ->
       SideEffects :: ra_machine:effects().
 %% @private
 
-run(State, StandaloneFun, Args, AllowUpdates)
+run(State, StandaloneFun, Args, AllowUpdates, RaMeta)
   when ?IS_HORUS_FUN(StandaloneFun) ->
     SideEffects = [],
-    TxProps = #{allow_updates => AllowUpdates},
+    TxProps0 = #{allow_updates => AllowUpdates},
+    TxProps = case RaMeta of
+                  _ when is_map(RaMeta) -> TxProps0#{ra_meta => RaMeta};
+                  undefined             -> TxProps0
+              end,
     NoState = erlang:put(?TX_STATE_KEY, {State, SideEffects}),
     NoProps = erlang:put(?TX_PROPS, TxProps),
     ?assertEqual(undefined, NoState),
@@ -1044,6 +1069,15 @@ get_tx_props() ->
             ?khepri_misuse(invalid_use_of_khepri_tx_outside_transaction, #{})
     end.
 
+-spec get_tx_effective_machine_version() -> MacVer when
+      MacVer :: ra_machine:version().
+%% @private
+
+get_tx_effective_machine_version() ->
+    TxProps = get_tx_props(),
+    #{ra_meta := #{machine_version := MacVer}} = TxProps,
+    MacVer.
+
 -spec path_from_string(PathPattern) -> NativePathPattern | no_return() when
       PathPattern :: khepri_path:pattern(),
       NativePathPattern :: khepri_path:native_pattern().
@@ -1070,3 +1104,48 @@ ensure_updates_are_allowed() ->
         #{allow_updates := false} ->
             ?khepri_misuse(denied_update_in_readonly_tx, #{})
     end.
+
+-spec maybe_return_indirect_deletes(TreeOptions) -> NewTreeOptions when
+      TreeOptions :: khepri:tree_options(),
+      NewTreeOptions :: khepri:tree_options().
+%% @doc Sets options if indirect deletes should be returned or not.
+%%
+%% This depends on the effective machive version.
+%%
+%% @private
+
+maybe_return_indirect_deletes(TreeOptions) ->
+    case khepri_tx:does_api_comply_with(indirect_deletes_in_ret) of
+        true  -> TreeOptions;
+        false -> TreeOptions#{return_indirect_deletes => false}
+    end.
+
+-spec maybe_write_ret_to_legacy_ret(PathPattern, Ret) -> NewRet when
+      PathPattern :: khepri_path:pattern(),
+      Ret :: khepri_machine:write_ret(),
+      NewRet :: khepri_machine:write_ret() | legacy_ret().
+%% @doc Converts the return value to the legacy format, if relevant.
+%%
+%% The legacy format was used by Khepri 0.16.0.
+%%
+%% This function will always return the new return value, except in unit tests
+%% because we don't set the `tx_api_version' process dict key.
+%%
+%% The reason for its existence is the same function may return the legacy
+%% format when the transaction is executed on another Khepri cluster member
+%% that still runs an older version of Khepri. The caller should be aware of
+%% that. It also heps with Dialyzer reports.
+%%
+%% @private
+
+maybe_write_ret_to_legacy_ret(PathPattern, {ok, NodePropsMap} = Ret) ->
+    case khepri_tx:does_api_comply_with(uniform_write_ret) of
+        true ->
+            Ret;
+        false ->
+            {true, Path} = khepri_path:targets_specific_node(PathPattern),
+            NodeProps = maps:get(Path, NodePropsMap),
+            {ok, NodeProps}
+    end;
+maybe_write_ret_to_legacy_ret(_PathPattern, {error, _} = Error) ->
+    Error.

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1725,9 +1725,6 @@ can_use_default_store_on_single_node(_Config) ->
        {error, ?khepri_error(node_not_found, _)},
        khepri:get([foo])),
 
-    ?assert(is_integer(khepri_tx:api_version())),
-    ?assert(khepri_tx:api_version() > 0),
-
     ?assertEqual(ok, khepri:stop()),
     ?assertEqual(ok, application:stop(khepri)),
     ?assertEqual(ok, application:stop(ra)),

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -1603,6 +1603,8 @@ can_use_default_store_on_single_node(_Config) ->
                          payload_version => 7}}},
        khepri_adv:get_many([foo], #{})),
 
+    ?assertNot(khepri_machine:does_api_comply_with(some_behaviour, StoreId)),
+
     ?assertEqual({ok, [{StoreId, Node}]}, khepri_cluster:members()),
     ?assertEqual(
        {ok, [{StoreId, Node}]},

--- a/test/delete_command.erl
+++ b/test/delete_command.erl
@@ -29,7 +29,7 @@ delete_non_existing_node_test() ->
        #{applied_command_count => 1},
        khepri_machine:get_metrics(S1)),
     ?assertEqual({ok, #{}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_non_existing_node_under_non_existing_parent_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -43,7 +43,7 @@ delete_non_existing_node_under_non_existing_parent_test() ->
        #{applied_command_count => 1},
        khepri_machine:get_metrics(S1)),
     ?assertEqual({ok, #{}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_existing_node_with_data_test() ->
     Commands = [#put{path = [foo],
@@ -68,7 +68,7 @@ delete_existing_node_with_data_test() ->
                                    payload_version => 1,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_existing_node_with_data_using_dot_test() ->
     Commands = [#put{path = [foo],
@@ -93,7 +93,7 @@ delete_existing_node_with_data_using_dot_test() ->
                                    payload_version => 1,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_existing_node_with_child_nodes_test() ->
     Commands = [#put{path = [foo, bar],
@@ -117,7 +117,7 @@ delete_existing_node_with_child_nodes_test() ->
     ?assertEqual({ok, #{[foo] => #{payload_version => 1,
                                    child_list_version => 1,
                                    child_list_length => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_a_node_deep_into_the_tree_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
@@ -151,7 +151,7 @@ delete_a_node_deep_into_the_tree_test() ->
                                    child_list_version => 2,
                                    child_list_length => 0,
                                    delete_reason => keep_while}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_existing_node_with_condition_true_test() ->
     Commands = [#put{path = [foo],
@@ -181,7 +181,7 @@ delete_existing_node_with_condition_true_test() ->
                                    payload_version => 1,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_existing_node_with_condition_false_test() ->
     Commands = [#put{path = [foo],
@@ -207,7 +207,7 @@ delete_existing_node_with_condition_false_test() ->
                   payload = khepri_payload:data(bar_value)}}},
        Root),
     ?assertEqual({ok, #{}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_existing_node_with_condition_true_using_dot_test() ->
     Commands = [#put{path = [foo],
@@ -241,7 +241,7 @@ delete_existing_node_with_condition_true_using_dot_test() ->
                                    payload_version => 1,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_existing_node_with_condition_false_using_dot_test() ->
     Commands = [#put{path = [foo],
@@ -271,7 +271,7 @@ delete_existing_node_with_condition_false_using_dot_test() ->
                   payload = khepri_payload:data(bar_value)}}},
        Root),
     ?assertEqual({ok, #{}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_many_nodes_at_once_test() ->
     Commands = [#put{path = [foo],
@@ -310,7 +310,7 @@ delete_many_nodes_at_once_test() ->
                                    child_list_version => 1,
                                    child_list_length => 0,
                                    delete_reason => explicit}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 delete_command_bumps_applied_command_count_test() ->
     Commands = [#delete{path = [foo]}],
@@ -328,7 +328,7 @@ delete_command_bumps_applied_command_count_test() ->
     ?assertEqual(
        #{applied_command_count => 1},
        khepri_machine:get_metrics(S1)),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE1),
 
     Command2 = #delete{path = [baz]},
     {S2, _, SE2} = khepri_machine:apply(?META, Command2, S1),
@@ -336,11 +336,12 @@ delete_command_bumps_applied_command_count_test() ->
     ?assertEqual(
        #{applied_command_count => 2},
        khepri_machine:get_metrics(S2)),
-    ?assertEqual([], SE2),
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE2),
 
     Command3 = #delete{path = [qux]},
     Meta = ?META,
     {S3, _, SE3} = khepri_machine:apply(Meta, Command3, S2),
 
     ?assertEqual(#{}, khepri_machine:get_metrics(S3)),
-    ?assertEqual([{release_cursor, maps:get(index, Meta), S3}], SE3).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval},
+                  {release_cursor, maps:get(index, Meta), S3}], SE3).

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -89,7 +89,7 @@ insert_when_keep_while_true_test() ->
        #{[baz] => KeepWhile},
        KeepWhileConds),
     ?assertEqual({ok, #{[baz] => #{}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 insert_when_keep_while_false_test() ->
     Commands = [#put{path = [foo],
@@ -117,7 +117,7 @@ insert_when_keep_while_false_test() ->
                        keep_while_reason =>
                        {pattern_matches_no_nodes, [foo, bar]}})},
                  Ret1),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE1),
 
     %% The targeted keep_while node exists but the condition is not verified.
     KeepWhile2 = #{[foo] => #if_child_list_length{count = 10}},
@@ -140,7 +140,7 @@ insert_when_keep_while_false_test() ->
                        keep_while_reason =>
                        #if_child_list_length{count = 10}})},
                  Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE2).
 
 insert_when_keep_while_true_on_self_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -163,7 +163,7 @@ insert_when_keep_while_true_on_self_test() ->
                payload = khepri_payload:data(foo_value)}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 insert_when_keep_while_false_on_self_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -186,7 +186,7 @@ insert_when_keep_while_false_on_self_test() ->
                payload = khepri_payload:data(foo_value)}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 keep_while_still_true_after_command_test() ->
     KeepWhile = #{[foo] => #if_child_list_length{count = 0}},
@@ -227,7 +227,7 @@ keep_while_still_true_after_command_test() ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 keep_while_now_false_after_command_test() ->
     KeepWhile = #{[foo] => #if_child_list_length{count = 0}},
@@ -262,7 +262,7 @@ keep_while_now_false_after_command_test() ->
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{},
                         [baz] => #{delete_reason => keep_while}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 recursive_automatic_cleanup_test() ->
     KeepWhile = #{[?THIS_KHEPRI_NODE] =>
@@ -308,7 +308,7 @@ recursive_automatic_cleanup_test() ->
                                    child_list_version => 3,
                                    child_list_length => 0,
                                    delete_reason => keep_while}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 keep_while_now_false_after_delete_command_test() ->
     KeepWhile = #{[foo] => #if_node_exists{exists = true}},
@@ -345,7 +345,7 @@ keep_while_now_false_after_delete_command_test() ->
                                    child_list_version => 1,
                                    child_list_length => 0,
                                    delete_reason => keep_while}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 automatic_reclaim_of_useless_nodes_works_test() ->
     Commands = [#put{path = [foo, bar, baz, qux],
@@ -366,7 +366,7 @@ automatic_reclaim_of_useless_nodes_works_test() ->
     ?assertEqual({ok, #{[foo, bar, baz] => #{delete_reason => explicit},
                         [foo, bar] => #{delete_reason => keep_while},
                         [foo] => #{delete_reason => keep_while}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 automatic_reclaim_keeps_relevant_nodes_1_test() ->
     %% `/:foo' was created automatically, but later gained a payload. It should
@@ -396,7 +396,7 @@ automatic_reclaim_keeps_relevant_nodes_1_test() ->
        Root),
     ?assertEqual({ok, #{[foo, bar, baz] => #{delete_reason => explicit},
                         [foo, bar] => #{delete_reason => keep_while}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 automatic_reclaim_keeps_relevant_nodes_2_test() ->
     %% `/:bar' was created with a payload. It later gained a child node. It
@@ -433,7 +433,7 @@ automatic_reclaim_keeps_relevant_nodes_2_test() ->
       {ok, #{[foo, bar, baz, qux] => #{delete_reason => explicit},
              [foo, bar, baz] => #{delete_reason => keep_while}}},
       Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
 keep_while_condition_on_non_existing_tree_node_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -456,7 +456,7 @@ keep_while_condition_on_non_existing_tree_node_test() ->
                payload = khepri_payload:data(bar_value)}}},
        Root1),
     ?assertEqual({ok, #{[bar] => #{}}}, Ret1),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE1),
 
     Command2 = #put{path = [foo],
                     payload = khepri_payload:data(foo_value),
@@ -477,4 +477,4 @@ keep_while_condition_on_non_existing_tree_node_test() ->
        Root2),
     ?assertEqual({ok, #{[foo] => #{},
                         [bar] => #{delete_reason => keep_while}}}, Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE2).

--- a/test/protect_against_dups_option.erl
+++ b/test/protect_against_dups_option.erl
@@ -51,7 +51,7 @@ multiple_dedup_commands_test() ->
                payload = khepri_payload:data(value)}}},
        Root1),
     ?assertEqual(ExpectedRet, Ret1),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE1),
 
     %% The put command is idempotent, so not really ideal to test
     %% deduplication. Instead, we mess up with the state and silently restore
@@ -69,7 +69,7 @@ multiple_dedup_commands_test() ->
     ?assertEqual(Root0, Root2),
 
     ?assertEqual(ExpectedRet, Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE2).
 
 dedup_and_dedup_ack_test() ->
     S00 = khepri_machine:init(?MACH_PARAMS()),
@@ -104,7 +104,7 @@ dedup_and_dedup_ack_test() ->
                payload = khepri_payload:data(value)}}},
        Root1),
     ?assertEqual(ExpectedRet, Ret1),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE1),
 
     DedupAck = #dedup_ack{ref = CommandRef},
     {S2, Ret2, SE2} = khepri_machine:apply(?META, DedupAck, S1),
@@ -125,7 +125,7 @@ dedup_and_dedup_ack_test() ->
                payload = khepri_payload:data(value)}}},
        Root2),
     ?assertEqual(ok, Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE2).
 
 dedup_expiry_test_() ->
    TickTimeout = 200,
@@ -221,7 +221,7 @@ dedup_ack_after_no_dedup_test() ->
           child_nodes = #{}},
        Root1),
     ?assertEqual(ok, Ret1),
-    ?assertEqual([], SE1).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE1).
 
 dedup_on_old_machine_test() ->
     S00 = khepri_machine:init(?MACH_PARAMS()),

--- a/test/put_command.erl
+++ b/test/put_command.erl
@@ -68,7 +68,7 @@ insert_a_node_at_the_root_of_an_empty_db_test() ->
                payload = khepri_payload:data(value)}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{payload_version => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_at_the_root_of_an_empty_db_with_conditions_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -97,7 +97,7 @@ insert_a_node_at_the_root_of_an_empty_db_with_conditions_test() ->
                payload = khepri_payload:data(value)}}},
        Root),
     ?assertEqual({ok, #{[foo] => #{payload_version => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 overwrite_an_existing_node_data_test() ->
     Commands = [#put{path = [foo],
@@ -129,7 +129,7 @@ overwrite_an_existing_node_data_test() ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -157,7 +157,7 @@ insert_a_node_with_path_containing_dot_and_dot_dot_test() ->
                     payload = khepri_payload:data(value)}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{payload_version => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_under_an_nonexisting_parents_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -194,7 +194,7 @@ insert_a_node_under_an_nonexisting_parents_test() ->
     ?assertEqual(
        {ok, #{[foo, bar, baz, qux] => #{payload_version => 1}}},
        Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_with_condition_true_on_self_test() ->
     Commands = [#put{path = [foo],
@@ -227,7 +227,7 @@ insert_a_node_with_condition_true_on_self_test() ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_with_condition_false_on_self_test() ->
     Commands = [#put{path = [foo],
@@ -259,7 +259,7 @@ insert_a_node_with_condition_false_on_self_test() ->
                        node_props => #{data => value1,
                                        payload_version => 1},
                        condition => Compiled})}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_with_condition_true_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
@@ -293,7 +293,7 @@ insert_a_node_with_condition_true_on_self_using_dot_test() ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_with_condition_false_on_self_using_dot_test() ->
     Commands = [#put{path = [foo],
@@ -326,7 +326,7 @@ insert_a_node_with_condition_false_on_self_using_dot_test() ->
                        node_props => #{data => value1,
                                        payload_version => 1},
                        condition => Compiled})}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_with_condition_true_on_parent_test() ->
     Commands = [#put{path = [foo],
@@ -360,7 +360,7 @@ insert_a_node_with_condition_true_on_parent_test() ->
                     payload = khepri_payload:data(bar_value)}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{payload_version => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 insert_a_node_with_condition_false_on_parent_test() ->
     Commands = [#put{path = [foo],
@@ -393,7 +393,7 @@ insert_a_node_with_condition_false_on_parent_test() ->
                        node_props => #{data => value1,
                                        payload_version => 1},
                        condition => Compiled})}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 %% The #if_node_exists{} is tested explicitly in addition to the testcases
 %% above because there is specific code to manage it when the node is not
@@ -434,7 +434,7 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret1),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE1),
 
     Compiled = khepri_condition:compile(
                  #if_all{conditions =
@@ -460,7 +460,7 @@ insert_a_node_with_if_node_exists_true_on_self_test() ->
                        node_path => [baz],
                        node_is_target => true,
                        condition => Compiled})}, Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE2).
 
 insert_a_node_with_if_node_exists_false_on_self_test() ->
     Commands = [#put{path = [foo],
@@ -491,7 +491,7 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
                        node_props => #{data => value1,
                                        payload_version => 1},
                        condition => #if_node_exists{exists = false}})}, Ret1),
-                  ?assertEqual([], SE1),
+                  ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE1),
 
     Command2 = #put{path = [#if_all{conditions =
                                     [baz,
@@ -521,7 +521,7 @@ insert_a_node_with_if_node_exists_false_on_self_test() ->
                payload = khepri_payload:data(value2)}}},
        Root),
     ?assertEqual({ok, #{[baz] => #{payload_version => 1}}}, Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE2).
 
 insert_a_node_with_if_node_exists_true_on_parent_test() ->
     Commands = [#put{path = [foo],
@@ -556,7 +556,7 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
                     payload = khepri_payload:data(bar_value)}}}}},
        Root),
     ?assertEqual({ok, #{[foo, bar] => #{payload_version => 1}}}, Ret1),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE1),
 
     Compiled = khepri_condition:compile(
                  #if_all{conditions =
@@ -583,7 +583,7 @@ insert_a_node_with_if_node_exists_true_on_parent_test() ->
                        node_path => [baz],
                        node_is_target => false,
                        condition => Compiled})}, Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE2).
 
 insert_a_node_with_if_node_exists_false_on_parent_test() ->
     Commands = [#put{path = [foo],
@@ -615,7 +615,7 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
                        node_props => #{data => value1,
                                        payload_version => 1},
                        condition => #if_node_exists{exists = false}})}, Ret1),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE1),
 
     Command2 = #put{path = [#if_all{conditions =
                                     [baz,
@@ -650,7 +650,7 @@ insert_a_node_with_if_node_exists_false_on_parent_test() ->
                     payload = khepri_payload:data(bar_value)}}}}},
        Root),
     ?assertEqual({ok, #{[baz, bar] => #{payload_version => 1}}}, Ret2),
-    ?assertEqual([], SE2).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE2).
 
 insert_with_a_path_matching_many_nodes_test() ->
     Commands = [#put{path = [foo],
@@ -678,7 +678,7 @@ insert_with_a_path_matching_many_nodes_test() ->
            possibly_matching_many_nodes_denied,
            #{path => [#if_name_matches{regex = any}]})},
        Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 clear_payload_in_an_existing_node_test() ->
     Commands = [#put{path = [foo],
@@ -710,7 +710,7 @@ clear_payload_in_an_existing_node_test() ->
                                    payload_version => 2,
                                    child_list_version => 1,
                                    child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 put_command_bumps_applied_command_count_test() ->
     Commands = [#put{path = [foo],
@@ -730,7 +730,7 @@ put_command_bumps_applied_command_count_test() ->
     ?assertEqual(
        #{applied_command_count => 1},
        khepri_machine:get_metrics(S1)),
-    ?assertEqual([], SE1),
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE1),
 
     Command2 = #put{path = [baz],
                     payload = ?NO_PAYLOAD},
@@ -739,7 +739,7 @@ put_command_bumps_applied_command_count_test() ->
     ?assertEqual(
        #{applied_command_count => 2},
        khepri_machine:get_metrics(S2)),
-    ?assertEqual([], SE2),
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE2),
 
     Command3 = #put{path = [qux],
                     payload = ?NO_PAYLOAD},
@@ -747,4 +747,5 @@ put_command_bumps_applied_command_count_test() ->
     {S3, _, SE3} = khepri_machine:apply(Meta, Command3, S2),
 
     ?assertEqual(#{}, khepri_machine:get_metrics(S3)),
-    ?assertEqual([{release_cursor, maps:get(index, Meta), S3}], SE3).
+    ?assertEqual([{aux, trigger_delayed_aux_queries_eval},
+                  {release_cursor, maps:get(index, Meta), S3}], SE3).

--- a/test/return_indirect_deletes_option.erl
+++ b/test/return_indirect_deletes_option.erl
@@ -1,0 +1,133 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2025 Broadcom. All Rights Reserved. The term "Broadcom"
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(return_indirect_deletes_option).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("include/khepri.hrl").
+-include("src/khepri_machine.hrl").
+-include("src/khepri_error.hrl").
+-include("test/helpers.hrl").
+
+put_with_default_return_indirect_deletes_test_() ->
+    KeepWhile = #{[foo] => #if_node_exists{exists = false}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [bar], bar_value,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{payload_version => 1},
+                [bar] => #{data => bar_value,
+                           payload_version => 1,
+                           delete_reason => keep_while}}},
+         khepri_adv:create(?FUNCTION_NAME, [foo], foo_value))]}.
+
+put_with_return_indirect_deletes_true_test_() ->
+    KeepWhile = #{[foo] => #if_node_exists{exists = false}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [bar], bar_value,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{payload_version => 1},
+                [bar] => #{data => bar_value,
+                           payload_version => 1,
+                           delete_reason => keep_while}}},
+         khepri_adv:create(
+           ?FUNCTION_NAME, [foo], foo_value,
+           #{return_indirect_deletes => true}))]}.
+
+put_with_return_indirect_deletes_false_test_() ->
+    KeepWhile = #{[foo] => #if_node_exists{exists = false}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [bar], bar_value,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{payload_version => 1}}},
+         khepri_adv:create(
+           ?FUNCTION_NAME, [foo], foo_value,
+           #{return_indirect_deletes => false}))]}.
+
+delete_with_default_return_indirect_deletes_test_() ->
+    KeepWhile = #{[foo] => #if_node_exists{exists = true}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [bar], bar_value,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{data => foo_value,
+                           payload_version => 1,
+                           delete_reason => explicit},
+                [bar] => #{data => bar_value,
+                           payload_version => 1,
+                           delete_reason => keep_while}}},
+         khepri_adv:delete(?FUNCTION_NAME, [foo]))]}.
+
+delete_with_return_indirect_deletes_true_test_() ->
+    KeepWhile = #{[foo] => #if_node_exists{exists = true}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [bar], bar_value,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{data => foo_value,
+                           payload_version => 1,
+                           delete_reason => explicit},
+                [bar] => #{data => bar_value,
+                           payload_version => 1,
+                           delete_reason => keep_while}}},
+         khepri_adv:delete(
+           ?FUNCTION_NAME, [foo], #{return_indirect_deletes => true}))]}.
+
+delete_with_return_indirect_deletes_false_test_() ->
+    KeepWhile = #{[foo] => #if_node_exists{exists = true}},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertEqual(
+         ok,
+         khepri:create(
+           ?FUNCTION_NAME, [bar], bar_value,
+           #{keep_while => KeepWhile})),
+      ?_assertEqual(
+         {ok, #{[foo] => #{data => foo_value,
+                           payload_version => 1,
+                           delete_reason => explicit}}},
+         khepri_adv:delete(
+           ?FUNCTION_NAME, [foo], #{return_indirect_deletes => false}))]}.

--- a/test/root_node.erl
+++ b/test/root_node.erl
@@ -160,7 +160,7 @@ store_data_in_root_node_using_empty_path_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 store_data_in_root_node_using_root_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -183,7 +183,7 @@ store_data_in_root_node_using_root_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 store_data_in_root_node_using_dot_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -206,7 +206,7 @@ store_data_in_root_node_using_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 store_data_in_root_node_using_dot_dot_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -229,7 +229,7 @@ store_data_in_root_node_using_dot_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 store_data_in_root_node_with_condition_true_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -254,7 +254,7 @@ store_data_in_root_node_with_condition_true_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 store_data_in_root_node_with_condition_true_using_dot_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -279,7 +279,7 @@ store_data_in_root_node_with_condition_true_using_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 store_data_in_root_node_with_condition_false_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -305,7 +305,7 @@ store_data_in_root_node_with_condition_false_test() ->
                        node_is_target => true,
                        node_props => #{payload_version => 1},
                        condition => Compiled})}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_empty_root_node_test() ->
     S0 = khepri_machine:init(?MACH_PARAMS()),
@@ -326,7 +326,7 @@ delete_empty_root_node_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_using_empty_path_test() ->
     Commands = [#put{path = [],
@@ -350,7 +350,7 @@ delete_root_node_using_empty_path_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_using_root_test() ->
     Commands = [#put{path = [],
@@ -374,7 +374,7 @@ delete_root_node_using_root_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_using_dot_test() ->
     Commands = [#put{path = [],
@@ -398,7 +398,7 @@ delete_root_node_using_dot_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_using_dot_dot_test() ->
     Commands = [#put{path = [],
@@ -422,7 +422,7 @@ delete_root_node_using_dot_dot_test() ->
                                 payload_version => 2,
                                 child_list_version => 1,
                                 child_list_length => 0}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_with_child_nodes_test() ->
     Commands = [#put{path = [foo, bar],
@@ -447,7 +447,7 @@ delete_root_node_with_child_nodes_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 3,
                                 child_list_length => 2}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_with_condition_true_test() ->
     Commands = [#put{path = [foo],
@@ -472,7 +472,7 @@ delete_root_node_with_condition_true_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 2,
                                 child_list_length => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_with_condition_true_using_dot_test() ->
     Commands = [#put{path = [foo],
@@ -497,7 +497,7 @@ delete_root_node_with_condition_true_using_dot_test() ->
     ?assertEqual({ok, #{[] => #{payload_version => 1,
                                 child_list_version => 2,
                                 child_list_length => 1}}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).
 
 delete_root_node_with_condition_false_test() ->
     Commands = [#put{path = [foo],
@@ -520,4 +520,4 @@ delete_root_node_with_condition_false_test() ->
                   payload = khepri_payload:data(foo_value)}}},
        Root),
     ?assertEqual({ok, #{}}, Ret),
-    ?assertEqual([], SE).
+    ?assertEqual([{aux,trigger_delayed_aux_queries_eval}], SE).

--- a/test/simple_get.erl
+++ b/test/simple_get.erl
@@ -354,6 +354,19 @@ crash_during_fold_test_() ->
          bug,
          khepri:fold(?FUNCTION_NAME, [foo], Fun, []))]}.
 
+crash_during_delayed_fold_test_() ->
+    Fun = fun(_Path, _NodeProps, _Acc) -> throw(bug) end,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         ok,
+         khepri:create(?FUNCTION_NAME, [foo], foo_value)),
+      ?_assertThrow(
+         bug,
+         khepri:fold(
+           ?FUNCTION_NAME, [foo], Fun, [], #{favor => consistency}))]}.
+
 list_nodes_cb(Path, _NodeProps, List) ->
     lists:sort([Path | List]).
 

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -60,6 +60,10 @@ denied_khepri_tx_adv_run_4_test() ->
     Params = #{store_id => ?FUNCTION_NAME,
                member => {?FUNCTION_NAME, node()}},
     MachineState = khepri_machine:make_virgin_state(Params),
+    Meta = #{system_time => erlang:system_time(millisecond),
+             index => 1,
+             term => 1,
+             machine_version => 1},
     ?assertToFunError(
        ?khepri_exception(
           failed_to_prepare_tx_fun,
@@ -68,7 +72,7 @@ denied_khepri_tx_adv_run_4_test() ->
                extraction_denied,
                #{error := {call_denied, {khepri_tx_adv, run, 5}}})}),
        _ = khepri_tx_adv:run(
-             MachineState, fun() -> ok end, [], true, undefined)).
+             MachineState, fun() -> ok end, [], true, Meta)).
 
 denied_receive_block_test() ->
     ?assertToFunError(

--- a/test/tx_funs.erl
+++ b/test/tx_funs.erl
@@ -53,7 +53,7 @@ allowed_khepri_tx_api_test() ->
            _ = khepri_tx:delete([foo]),
            _ = khepri_tx:abort(error),
            _ = khepri_tx:is_transaction(),
-           _ = khepri_tx:api_version()
+           _ = khepri_tx:does_api_comply_with(some_behaviour)
        end).
 
 denied_khepri_tx_adv_run_4_test() ->
@@ -66,8 +66,9 @@ denied_khepri_tx_adv_run_4_test() ->
           #{error :=
             ?horus_error(
                extraction_denied,
-               #{error := {call_denied, {khepri_tx_adv, run, 4}}})}),
-       _ = khepri_tx_adv:run(MachineState, fun() -> ok end, [], true)).
+               #{error := {call_denied, {khepri_tx_adv, run, 5}}})}),
+       _ = khepri_tx_adv:run(
+             MachineState, fun() -> ok end, [], true, undefined)).
 
 denied_receive_block_test() ->
     ?assertToFunError(


### PR DESCRIPTION
## Why

In Khepri cluster, a transaction function is submitted by one member and executed on all members. All runs of that function must reach the same output state from the same input.

We made several changes to refine the API since Khepri 0.16.0:
* #303: return values of the advanced API were unified.
* #305: all indirectly deleted tree nodes are returned in the return values of put and delete advanced commands, and the delete reason was added to each deleted tree node.

These are breaking changes in both the "regular" and the transaction APIs. For the regural API, that is ok, because the state machine code itself remained compatible with older versions. Only on formatting of the return value was affected and that formattion is local to the caller (except in the case of an RPC call, but that’s outside Khepri scope).

The transaction API however broke in an incompatible change. If all members were running the same version of the Khepri state machine, that would be ok. But during an upgrade, there can be a mix of old and new Khepri machines. In this case, a transaction can be submitted from an old node and executed on a new node, and it can be submitted from a new node and executed on an old node.

This is problematic because the difference in the transaction APIs could cause the old and the new state machines to reach a different result from the same input which is a serious issue for a Raft state machine. Therefore, a new node must behaves like the old node until all nodes are running the new version.

## How

The new node can use the effective machine version to determine how to behave. This is what this series of patches does. New `khepri_machine:does_api_comply_with/2` and `khepri_tx:does_api_comply_with/1` are added to let Khepri and the transaction function itself khow how to behave and what to expect. This helps make sure that during a rolling upgrade of Khepri, the cluster will remain on the old behaviout until the entire cluster is up-to-date.

This required a significant change to how we use Ra to perform queries. The normal way of using `ra:local_query()` can’t work with this new need because the query function doesn’t have access to the effective machive version. Therefore, we changed that to use the `aux` Ra commands mechanism.

We also introduce a new command option, `return_indirect_deletes`, to indicate if indirectly deleted tree nodes should be part of the return value or not. It is enabled by default except in transactions if the effective machine version is too old.

Please read each commit to learn more about the implementation details of each part.