### PR TITLE
cluster_SUITE: Add a timeout handling test case

### DIFF
--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -919,6 +919,7 @@ is_remote_call_valid(re, run, _) -> true;
 is_remote_call_valid(re, split, _) -> true;
 is_remote_call_valid(sets, _, _) -> true;
 is_remote_call_valid(string, _, _) -> true;
+is_remote_call_valid(timer, sleep, _) -> true;
 is_remote_call_valid(unicode, _, _) -> true;
 
 is_remote_call_valid(_, _, _) -> false.


### PR DESCRIPTION
## Why

In an issue reported by a RabbitMQ user, the timeout passed to `khepri_cluster:wait_for_leader/2` may not have been honored. We are not sure of that because we lack information from this user. But this timeout was not covered by a test case before.

## How

The new test case starts a single-node store, runs several slow transactions that take 40 seconds overall, then restarts the store twice. The restart returns immediately but behind the scene, it takes 40 seconds again to replay the transactions during recovery.

After the first restart, we call `khepri_cluster:wait_for_leader/2` with a timeout of 60 seconds. It returns successfully after 40 seconds.

After the second restart, we call the function again but with a timeout of 30 seconds. This time, it returns `{error, timeout}` after 30 seconds as expected.

This test case succeeds so far, so the reported problem seems unrelated to Ra or Khepri as the timeout is properly honored. At least, we have a test case now to ensure it stays that way.