### PR TITLE
Fix Dialyzer warnings

### DIFF
--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -239,7 +239,7 @@ do_export(State, PathPattern, Module, ModulePriv) ->
                      Tree, PathPattern, TreeOptions, Fun, ModulePriv1),
             case Ret1 of
                 {ok, Tree1, _AppliedChanges, FinalModulePriv} ->
-                    ?assertEqual(Tree, Tree1),
+                    khepri_tree:assert_equal(Tree, Tree1),
                     commit_write(Module, FinalModulePriv);
                 {error, _} = Error ->
                     Error

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -520,9 +520,10 @@ readonly_transaction(StoreId, Fun, Args, Options)
                     %% It is a read-only transaction, therefore we assert that
                     %% the state is unchanged and that there are no side
                     %% effects.
-                    {State, Ret, []} = khepri_tx_adv:run(
-                                         State, Fun, Args, false,
-                                         Meta),
+                    {State1, Ret, []} = khepri_tx_adv:run(
+                                          State, Fun, Args, false,
+                                          Meta),
+                    assert_equal(State, State1),
                     Ret
             end,
     case process_query(StoreId, Query, Options) of
@@ -537,9 +538,10 @@ readonly_transaction(StoreId, PathPattern, Args, Options)
                     %% It is a read-only transaction, therefore we assert that
                     %% the state is unchanged and that there are no side
                     %% effects.
-                    {State, Ret, []} = locate_sproc_and_execute_tx(
-                                         State, PathPattern, Args, false,
-                                         Meta),
+                    {State1, Ret, []} = locate_sproc_and_execute_tx(
+                                          State, PathPattern, Args, false,
+                                          Meta),
+                    assert_equal(State, State1),
                     Ret
             end,
     case process_query(StoreId, Query, Options) of
@@ -2633,6 +2635,16 @@ set_dedups(State, _Dedups) ->
 get_store_id(State) ->
     #config{store_id = StoreId} = get_config(State),
     StoreId.
