### PR TITLE
khepri_machine: Fix `api_behaviour_to_machine_version/1` spec

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -2054,7 +2054,7 @@ clear_cached_effective_machine_version(StoreId) ->
 -spec api_behaviour_to_machine_version(Behaviour) -> Ret when
       Behaviour :: khepri_machine:api_behaviour(),
       Ret :: MacVer | undefined,
-      MacVer :: 1..2.
+      MacVer :: 1..3.
 %% @doc Returns the state machine version that implemented the given API behaviour.
 %%
 %% If the behaviour is unknown to this implementation, `undefined' is returned.


### PR DESCRIPTION
## Why

It can return a version up to the latest version, so 3 in this case. It should have been bump when version 3 was added.