### PR TITLE
khepri_evf: Add `event_filter_or_compat()` type

### DIFF
--- a/include/khepri.hrl
+++ b/include/khepri.hrl
@@ -28,7 +28,19 @@
          PathComponent =:= ?PARENT_KHEPRI_NODE)).
 
 -define(IS_KHEPRI_PATH(Path),
-        (Path =:= [] orelse ?IS_KHEPRI_PATH_COMPONENT(hd(Path)))).
+        (is_list(Path) andalso
+         (Path =:= [] orelse ?IS_KHEPRI_PATH_COMPONENT(hd(Path))))).
+
+-define(__K__IS_STRING(String),
+        (is_list(String) andalso
+         (String =:= "" orelse
+          (is_integer(hd(String)) andalso hd(String) >= 0)))).
+
+-define(__K__IS_UNIX_PATH(Path),
+        (?__K__IS_STRING(Path) orelse is_binary(Path))).
+
+-define(IS_KHEPRI_PATH_OR_COMPAT(Path),
+        (?IS_KHEPRI_PATH(Path) orelse ?__K__IS_UNIX_PATH(Path)).
 
 -define(IS_KHEPRI_CONDITION(Condition),
         (is_record(Condition, if_child_list_length) orelse
@@ -50,7 +62,11 @@
          ?IS_KHEPRI_CONDITION(PathCondition))).
 
 -define(IS_KHEPRI_PATH_PATTERN(Path),
-        (Path =:= [] orelse ?IS_KHEPRI_PATH_CONDITION(hd(Path)))).
+        (is_list(Path) andalso
+         (Path =:= [] orelse ?IS_KHEPRI_PATH_CONDITION(hd(Path))))).
+
+-define(IS_KHEPRI_PATH_PATTERN_OR_COMPAT(Path),
+        (?IS_KHEPRI_PATH_PATTERN(Path) orelse ?__K__IS_UNIX_PATH(Path))).
 
 %% -------------------------------------------------------------------
 %% Path conditions.

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -2822,8 +2822,7 @@ clear_many_payloads(StoreId, PathPattern, Options) ->
 
 -spec register_trigger(TriggerId, EventFilter, StoredProcPath) -> Ret when
       TriggerId :: trigger_id(),
-      EventFilter :: khepri_evf:event_filter() |
-                     khepri_path:pattern(),
+      EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
       Ret :: ok | error().
 %% @doc Registers a trigger.
@@ -2842,14 +2841,12 @@ register_trigger(TriggerId, EventFilter, StoredProcPath) ->
 (StoreId, TriggerId, EventFilter, StoredProcPath) -> Ret when
       StoreId :: khepri:store_id(),
       TriggerId :: trigger_id(),
-      EventFilter :: khepri_evf:event_filter() |
-                     khepri_path:pattern(),
+      EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
       Ret :: ok | error();
 (TriggerId, EventFilter, StoredProcPath, Options) -> Ret when
       TriggerId :: trigger_id(),
-      EventFilter :: khepri_evf:event_filter() |
-                     khepri_path:pattern(),
+      EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
       Options :: command_options(),
       Ret :: ok | error().
@@ -2882,8 +2879,7 @@ register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
     Ret when
       StoreId :: khepri:store_id(),
       TriggerId :: trigger_id(),
-      EventFilter :: khepri_evf:event_filter() |
-                     khepri_path:pattern(),
+      EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
       Options :: command_options(),
       Ret :: ok | error().

--- a/src/khepri_evf.erl
+++ b/src/khepri_evf.erl
@@ -10,6 +10,7 @@
 
 -module(khepri_evf).
 
+-include("include/khepri.hrl").
 -include("src/khepri_evf.hrl").
 
 -export([tree/1, tree/2,
@@ -50,6 +51,16 @@
 %% and converted to an event filter with default properties. See each event
 %% filter type for more details.
 
+-type event_filter_or_compat() :: khepri_evf:event_filter() |
+                                  khepri_path:pattern().
+%% An event filter, or any type that can be automatically converted to an
+%% event filter.
+%%
+%% For instance, a Khepri path or a string can be converted to a {@link
+%% tree_event_filter()}.
+%%
+%% @see wrap/1.
+
 -type priority() :: integer().
 %% An event filter priority.
 %%
@@ -59,6 +70,7 @@
 %% The default priority is 0.
 
 -export_type([event_filter/0,
+              event_filter_or_compat/0,
               tree_event_filter/0,
               tree_event_filter_props/0,
               priority/0]).
@@ -81,13 +93,13 @@ tree(PathPattern) ->
 %%
 %% @see tree_event_filter().
 
-tree(PathPattern, Props) ->
+tree(PathPattern, Props) when ?IS_KHEPRI_PATH_PATTERN_OR_COMPAT(PathPattern) ->
     PathPattern1 = khepri_path:from_string(PathPattern),
     #evf_tree{path = PathPattern1,
               props = Props}.
 
 -spec wrap(Input) -> EventFilter when
-      Input :: khepri_evf:event_filter() | khepri_path:pattern(),
+      Input :: khepri_evf:event_filter_or_compat(),
       EventFilter :: khepri_evf:event_filter().
 %% @doc Automatically detects the event filter type and ensures it is wrapped
 %% in one of the internal types.
@@ -99,7 +111,7 @@ tree(PathPattern, Props) ->
 
 wrap(EventFilter) when ?IS_KHEPRI_EVENT_FILTER(EventFilter) ->
     EventFilter;
-wrap(PathPattern) when is_list(PathPattern) ->
+wrap(PathPattern) when ?IS_KHEPRI_PATH_PATTERN_OR_COMPAT(PathPattern) ->
     tree(PathPattern).
 
 -spec get_priority(EventFilter) -> Priority when

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -614,7 +614,7 @@ handle_tx_exception(
     Ret when
       StoreId :: khepri:store_id(),
       TriggerId :: khepri:trigger_id(),
-      EventFilter :: khepri_evf:event_filter() | khepri_path:pattern(),
+      EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
       Options :: khepri:command_options(),
       Ret :: ok | khepri:error().


### PR DESCRIPTION
## Why

Before, `khepri_evf:wrap/{1,2}` and all users of `khepri_evf:event_filter()` were specifying the compatible types as well, i.e. a Khepri path pattern, a string, and so on.

This list of compatible types was inconsistent and sometimes incomplete.

## How

With the new event filter types coming in a future version of Khepri, let's add an `event_filter_or_compat()` type which encapsulates the `event_filter()` type and all compatible types that can be wrapped into/converted to an event filter automatically.

While here, improve a new macros to correcly check a Khepri path or path pattern in a guard expression.