### PR TITLE
rebar.config: Update PropEr from 1.4.0 to 1.5.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -52,7 +52,7 @@
 
 {profiles,
  [{test,
-   [{deps, [{proper, "1.4.0"},
+   [{deps, [{proper, "1.5.0"},
             %% FIXME: We need to add `cth_readable' as a dependency and an
             %% extra app for Dialyzer. That's because Rebar is using that
             %% application to override `ct:pal()' and Dialyzer complains it


### PR DESCRIPTION
## Why

This should fix a deprecation warning reported at compile time for quite some time.