### PR TITLE
khepri_machine: Define API behaviour mapping in macros

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1464,7 +1464,8 @@ handle_aux(leader, cast, tick, AuxState, IntState) ->
     %% a very large batch of transactions at once, so this expiration step was
     %% moved to the `tick' handler in version 2.
     case ra_aux:effective_machine_version(IntState) of
-        EffectiveMacVer when EffectiveMacVer >= 2 ->
+        EffectiveMacVer
+          when EffectiveMacVer >= ?API_BEHAV_MACVER(expire_dedups_from_tick) ->
             State = ra_aux:machine_state(IntState),
             Timestamp = erlang:system_time(millisecond),
             Dedups = get_dedups(State),
@@ -1716,7 +1717,7 @@ apply(
   State)
   when is_reference(CommandRef) andalso
        is_integer(Expiry) andalso
-       MacVer >= 1 ->
+       MacVer >= ?API_BEHAV_MACVER(dedup_protection) ->
     Dedups = get_dedups(State),
     case Dedups of
         #{CommandRef := {Reply, _Expiry}} ->
@@ -1733,7 +1734,7 @@ apply(
   #dedup_ack{ref = CommandRef},
   State)
   when is_reference(CommandRef) andalso
-       MacVer >= 1 ->
+       MacVer >= ?API_BEHAV_MACVER(dedup_protection) ->
     Dedups = get_dedups(State),
     State1 = case Dedups of
                  #{CommandRef := _} ->
@@ -1747,7 +1748,7 @@ apply(
 apply(
   #{machine_version := MacVer} = Meta,
   #drop_dedups{refs = RefsToDrop},
-  State) when MacVer >= 2 ->
+  State) when MacVer >= ?API_BEHAV_MACVER(expire_dedups_from_tick) ->
     %% `#drop_dedups{}' is emitted by the `handle_aux/5' clause for the `tick'
     %% effect to periodically drop dedups that have expired. This expiration
     %% was originally done in `post_apply/2' via `drop_expired_dedups/2' until
@@ -2056,17 +2057,16 @@ clear_cached_effective_machine_version(StoreId) ->
       Behaviour :: khepri_machine:api_behaviour(),
       Ret :: MacVer | undefined,
       MacVer :: 1..?LATEST_MACVER.
