### PR TITLE
khepri_machine: Pass `machine_version` when applying init-time commands

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1335,8 +1335,9 @@ init(Params) ->
     %% state format.
     State = khepri_machine_v0:init(Params),
 
+    InitialMacVer = 0,
     #config{store_id = StoreId} = get_config(State),
-    cache_effective_machine_version(StoreId, 0),
+    cache_effective_machine_version(StoreId, InitialMacVer),
 
     %% Create initial "schema" if provided.
     Commands = maps:get(commands, Params, []),
@@ -1344,7 +1345,8 @@ init(Params) ->
                fun(Command, State1) ->
                        Meta = #{index => 0,
                                 term => 0,
-                                system_time => 0},
+                                system_time => 0,
+                                machine_version => InitialMacVer},
                        {S, _, _} = apply(Meta, Command, State1),
                        S
                end, State, Commands),


### PR DESCRIPTION
## Why

The meta map we constructed so far did not have this machine version and some commands expect it to be available. This is not a problem in 0.17.x but it will be one in future versions.