### PR TITLE
khepri_machine: Handle `{error, normal}` in process_sync_command/3

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -994,7 +994,7 @@ do_process_sync_command(StoreId, Command, Options) ->
         {error, Reason} = Error
           when ?HAS_TIME_LEFT(Timeout) andalso
                (Reason == noproc orelse Reason == nodedown orelse
-                Reason == shutdown) ->
+                Reason == shutdown orelse Reason == normal) ->
             %% We retry the command if either:
             %% - the command was sent directly to a remote server, or
             %% - the command was sent to the local server and it is still


### PR DESCRIPTION
## Why

Ra can return `{error, normal}` when a Ra server exits. We already handle this return value, thanks to pull requests #314 and #335. However, it can happen in `process_sync_command/3`: this was reported once in CI. Thus it is rare, but still possible.

## How

Like in previous patches, we treat `{error, normal}` like `{error, noproc}`.