### PR TITLE
Replace `catch` with try/catch blocks

### DIFF
--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -222,7 +222,12 @@ do_export(State, PathPattern, Module, ModulePriv) ->
                         write(State, Path, Node, Module, ModulePriv2)
                     catch
                         Class:Exception:Stacktrace ->
-                            _ = catch abort_write(Module, ModulePriv2),
+                            _ = try
+                                    abort_write(Module, ModulePriv2)
+                                catch
+                                    _:_ ->
+                                        ok
+                                end,
                             erlang:raise(Class, Exception, Stacktrace)
                     end,
                     case Ret of
@@ -365,7 +370,12 @@ do_import(StoreId, Module, ModulePriv) ->
               read(Module, ModulePriv)
           catch
               Class:Exception:Stacktrace ->
-                  _ = catch close_read(Module, ModulePriv),
+                  _ = try
+                          close_read(Module, ModulePriv)
+                      catch
+                          _:_ ->
+                              ok
+                      end,
                   erlang:raise(Class, Exception, Stacktrace)
           end,
     case Ret of

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -179,9 +179,14 @@ end_per_testcase(_Testcase, Config) ->
     maps:foreach(
       fun
           (Node, #{peer := Peer, props := Props}) ->
-              _ = catch peer:call(
-                          Peer, helpers, stop_ra_system, [Props], infinity),
-              _ = catch helpers:stop_erlang_node(Node, Peer);
+              try
+                  _ = peer:call(
+                        Peer, helpers, stop_ra_system, [Props], infinity),
+                  _ = helpers:stop_erlang_node(Node, Peer)
+              catch
+                  _:_ ->
+                      ok
+              end;
           (_Node, #{props := Props}) ->
               helpers:stop_ra_system(Props)
       end, PropsPerNode),
@@ -452,8 +457,13 @@ fail_to_start_with_bad_ra_server_config(Config) ->
     StoreId = RaSystem,
 
     ct:pal("Start database"),
-    Ret1 = (catch khepri:start(RaSystem, #{cluster_name => StoreId,
-                                           tick_timeout => not_a_timeout})),
+    Ret1 = try
+               khepri:start(RaSystem, #{cluster_name => StoreId,
+                                        tick_timeout => not_a_timeout})
+           catch
+               _Class1:Reason1 ->
+                   {'EXIT', Reason1}
+           end,
     ct:pal("Return value of khepri:start/2: ~p", [Ret1]),
     ?assert(
        case Ret1 of
@@ -477,7 +487,12 @@ fail_to_start_with_bad_ra_server_config(Config) ->
     %% The process is restarted by its supervisor. Depending on the timing, we
     %% may get a `noproc' or an exception.
     ct:pal("Database unusable after failing to start it"),
-    Ret2 = (catch khepri:get(StoreId, [foo])),
+    Ret2 = try
+               khepri:get(StoreId, [foo])
+           catch
+               _Class2:Reason2 ->
+                   {'EXIT', Reason2}
+           end,
     ct:pal("Return value of khepri:get/2: ~p", [Ret2]),
     ?assert(
        case Ret2 of

--- a/test/helpers.erl
+++ b/test/helpers.erl
@@ -300,7 +300,12 @@ get_leader_in_store(Config, StoreId, [Node | _] = _RunningNodes) ->
                       Config, Node,
                       khepri_cluster, members,
                       [StoreId, #{timeout => 60000}]),
-    Pids = [[Member, catch call(Config, N, erlang, whereis, [RegName])]
+    Pids = [[Member, try
+                         call(Config, N, erlang, whereis, [RegName])
+                     catch
+                         _Class:Reason ->
+                             {'EXIT', Reason}
+                     end]
             || {RegName, N} = Member <- Members],
     LeaderId = call(Config, Node, ra_leaderboard, lookup_leader, [StoreId]),
     ?assertNotEqual(undefined, LeaderId),


### PR DESCRIPTION
## Why

The use of `catch` was deprecated a long time ago (I was not aware of that) and the Erlang/OTP 29 compiler starts to emit warnings about its use.

## How

The `catch` operator must be replaced by a try/catch block.