### PR TITLE
Fix state machine crash when a path-condition trigger matches a deleted node

### DIFF
--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -801,22 +801,32 @@ does_path_match(
                                         payload_version,
                                         child_list_version,
                                         child_list_length]},
-    {ok, #{CurrentPath := Node}} = find_matching_nodes(
-                                     Tree,
-                                     lists:reverse([Component | ReversedPath]),
-                                     TreeOptions),
+    %% The node at `CurrentPath' may no longer exist — most commonly when
+    %% this trigger is being evaluated for the *deletion* of that very node.
+    %% `find_matching_nodes/3' then returns
+    %% `{error, {khepri, node_not_found, _}}'. A path condition that must
+    %% query an absent node cannot be met, so the path does not match.
+    %% (Previously this hard-matched `{ok, _} = ...' and crashed the state
+    %% machine; as the delete command is persisted, it then replayed and
+    %% crashed on every restart, making the store unrecoverable.)
+    case find_matching_nodes(Tree, CurrentPath, TreeOptions) of
+        {ok, #{CurrentPath := Node}} ->
+            does_matched_node_path_match(
+              Condition, Component, Node, Path, PathPattern, ReversedPath1, Tree);
+        _NodeAbsentOrError ->
+            false
+    end.
+
+does_matched_node_path_match(
+  Condition, Component, Node, Path, PathPattern, ReversedPath1, Tree) ->
     case khepri_condition:is_met(Condition, Component, Node) of
         true ->
-            ConditionMatchesGrandchildren =
-            case khepri_condition:applies_to_grandchildren(Condition) of
-                true ->
-                    does_path_match(
-                      Path, [Condition | PathPattern], ReversedPath1, Tree);
-                false ->
-                    false
-            end,
-            ConditionMatchesGrandchildren orelse
-              does_path_match(Path, PathPattern, ReversedPath1, Tree);
+            MatchesGrandchildren =
+                khepri_condition:applies_to_grandchildren(Condition)
+                andalso does_path_match(
+                          Path, [Condition | PathPattern], ReversedPath1, Tree),
+            MatchesGrandchildren orelse
+                does_path_match(Path, PathPattern, ReversedPath1, Tree);
         {false, _} ->
             false
     end.

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -442,6 +442,61 @@ filter_on_change_type_test_() ->
          ?_assertEqual(executed, receive_sproc_msg(DeletedKey))}]
       }]}.
 
+deleting_a_node_matched_by_a_path_condition_does_not_crash_test_() ->
+    %% Regression test: a trigger whose event-filter path pattern contains
+    %% a *condition* (here `#if_child_list_length{}`) at a non-terminal
+    %% position must not crash the state machine when the matching node is
+    %% deleted. While evaluating the trigger for the delete,
+    %% `khepri_tree:does_path_match/4` queried the just-deleted node and
+    %% hard-matched `{ok, _} = find_matching_nodes(...)`; the lookup returns
+    %% `{error, {khepri, node_not_found, _}}` for the gone node, so the
+    %% badmatch crashed the Khepri/Ra state machine. As the delete command
+    %% is persisted, it replayed on every restart, making the store
+    %% permanently unrecoverable.
+    EventFilter = khepri_evf:tree([foo, #if_child_list_length{count = 0}]),
+    StoredProcPath = [sproc],
+    Key = ?FUNCTION_NAME,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Storing a procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath,
+              make_sproc(self(), Key)))},
+
+        {"Registering a trigger with a path condition",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              StoredProcPath))},
+
+        {"Creating the matching node",
+         ?_assertMatch(
+            ok,
+            khepri:put(?FUNCTION_NAME, [foo, bar], value))},
+
+        {"Deleting the matching node must not crash the state machine",
+         ?_assertMatch(
+            ok,
+            khepri:delete(?FUNCTION_NAME, [foo, bar]))},
+
+        {"The store is still responsive after the delete-triggered eval",
+         ?_assertMatch(
+            ok,
+            khepri:put(?FUNCTION_NAME, [other], value))},
+
+        {"and reads still serve correctly",
+         ?_assertMatch(
+            {ok, value},
+            khepri:get(?FUNCTION_NAME, [other]))}]
+      }]}.
+
 a_buggy_sproc_does_not_crash_state_machine_test_() ->
     EventFilter = khepri_evf:tree([foo]),
     StoredProcPath = [sproc],


### PR DESCRIPTION
## Summary

A registered trigger whose event-filter path pattern contains a **condition**
(e.g. `#if_child_list_length{}`, `#if_data_matches{}`, a wildcard) at a
non-terminal position crashes the Khepri/Ra **state machine** when the matching
node is **deleted**. Because the offending `delete` command is persisted in the
Ra log, it is **replayed on every restart** and crashes again each time —
turning a transient delete into a **permanent, unrecoverable store outage**
(`ra_server_sup` → `reached_max_restart_intensity`).

## Root cause

To evaluate a path condition, `khepri_tree:does_path_match/4` looks up the tree
node at the current path:

```erlang
{ok, #{CurrentPath := Node}} = find_matching_nodes(
                                 Tree,
                                 lists:reverse([Component | ReversedPath]),
                                 TreeOptions),
```

When the trigger is evaluated for the **deletion** of that very node,
`find_matching_nodes/3` returns `{error, {khepri, node_not_found, _}}` for the
now-absent node. The hard `{ok, ...} =` match then fails with a `badmatch`,
crashing the state machine inside `ra_server_proc:handle_leader/2`.

Observed crash:

```
** State machine <store> terminating. Reason:
{badmatch,{error,{khepri,node_not_found,#{node_name => <<"...">>, ...}}}}
  khepri_tree:does_path_match/4        (khepri_tree.erl:804)
  khepri_machine:evaluate_trigger/6    (khepri_machine.erl)
  khepri_machine:add_trigger_side_effects/4
  khepri_machine:delete_matching_nodes/4
  ra_server_proc:handle_leader/2
```

Triggers with **literal-only** path patterns are unaffected — those are handled
by the literal-component clauses of `does_path_match/4` and never reach the node
lookup. That is why the existing delete-trigger tests (which use a literal path)
did not surface this.

## Fix

A path condition that must query a node which no longer exists cannot be met, so
the path simply does not match. `does_path_match/4` now returns `false` for the
absent-node / error case instead of badmatching. The post-lookup branch is
extracted into `does_matched_node_path_match/7`.

Behaviour change: a condition-bearing trigger no longer fires for the `delete`
of a matching node (the condition can't be evaluated against a node that is
gone). This matches the prior behaviour for any case where the condition no
longer holds, and is strictly preferable to crashing the state machine. Happy to
adjust if maintainers would rather evaluate the condition against the node's
pre-delete state.

## Test

`test/triggers.erl` gains
`deleting_a_node_matched_by_a_path_condition_does_not_crash_test_/0`, which
registers a trigger with a `#if_child_list_length{}` path condition, creates the
matching node, deletes it, and asserts the store remains responsive. Without the
fix this reproduces the `node_not_found` state-machine crash; with it the suite
is green (`80 tests, 0 failures`).

## How it was found

reckon-db's retention/scavenge deletes event streams that still have active
subscription triggers registered, which deterministically hit this path in
production.