+
+-spec assert_equal(State1, State2) -> ok when
+      State1 :: khepri_machine:state(),
+      State2 :: khepri_machine:state().
+
+assert_equal(#khepri_machine{} = State1, #khepri_machine{} = State2) ->
+    ?assertEqual(State1, State2),
+    ok;
+assert_equal(State1, State2) ->
+    khepri_machine_v0:assert_equal(State1, State2).
 
 -ifdef(TEST).
 -spec make_virgin_state(Params) -> State when

--- a/src/khepri_machine_v0.erl
+++ b/src/khepri_machine_v0.erl
@@ -88,7 +88,7 @@ get_config(#khepri_machine{config = Config}) ->
 
 -spec get_tree(State) -> Tree when
       State :: khepri_machine_v0:state(),
-      Tree :: khepri_tree:tree().
+      Tree :: khepri_tree:tree_v0().
 %% @doc Returns the tree from the given state.
 %%
 %% @private

--- a/src/khepri_machine_v0.erl
+++ b/src/khepri_machine_v0.erl
@@ -13,6 +13,8 @@
 
 -module(khepri_machine_v0).
 
+-include_lib("stdlib/include/assert.hrl").
+
 -include("src/khepri_machine.hrl").
 
 -export([init/1]).
@@ -25,6 +27,7 @@
          get_emitted_triggers/1, set_emitted_triggers/2,
          get_projections/1, set_projections/2,
          get_metrics/1, set_metrics/2,
+         assert_equal/2,
          state_to_list/1]).
 
 -record(khepri_machine,
@@ -191,6 +194,7 @@ get_metrics(#khepri_machine{metrics = Metrics}) ->
 set_metrics(#khepri_machine{} = State, Metrics) ->
     State#khepri_machine{metrics = Metrics}.
 
+
 -spec state_to_list(State) -> Fields when
       State :: khepri_machine_v0:state(),
       Fields :: [any()].
@@ -200,3 +204,11 @@ set_metrics(#khepri_machine{} = State, Metrics) ->
 
 state_to_list(#khepri_machine{} = State) ->
     tuple_to_list(State).
+
+-spec assert_equal(State1, State2) -> ok when
+      State1 :: khepri_machine:state(),
+      State2 :: khepri_machine:state().
+
+assert_equal(#khepri_machine{} = State1, #khepri_machine{} = State2) ->
+    ?assertEqual(State1, State2),
+    ok.

--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -625,8 +625,9 @@ abspath([_ | _] = RelativePath, BasePath) ->
 abspath([] = PathToRoot, _) ->
     PathToRoot.
 
--spec realpath(Path) -> Path when
-      Path :: native_pattern().
+-spec realpath(Path) -> NewPath when
+      Path :: native_pattern(),
+      NewPath :: native_pattern().
 
 realpath(Path) ->
     realpath(Path, []).

--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -73,9 +73,9 @@
 %% A node name.
 
 -type component() :: node_id() |
-                    ?KHEPRI_ROOT_NODE |
-                    ?THIS_KHEPRI_NODE |
-                    ?PARENT_KHEPRI_NODE.
+                     ?KHEPRI_ROOT_NODE |
+                     ?THIS_KHEPRI_NODE |
+                     ?PARENT_KHEPRI_NODE.
 %% Component name in a path to a node.
 
 -type native_path() :: [component()].

--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -639,7 +639,10 @@ realpath([?PARENT_KHEPRI_NODE | Rest], [_ | Result]) ->
     realpath(Rest, Result);
 realpath([?PARENT_KHEPRI_NODE | Rest], [] = Result) ->
     realpath(Rest, Result);
-realpath([Component | Rest], Result) ->
+realpath([Component | Rest], Result)
+  when is_atom(Component) orelse
+       is_binary(Component) orelse
+       ?IS_KHEPRI_CONDITION(Component) ->
     realpath(Rest, [Component | Result]);
 realpath([], Result) ->
     lists:reverse(Result).

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -321,9 +321,10 @@ squash_version_bumps_after_keep_while(
 %% Keep-while functions.
 %% -------------------------------------------------------------------
 
--spec to_absolute_keep_while(BasePath, KeepWhile) -> KeepWhile when
+-spec to_absolute_keep_while(BasePath, KeepWhile) -> AbsKeepWhile when
       BasePath :: khepri_path:native_path(),
-      KeepWhile :: khepri_condition:native_keep_while().
+      KeepWhile :: khepri_condition:native_keep_while(),
+      AbsKeepWhile :: khepri_condition:native_keep_while().
 %% @private
 
 to_absolute_keep_while(BasePath, KeepWhile) ->
@@ -395,11 +396,11 @@ update_keep_while_conds(Tree, Watcher, KeepWhile) ->
     KeepWhileConds1 = KeepWhileConds#{Watcher => AbsKeepWhile},
     Tree1#tree{keep_while_conds = KeepWhileConds1}.
 
--spec update_keep_while_conds_revidx(Tree, Watcher, KeepWhile) ->
-    Tree when
+-spec update_keep_while_conds_revidx(Tree, Watcher, KeepWhile) -> NewTree when
       Tree :: tree(),
       Watcher :: khepri_path:native_path(),
-      KeepWhile :: khepri_condition:native_keep_while().
+      KeepWhile :: khepri_condition:native_keep_while(),
+      NewTree :: tree().
 
 update_keep_while_conds_revidx(
   #tree{keep_while_conds_revidx = KeepWhileCondsRevIdx} = Tree,

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -22,6 +22,7 @@
 -export([new/0,
          get_root/1,
          get_keep_while_conds/1,
+         assert_equal/2,
 
          are_keep_while_conditions_met/2,
 
@@ -124,6 +125,14 @@ get_root(#tree{root = Root}) ->
 
 get_keep_while_conds(#tree{keep_while_conds = KeepWhileConds}) ->
     KeepWhileConds.
+
+-spec assert_equal(Tree1, Tree2) -> ok when
+      Tree1 :: khepri_tree:tree(),
+      Tree2 :: khepri_tree:tree().
+
+assert_equal(#tree{} = Tree1, #tree{} = Tree2) ->
+    ?assertEqual(Tree1, Tree2),
+    ok.
 
 -spec create_node_record(Payload) -> Node when
       Payload :: khepri_payload:payload(),

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -40,16 +40,16 @@
 
 -record(tree, {root = #node{} :: khepri_tree:tree_node(),
                keep_while_conds = #{} :: khepri_tree:keep_while_conds_map(),
-               keep_while_conds_revidx = #{} ::
-               khepri_tree:keep_while_conds_revidx()}).
+               keep_while_conds_revidx = #{}}).
 
 -type tree_node() :: #node{}.
 %% A node in the tree structure.
 
--opaque tree_v0() :: #tree{keep_while_conds_revidx ::
-                           khepri_tree:keep_while_conds_revidx_v0()}.
--opaque tree_v1() :: #tree{keep_while_conds_revidx ::
-                           khepri_tree:keep_while_conds_revidx_v1()}.
+-type tree(KeepWhileCondsRevIdxType) :: #tree{keep_while_conds_revidx ::
+                                              KeepWhileCondsRevIdxType}.
+
+-opaque tree_v0() :: tree(khepri_tree:keep_while_conds_revidx_v0()).
+-opaque tree_v1() :: tree(khepri_tree:keep_while_conds_revidx_v1()).
 
 -type tree() :: tree_v0() | tree_v1().
 
@@ -389,10 +389,16 @@ is_keep_while_condition_met_on_self(
             true
     end.
 
+-spec update_keep_while_conds(Tree, Watcher, KeepWhile) -> NewTree when
+      Tree :: khepri_tree:tree(),
+      Watcher :: khepri_path:native_path(),
+      KeepWhile :: khepri_condition:native_keep_while(),
+      NewTree :: khepri_tree:tree().
+
 update_keep_while_conds(Tree, Watcher, KeepWhile) ->
     AbsKeepWhile = to_absolute_keep_while(Watcher, KeepWhile),
     Tree1 = update_keep_while_conds_revidx(Tree, Watcher, AbsKeepWhile),
-    #tree{keep_while_conds = KeepWhileConds} = Tree1,
+    KeepWhileConds = get_keep_while_conds(Tree1),
     KeepWhileConds1 = KeepWhileConds#{Watcher => AbsKeepWhile},
     Tree1#tree{keep_while_conds = KeepWhileConds1}.
 


### PR DESCRIPTION
This is a collection of fixes of warnings reported by Dialyzer in Erlang/OTP 28.

These are not reported on CI yet because we can’t test against Erlang/OTP 28 until a new release of Rebar is published with the fix to make it work on Windows (erlang/rebar3#2954).