### PR TITLE
test/prop_state_machine: Unwrap `#p_data{}` when checking result validity

### DIFF
--- a/test/prop_state_machine.erl
+++ b/test/prop_state_machine.erl
@@ -195,15 +195,17 @@ result_is_ok_after_delete({ok, NodePropsMap}, Entries, Path) ->
 result_is_ok_after_delete(_, _Entries, _Path) ->
     false.
 
-result_is_ok_after_put(Result, Entries, Path, Payload, Default) ->
+result_is_ok_after_put(Result, Entries, Path, #p_data{data = Data}, Default) ->
+    result_is_ok_after_put(Result, Entries, Path, Data, Default);
+result_is_ok_after_put(Result, Entries, Path, Data, Default) ->
     case Entries of
-        #{Path := #{data := Payload} = NodeProps} ->
+        #{Path := #{data := Data} = NodeProps} ->
             %% The payload didn't change.
             Expected = {ok, #{Path => NodeProps}},
             Expected =:= Result;
         #{Path := NodeProps}
           when not is_map_key(data, NodeProps) andalso
-               Payload =:= ?NO_PAYLOAD ->
+               Data =:= ?NO_PAYLOAD ->
             %% The payload didn't change; there is still none.
             Expected = {ok, #{Path => NodeProps}},
             Expected =:= Result;


### PR DESCRIPTION
## Why

`khepri:put_many/3` accepts either an arbitrary Erlang term (which is then wrapped into a `#p_data{}` record), or a `#p_data{}` record.

In this property-based test, we were not considering the latter when comparing the payload argument to the possible valid ones. It means we could compare a `#p_data{}` record argument to the data it wraps, leading to a test failure.

## How

The `result_is_ok_after_delete/5` function is modified to unwrap the `#p_data{}` record first so that it always compare apples to apples.