### PR TITLE
cluster_SUITE: Improve reliablitily of `can_join_several_times_a_three_node_cluster`

### DIFF
--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -670,7 +670,7 @@ can_join_several_times_a_three_node_cluster(Config) ->
     lists:foreach(
       fun(Node) ->
               Options = case Node of
-                            LeaderNode -> #{};
+                            LeaderNode   -> #{};
                             FollowerNode -> #{};
                             _            -> #{favor => consistency}
                         end,
@@ -699,7 +699,9 @@ can_join_several_times_a_three_node_cluster(Config) ->
               ct:pal("- khepri:get() from node ~s", [Node]),
               ?assertEqual(
                  {ok, value2},
-                 rpc:call(Node, khepri, get, [StoreId, [foo]]))
+                 rpc:call(
+                   Node, khepri, get,
+                   [StoreId, [foo], #{favor => consistency}]))
       end, Nodes),
 
     ok.


### PR DESCRIPTION
## Why

We perform a get on all nodes after writing to one of them. It happens in CI that the write is not applied everywhere yet.

## How

We perform the get with the favor option set to `consistency` to make sure that the latest leader command was appied locally.