### PR TITLE
khepri_tree: Optimise walk when component pattern matches a specific list of nodes

### DIFF
--- a/src/khepri_path.erl
+++ b/src/khepri_path.erl
@@ -59,6 +59,7 @@
          combine_with_conditions/2,
          targets_specific_node/1,
          component_targets_specific_node/1,
+         component_targets_specific_siblings/1,
          is_valid/1,
          ensure_is_valid/1,
          abspath/2,
@@ -526,6 +527,16 @@ combine_with_conditions(Path, Conditions) ->
       PathPattern :: native_pattern(),
       Ret :: {true, Path} | false,
       Path :: native_path().
+%% @doc Indicates if the given path pattern can only match a specific tree
+%% node.
+%%
+%% In other words, the conditions the path pattern contains can only match a
+%% single specific tree node, even though it uses conditions, and that tree
+%% node path is known from the pattern. That characteristic does not depend on
+%% the content of the tree.
+%%
+%% @returns `{true, Path}' if the path pattern would match a specific tree node
+%% where `Path' is the path to that tree node, `false' otherwise.
 
 targets_specific_node(PathPattern) ->
     targets_specific_node(PathPattern, []).
@@ -542,47 +553,94 @@ targets_specific_node([], Path) ->
       ComponentPattern :: pattern_component(),
       Ret :: {true, Component} | false,
       Component :: component().
+%% @doc Indicates if the given path component pattern can only match a specific
+%% tree node.
+%%
+%% In other words, the conditions used by the pattern can only match a single
+%% specific tree node, even though it uses conditions, and that tree node name
+%% is known from the pattern. That characteristic does not depend on the
+%% content of the tree.
+%%
+%% @returns `{true, Component}' if the path component pattern would match a
+%% specific tree node where `Component' is name of that tree node, `false'
+%% otherwise.
+%%
 %% @private
 
-component_targets_specific_node(ChildName)
+component_targets_specific_node(ComponentPattern) ->
+    case component_targets_specific_siblings(ComponentPattern) of
+        {true, [Component]} -> {true, Component};
+        {true, _Siblings}   -> false;
+        false               -> false
+    end.
+
+-spec component_targets_specific_siblings(ComponentPattern) -> Ret when
+      ComponentPattern :: pattern_component(),
+      Ret :: {true, Components} | false,
+      Components :: [component()].
+%% @doc Indicates if the given path component pattern can only match specific
+%% tree nodes.
+%%
+%% In other words, the conditions used by the pattern can only match specific
+%% tree nodes, even though it uses conditions, and that these tree node names
+%% are known from the pattern. That characteristic does not depend on the
+%% content of the tree.
+%%
+%% @returns `{true, Component}' if the path component pattern would match a
+%% specific tree node where `Component' is name of that tree node, `false'
+%% otherwise.
+%%
+%% @private
+
+component_targets_specific_siblings(ChildName)
   when ?IS_KHEPRI_PATH_COMPONENT(ChildName) ->
