### PR TITLE
GitHub Actions: Test against Erlang/OTP 28

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -10,7 +10,7 @@ concurrency:
 
 env:
   REBAR_VERSION: '3.25.1'
-  LATEST_ERLANG_VERSION: '27'
+  LATEST_ERLANG_VERSION: '28'
 
 jobs:
   # `env_to_output` works around a limitation of GitHub Actions that prevents

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REBAR_VERSION: '3.23.0'
+  REBAR_VERSION: '3.25.1'
   LATEST_ERLANG_VERSION: '27'
 
 jobs:

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        otp_version: ['26', '27']
+        otp_version: ['26', '27', '28']
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
While here, bump Rebar version from 3.23.0 to 3.25.1.