### PR TITLE
Allow overriding projection ETS option `protection`

### DIFF
--- a/src/khepri_projection.erl
+++ b/src/khepri_projection.erl
@@ -274,7 +274,8 @@ fun((Tids :: ets:tid() | #{atom() => ets:tid()},
                                      keypos => pos_integer(),
                                      read_concurrency => boolean(),
                                      write_concurrency => boolean() | auto,
-                                     compressed => boolean()}.
+                                     compressed => boolean(),
+                                     protection => ets:table_access()}.
 %% Overrideable ETS options.
 %%
 %% They can be used for single-table and multi-table projections. For the
@@ -297,7 +298,8 @@ fun((Tids :: ets:tid() | #{atom() => ets:tid()},
                      keypos => pos_integer(),
                      read_concurrency => boolean(),
                      write_concurrency => boolean() | auto,
-                     compressed => boolean()}.
+                     compressed => boolean(),
+                     protection => ets:table_access()}.
 %% Options which control the created ETS table.
 %%
 %% If provided, `standalone_fun_options' are merged with defaults and passed to
@@ -496,6 +498,15 @@ to_ets_options(compressed, true, Acc) ->
     [compressed | Acc];
 to_ets_options(compressed, false, Acc) ->
     Acc;
+to_ets_options(protection, Protection, Acc)
+  when Protection =:= public orelse
+       Protection =:= protected orelse
+       Protection =:= private ->
+    Acc1 = [Option || Option <- Acc,
+                      Option =/= public,
+                      Option =/= protected,
+                      Option =/= private],
+    [Protection | Acc1];
 to_ets_options(Key, Value, _Acc) ->
     ?khepri_misuse(
        unexpected_projection_option,

--- a/test/projections.erl
+++ b/test/projections.erl
@@ -589,9 +589,11 @@ multi_table_projection_with_global_ets_options_works_test_() ->
           ?_test(
               begin
                   Options = #{type => ordered_set,
+                              protection => protected,
                               tables =>
                               #{mtp_ordered => #{},
-                                mtp_bag => #{type => bag}}},
+                                mtp_bag => #{type => bag,
+                                             protection => public}}},
                   Projection = khepri_projection:new(
                                  ?MODULE, ProjectFun, Options),
                   ?assertEqual(
@@ -602,14 +604,20 @@ multi_table_projection_with_global_ets_options_works_test_() ->
 
          {"The ETS tables have the expected type",
           ?_test(
-              begin
-                  ?assertEqual(
-                     ordered_set,
-                     ets:info(mtp_ordered, type)),
-                  ?assertEqual(
-                     bag,
-                     ets:info(mtp_bag, type))
-              end)}]
+             begin
+                 ?assertEqual(
+                    ordered_set,
+                    ets:info(mtp_ordered, type)),
+                 ?assertEqual(
+                    protected,
+                    ets:info(mtp_ordered, protection)),
+                 ?assertEqual(
+                    bag,
+                    ets:info(mtp_bag, type)),
+                 ?assertEqual(
+                    public,
+                    ets:info(mtp_bag, protection))
+             end)}]
       }]}.
 
 multi_table_projection_with_invalid_func_is_denied_test_() ->


### PR DESCRIPTION
Some applications would like Khepri to own a projection ETS table, while still allowing other processes to insert and delete objects. Prior to this commit, this wasn't allowed since `protected` was hardcoded as default option.