-%% @doc Returns the state machine version that implemented the given API behaviour.
+%% @doc Returns the state machine version that implemented the given API
+%% behaviour.
 %%
 %% If the behaviour is unknown to this implementation, `undefined' is returned.
 
-api_behaviour_to_machine_version(dedup_protection)                  -> 1;
-api_behaviour_to_machine_version(delete_reason_in_node_props)       -> 2;
-api_behaviour_to_machine_version(indirect_deletes_in_ret)           -> 2;
-api_behaviour_to_machine_version(uniform_write_ret)                 -> 2;
-api_behaviour_to_machine_version(multi_table_projections)           -> 3;
 api_behaviour_to_machine_version(Behaviour) when is_atom(Behaviour) ->
-    undefined.
+    case ?API_BEHAV_MACVER_MAP of
+        #{Behaviour := MacVer} -> MacVer;
+        _                      -> undefined
+    end.
 
 -spec does_api_comply_with(Behaviour, MacVer | StoreId) -> DoesUse when
       Behaviour :: khepri_machine:api_behaviour(),

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -2825,8 +2825,8 @@ make_virgin_state(Params) ->
 
 -spec convert_state(OldState, OldMacVer, NewMacVer) -> NewState when
       OldState :: khepri_machine:state(),
-      OldMacVer :: ra_machine:version(),
-      NewMacVer :: ra_machine:version(),
+      OldMacVer :: 0..?LATEST_MACVER,
+      NewMacVer :: 1..?LATEST_MACVER,
       NewState :: khepri_machine:state().
 %% @doc Converts a state to a newer version.
 %%
@@ -2839,6 +2839,15 @@ convert_state(State, OldMacVer, NewMacVer) ->
               NewMacVer1 = erlang:min(N + 1, NewMacVer),
               convert_state1(State1, OldMacVer1, NewMacVer1)
       end, State, lists:seq(OldMacVer, NewMacVer)).
+
+-spec convert_state1(OldState, OldMacVer, NewMacVer) -> NewState when
+      OldState :: khepri_machine:state(),
+      OldMacVer :: 0..?LATEST_MACVER,
+      NewMacVer :: 1..?LATEST_MACVER,
+      NewState :: khepri_machine:state().
+%% @doc Converts a state from one version to the next.
+%%
+%% @private
 
 convert_state1(State, MacVer, MacVer) ->
     State;

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1980,21 +1980,20 @@ overview(State) ->
       keep_while_conds => KeepWhileConds}.
 
 -spec version() -> MacVer when
-      MacVer :: 3.
+      MacVer :: ?LATEST_MACVER.
 %% @doc Returns the state machine version.
 
 version() ->
-    3.
+    ?LATEST_MACVER.
 
 -spec which_module(MacVer) -> Module when
-      MacVer :: 0..3,
+      MacVer :: 0..?LATEST_MACVER,
       Module :: ?MODULE.
 %% @doc Returns the state machine module corresponding to the given version.
 
-which_module(3) -> ?MODULE;
-which_module(2) -> ?MODULE;
-which_module(1) -> ?MODULE;
-which_module(0) -> ?MODULE.
+which_module(MacVer)
+  when MacVer >= 0 andalso MacVer =< ?LATEST_MACVER ->
+    ?MODULE.
 
 -define(
    PT_EFFECTIVE_MACVER(StoreId),
@@ -2056,7 +2055,7 @@ clear_cached_effective_machine_version(StoreId) ->
 -spec api_behaviour_to_machine_version(Behaviour) -> Ret when
       Behaviour :: khepri_machine:api_behaviour(),
       Ret :: MacVer | undefined,
-      MacVer :: 1..3.
+      MacVer :: 1..?LATEST_MACVER.
 %% @doc Returns the state machine version that implemented the given API behaviour.
 %%
 %% If the behaviour is unknown to this implementation, `undefined' is returned.

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -26,6 +26,23 @@
 %% function specs too.
 -define(LATEST_MACVER, 3).
 
+%% Map API behaviours with the state machine version they were introduced in.
+-define(API_BEHAV_MACVER_MAP,
+        #{dedup_protection            => 1,
+
+          delete_reason_in_node_props => 2,
+          expire_dedups_from_tick     => 2,
+          indirect_deletes_in_ret     => 2,
+          uniform_write_ret           => 2,
+
+          multi_table_projections     => 3}).
+
+%% Get the state machine version the given API behaviour was introduced in.
+%% This is similar to `khepri_machine:api_behaviour_to_machine_version/1' but
+%% can be used in guards.
+-define(API_BEHAV_MACVER(Behaviour),
+        map_get(Behaviour, ?API_BEHAV_MACVER_MAP)).
+
 %% State machine commands and aux. effects.
 
 -record(put, {path :: khepri_path:native_pattern(),

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -21,6 +21,11 @@
         {store_id :: khepri:store_id(),
          delayed_aux_queries = [] :: [khepri_machine:delayed_aux_query()]}).
 
+%% The current/latest version of the state machine is defined in this macro
+%% instead of `khepri_machine:version/0' only. This way, it can be used in
+%% function specs too.
+-define(LATEST_MACVER, 3).
+
 %% State machine commands and aux. effects.
 
 -record(put, {path :: khepri_path:native_pattern(),


### PR DESCRIPTION
## Why

This allows to use this information in guards.

## How

The mapping itself is defined in `?API_BEHAV_MACVER_MAP` as a regular map.

Then, `?API_BEHAV_MACVER(Behaviour)` can be used to fetch the machine version corresponding to the given behaviour. It uses `map_get/2` which is allowed in guards.

Here is an example:

```erlang
MacVer >= ?API_BEHAV_MACVER(my_behaviour)
```