### PR TITLE
khepri_path: Fix bug with #if_not{} condition in `component_targets_s…

### DIFF
--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -547,8 +547,8 @@ targets_specific_node([], Path) ->
 component_targets_specific_node(ChildName)
   when ?IS_KHEPRI_PATH_COMPONENT(ChildName) ->
     {true, ChildName};
-component_targets_specific_node(#if_not{condition = Cond}) ->
-    component_targets_specific_node(Cond);
+% component_targets_specific_node(#if_not{condition = Cond}) ->
+%     component_targets_specific_node(Cond);
 component_targets_specific_node(#if_all{conditions = []}) ->
     false;
 component_targets_specific_node(#if_all{conditions = Conds}) ->

--- a/test/path_operations.erl
+++ b/test/path_operations.erl
@@ -368,8 +368,7 @@ pattern_component_targets_specific_node_test() ->
          #if_has_data{has_data = true})).
 
 if_not_condition_targets_specific_node_test() ->
-    ?assertEqual(
-       {true, foo},
+    ?assertNot(
        khepri_path:component_targets_specific_node(
          #if_not{condition = foo})),
     ?assertNot(


### PR DESCRIPTION
## Why

The following condition was considred to target a specific tree node:

```erlang
#if_not{conditions = [foo]}
```

That's because `component_targets_specific_node/1` was recursing with the inner conditions of #if_not{}, without more interpretations.

This is wrong because #if_not{} tells what it doesn't match, not what it can match. Therefore, there is no way #if_not{} can ever match a specific tree node. #if_not{} should always be considered to match many tree nodes.

## How

Just remore the function clause that matched against #if_not{} in `component_targets_specific_node/1`.