### PR TITLE
khepri_cluster: Handle `{error, normal}` in do_reset/4

### DIFF
--- a/src/khepri_cluster.erl
+++ b/src/khepri_cluster.erl
@@ -979,7 +979,7 @@ do_reset(RaSystem, StoreId, ThisMember, Timeout) ->
             end;
         {timeout, _} ->
             {error, timeout};
-        {error, noproc} ->
+        {error, Reason} when Reason =:= noproc orelse Reason =:= normal ->
             ?LOG_DEBUG(
                "The local Ra server exited while we tried to detach it from "
                "its cluster. It means it was removed from the cluster by "


### PR DESCRIPTION
## Why

If the reset occurs at the same time the Ra process is exiting, it could return `{error, normal}`, `normal` being its exit reason probably.

It should be handled the same way as `{error, noproc}` which corresponds to an already exited Ra process.