### PR TITLE
khepri_machine: Fix last entry in the state machine version table

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -58,7 +58,7 @@
 %% </td>
 %% </tr>
 %% <tr>
-%% <td style="text-align: right; vertical-align: top;">2</td>
+%% <td style="text-align: right; vertical-align: top;">3</td>
 %% <td>
 %% <ul>
 %% <li>Added support for multi-table projections (see {@link


### PR DESCRIPTION
## Why

The new version is 3, but the table mentions version 2 twice. The last entry should say "version 3".