### PR TITLE
khepri_machine: Fix query/command options filtering for transactions

### DIFF
--- a/test/simple_tx_get.erl
+++ b/test/simple_tx_get.erl
@@ -942,3 +942,22 @@ filter_node_cb([_ | _] = Path, _NodeProps) ->
     lists:last(Path) =:= baz;
 filter_node_cb(_Path, _NodeProps) ->
     false.
+
+options_are_correctly_filtered_in_auto_txs_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok,
+          {error, ?khepri_error(node_not_found, #{node_name => foo,
+                                                  node_path => [foo],
+                                                  node_is_target => true})}},
+         begin
+             Fun = fun() ->
+                           khepri_tx:get([foo])
+                   end,
+             khepri:transaction(
+               ?FUNCTION_NAME, Fun, auto, #{async => true,
+                                            protect_against_dups => true,
+                                            reply_from => leader})
+         end)]}.

--- a/test/simple_tx_put.erl
+++ b/test/simple_tx_put.erl
@@ -440,3 +440,21 @@ invalid_compare_and_swap_call_test_() ->
                    end,
              khepri:transaction(?FUNCTION_NAME, Fun, rw)
          end)]}.
+
+options_are_correctly_filtered_in_auto_txs_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, ok},
+         begin
+             Fun = fun() ->
+                           khepri_tx:create([foo], foo_value)
+                   end,
+             khepri:transaction(
+               ?FUNCTION_NAME, Fun, auto, #{condition => {applied, {1, 1}},
+                                            favor => consistency})
+         end),
+      ?_assertEqual(
+         {ok, foo_value},
+         khepri:get(?FUNCTION_NAME, [foo]))]}.


### PR DESCRIPTION
## Why

We used `split_{query,command}_options()` to extract relevant options to pass to the transaction implementation. However these `split_*()` functions are strict and they will raise an exception if a query option is mixed with a command option.

This is impracticle with "auto" transactions that could be queries or writes.

## How

In the context of auto transactions, we remove query options before we extract command options, or the opposite. This way, we are sure the the `split_*()` function will not raise an exception.