### PR TITLE
GitHub Actions: Work around broken setup-beam actions

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@566deebc640988a494af16ecdf6f820fe0d3fea4
         id: install-erlang
         with:
           otp-version: ${{ env.LATEST_ERLANG_VERSION }}
@@ -93,7 +93,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@566deebc640988a494af16ecdf6f820fe0d3fea4
         with:
           otp-version: ${{ env.LATEST_ERLANG_VERSION }}
           rebar3-version: ${{ env.REBAR_VERSION }}
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@566deebc640988a494af16ecdf6f820fe0d3fea4
         id: install-erlang
         with:
           otp-version: ${{ env.LATEST_ERLANG_VERSION }}

--- a/.github/workflows/test-job.yaml
+++ b/.github/workflows/test-job.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: erlef/setup-beam@v1
+      - uses: erlef/setup-beam@566deebc640988a494af16ecdf6f820fe0d3fea4
         id: install-erlang
         with:
           otp-version: ${{ matrix.otp_version }}


### PR DESCRIPTION
## Why

`setup-beam` is broken with the latest version of Windows. A fix was committed but they don't release a version with the fix, even after a month and a half... This blocks any CI test of Khepri.

## How

Use a non-released version of `setup-beam` using a specific commit from the main branch.