-    {true, ChildName};
-component_targets_specific_node(#if_all{conditions = []}) ->
+    {true, [ChildName]};
+component_targets_specific_siblings(#if_all{conditions = []}) ->
     false;
-component_targets_specific_node(#if_all{conditions = Conds}) ->
+component_targets_specific_siblings(#if_all{conditions = Conds}) ->
     lists:foldl(
       fun
-          (Cond, {true, _} = True) ->
-              case component_targets_specific_node(Cond) of
-                  True      -> True;
-                  {true, _} -> false;
-                  false     -> True
+          (Cond, {true, Siblings1} = True) ->
+              case component_targets_specific_siblings(Cond) of
+                  True ->
+                      True;
+                  {true, Siblings2} ->
+                      Siblings3 = lists:usort(Siblings1 ++ Siblings2),
+                      {true, Siblings3};
+                  false ->
+                      True
               end;
           (Cond, false) ->
-              case component_targets_specific_node(Cond) of
-                  {true, _} = True -> True;
-                  false            -> false
+              case component_targets_specific_siblings(Cond) of
+                  {true, _} = True ->
+                      True;
+                  false ->
+                      false
               end;
           (Cond, undefined) ->
-              component_targets_specific_node(Cond)
+              component_targets_specific_siblings(Cond)
       end, undefined, Conds);
-component_targets_specific_node(#if_any{conditions = []}) ->
+component_targets_specific_siblings(#if_any{conditions = []}) ->
     false;
-component_targets_specific_node(#if_any{conditions = Conds}) ->
+component_targets_specific_siblings(#if_any{conditions = Conds}) ->
     lists:foldl(
       fun
-          (Cond, {true, _} = True) ->
-              case component_targets_specific_node(Cond) of
-                  True      -> True;
-                  {true, _} -> false;
-                  false     -> false
+          (Cond, {true, Siblings1} = True) ->
+              case component_targets_specific_siblings(Cond) of
+                  True ->
+                      True;
+                  {true, Siblings2} ->
+                      Siblings3 = lists:usort(Siblings1 ++ Siblings2),
+                      {true, Siblings3};
+                  false ->
+                      false
               end;
           (_, false) ->
               false;
           (Cond, undefined) ->
-              component_targets_specific_node(Cond)
+              component_targets_specific_siblings(Cond)
       end, undefined, Conds);
-component_targets_specific_node(_) ->
+component_targets_specific_siblings(_) ->
     false.
 
 -spec is_valid(PathPattern) -> IsValid when

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -1142,9 +1142,9 @@ walk_down_the_tree1(
     %% distinguish the case where the condition must be verified against the
     %% current node (i.e. the node name is ?KHEPRI_ROOT_NODE or
     %% ?THIS_KHEPRI_NODE in the condition) instead of its child nodes.
-    SpecificNode = khepri_path:component_targets_specific_node(Condition),
+    SpecificNode = khepri_path:component_targets_specific_siblings(Condition),
     case SpecificNode of
-        {true, NodeName}
+        {true, [NodeName]}
           when NodeName =:= ?KHEPRI_ROOT_NODE orelse
                NodeName =:= ?THIS_KHEPRI_NODE ->
             CurrentName = special_component_to_node_name(
@@ -1161,7 +1161,7 @@ walk_down_the_tree1(
                     Walk1 = Walk#walk{node = StartingNode},
                     {ok, Walk1}
             end;
-        {true, ?PARENT_KHEPRI_NODE} ->
+        {true, [?PARENT_KHEPRI_NODE]} ->
             %% TODO: Support calling Fun() with parent node based on
             %% conditions on child nodes.
             BadPathPattern =
@@ -1193,17 +1193,49 @@ walk_down_the_tree1(
             %% The result of the first part (the special case for the root
             %% node if relevant) is used as a starting point for handling all
             %% child nodes.
-            Ret1 = maps:fold(
-                     fun
-                         (ChildName, Child,
-                          {ok, Walk1}) ->
-                             Walk2 = Walk1#walk{path_pattern =
-                                                WholePathPattern,
-                                                reversed_path = ReversedPath},
-                             handle_branch(Walk2, ChildName, Child);
-                         (_, _, Error) ->
-                             Error
-                     end, Ret0, Children),
+            Ret1 = case SpecificNode of
+                       {true, Siblings} ->
+                           %% We know the list of siblings that the pattern can
+                           %% match. Therefore, start from this list to visit
+                           %% specific child tree nodes. This is more efficient
+                           %% than walking the entire children map.
+                           lists:foldl(
+                             fun
+                                 (ChildName,
+                                  {ok, Walk1} = Acc) ->
+                                     case Children of
+                                         #{ChildName := Child} ->
+                                             Walk2 = Walk1#walk{
+                                                       path_pattern =
+                                                       WholePathPattern,
+                                                       reversed_path =
+                                                       ReversedPath},
+                                             handle_branch(
+                                               Walk2, ChildName, Child);
+                                         _ ->
+                                             Acc
+                                     end;
+                                 (_, Error) ->
+                                     Error
+                             end, Ret0, Siblings);
+                       false ->
+                           %% We don't know which child tree nodes could match
+                           %% the pattern. Therefore, we have to walk through
+                           %% the entire children map.
+                           maps:fold(
+                             fun
+                                 (ChildName, Child,
+                                  {ok, Walk1}) ->
+                                     Walk2 = Walk1#walk{
+                                               path_pattern =
+                                               WholePathPattern,
+                                               reversed_path =
+                                               ReversedPath},
+                                     handle_branch(Walk2, ChildName, Child);
+                                 (_, _, Error) ->
+                                     Error
+                             end, Ret0, Children)
+                   end,
             case Ret1 of
                 {ok,
                  #walk{node = CurrentNode,

--- a/test/path_operations.erl
+++ b/test/path_operations.erl
@@ -513,6 +513,207 @@ complex_condition_targets_specific_node_test() ->
                                #if_child_list_version{version = 3},
                                #if_all{conditions = [foo]}]})).
 
+simple_component_targets_specific_siblings_test() ->
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(foo)),
+    ?assertEqual(
+       {true, [<<"foo">>]},
+       khepri_path:component_targets_specific_siblings(<<"foo">>)),
+    ?assertEqual(
+       {true, [?KHEPRI_ROOT_NODE]},
+       khepri_path:component_targets_specific_siblings(?KHEPRI_ROOT_NODE)),
+    ?assertEqual(
+       {true, [?THIS_KHEPRI_NODE]},
+       khepri_path:component_targets_specific_siblings(?THIS_KHEPRI_NODE)),
+    ?assertEqual(
+       {true, [?PARENT_KHEPRI_NODE]},
+       khepri_path:component_targets_specific_siblings(?PARENT_KHEPRI_NODE)),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(?KHEPRI_WILDCARD_STAR)),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         ?KHEPRI_WILDCARD_STAR_STAR)).
+
+pattern_component_targets_specific_siblings_test() ->
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_name_matches{regex = any})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_name_matches{regex = "a"})),
+    %% The regex matches a specific name but it could match an atom and a
+    %% binary. Anyway, the function doesn't parse the regex.
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_name_matches{regex = "^a$"})),
+
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_path_matches{regex = any})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_path_matches{regex = "a"})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_path_matches{regex = "^a$"})),
+
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_has_data{has_data = true})).
+
+if_not_condition_targets_specific_siblings_test() ->
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_not{condition = foo})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_not{condition = ?KHEPRI_WILDCARD_STAR})).
+
+if_all_condition_targets_specific_siblings_test() ->
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = []})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [foo]})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [foo,
+                               foo]})),
+    ?assertEqual(
+       {true, [bar, foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [foo,
+                               bar]})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [foo,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertEqual(
+       {true, [?KHEPRI_ROOT_NODE]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [?KHEPRI_ROOT_NODE,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertEqual(
+       {true, [?THIS_KHEPRI_NODE]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [?THIS_KHEPRI_NODE,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertEqual(
+       {true, [?PARENT_KHEPRI_NODE]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [?PARENT_KHEPRI_NODE,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [#if_name_matches{regex = "a"},
+                               foo,
+                               #if_child_list_version{version = 3}]})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [#if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3},
+                               foo]})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [foo,
+                               #if_name_matches{regex = "a"},
+                               foo,
+                               #if_child_list_version{version = 3},
+                               foo]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [#if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})).
+
+if_any_condition_targets_specific_siblings_test() ->
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = []})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [foo]})),
+    ?assertEqual(
+       {true, [foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [foo,
+                               foo]})),
+    ?assertEqual(
+       {true, [bar, foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [foo,
+                               bar]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [foo,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [?KHEPRI_ROOT_NODE,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [?THIS_KHEPRI_NODE,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [?PARENT_KHEPRI_NODE,
+                               #if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [#if_name_matches{regex = "a"},
+                               foo,
+                               #if_child_list_version{version = 3}]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [#if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3},
+                               foo]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [foo,
+                               #if_name_matches{regex = "a"},
+                               foo,
+                               #if_child_list_version{version = 3},
+                               foo]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [#if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3}]})).
+
+complex_condition_targets_specific_siblings_test() ->
+    ?assertEqual(
+       {true, [bar, foo]},
+       khepri_path:component_targets_specific_siblings(
+         #if_all{conditions = [#if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3},
+                               #if_any{conditions =
+                                       [foo,
+                                        #if_all{conditions = [bar]}]}]})),
+    ?assertNot(
+       khepri_path:component_targets_specific_siblings(
+         #if_any{conditions = [#if_name_matches{regex = "a"},
+                               #if_child_list_version{version = 3},
+                               #if_all{conditions =
+                                       [foo,
+                                        #if_all{conditions = [bar]}]}]})).
+
 path_targets_specific_node_test() ->
     ?assertEqual(
        {true, [foo, bar]},


### PR DESCRIPTION
## Why

Consider the following condition in a path pattern:

```erlang
#if_any{conditions = [foo, bar, baz]}
```

Or this more complex example:

```erlang
#if_any{conditions = [
    #if_all{conditions = [foo,
                          #if_data_matches{...}]},
    #if_all{conditions = [bar,
                          #if_data_matches{...}]},
    #if_all{conditions = [baz,
                          #if_data_matches{...}]}
  ]}
```

The pattern would only match the tree nodes names `foo`, `bar` or `baz`, regardless of the content of the tree.

So far, we walked through the entire list of child tree nodes when a component pattern could match more than one tree nodes, regardless if the pattern was specific or not. This was inefficient when a pattern such as the examples above was used on a very large list of child nodes.

## How

Now, we check if a complex pattern could still match a specific list of child tree nodes.

If this is the case, we only loop on this list of tree node names. Otherwise, we walk through the entire map as before. This improves the performance of commands that use such patterns.