### PR TITLE
khepri_tree: Don't crash in does_path_match when the matched node is absent

### DIFF
--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -899,22 +899,29 @@ does_path_match(
                                         payload_version,
                                         child_list_version,
                                         child_list_length]},
-    {ok, #{CurrentPath := Node}} = find_matching_nodes(
-                                     Tree,
-                                     lists:reverse([Component | ReversedPath]),
-                                     TreeOptions),
+    case find_matching_nodes(Tree, CurrentPath, TreeOptions) of
+        {ok, #{CurrentPath := Node}} ->
+            does_path_match_condition(
+              Component, Path, Condition, PathPattern, ReversedPath1, Tree,
+              Node);
+        {error, ?khepri_error(node_not_found, _)} ->
+            false
+    end.
+
+does_path_match_condition(
+  Component, Path, Condition, PathPattern, ReversedPath, Tree, Node) ->
     case khepri_condition:is_met(Condition, Component, Node) of
         true ->
             ConditionMatchesGrandchildren =
             case khepri_condition:applies_to_grandchildren(Condition) of
                 true ->
                     does_path_match(
-                      Path, [Condition | PathPattern], ReversedPath1, Tree);
+                      Path, [Condition | PathPattern], ReversedPath, Tree);
                 false ->
                     false
             end,
             ConditionMatchesGrandchildren orelse
-              does_path_match(Path, PathPattern, ReversedPath1, Tree);
+              does_path_match(Path, PathPattern, ReversedPath, Tree);
         {false, _} ->
             false
     end.

--- a/test/pattern_tree.erl
+++ b/test/pattern_tree.erl
@@ -128,6 +128,28 @@ fold_finds_all_patterns_matching_a_path_test() ->
       MatchingIndices([])),
     ok.
 
+does_path_match_tolerates_an_absent_node_test() ->
+    %% `does_path_match/3' must not crash when the matched path refers to a
+    %% node that is absent from the tree (e.g. matching the path of a node
+    %% that no longer exists). A path condition that has to query the
+    %% missing node cannot be met, so the path does not match.
+    %%
+    %% Previously the condition clause hard-matched
+    %% `{ok, _} = find_matching_nodes(...)'; for an absent node that lookup
+    %% returns `{error, {khepri, node_not_found, _}}', so the badmatch
+    %% crashed the caller. When the caller is the `khepri_machine' command
+    %% apply loop, the badmatch aborts (and is persisted in) the command,
+    %% so it replays on every restart.
+    TreePayload = #p_data{data = 1},
+    {ok, Tree, _, _} = khepri_tree:insert_or_update_node(
+                         khepri_tree:new(), [foo], TreePayload, #{}, #{}),
+    %% [foo, bar] is not in the tree; the condition at `bar''s position
+    %% forces a lookup of the absent node.
+    ?assertEqual(
+       false,
+       khepri_tree:does_path_match(
+         [foo, bar], [foo, #if_child_list_length{count = 0}], Tree)).
+
 %% Helper functions.
 
 -spec put_new(PatternTree, PathPattern, Payload) -> Ret when


### PR DESCRIPTION
## Summary

Defensive hardening of `khepri_tree:does_path_match/4` so it can never crash on
an absent node.

The path-condition clause queries the tree node at the current path to evaluate
the condition:

```erlang
{ok, #{CurrentPath := Node}} = find_matching_nodes(Tree, ..., TreeOptions),
```

If the matched path refers to a node that is **absent** from the tree,
`find_matching_nodes/3` returns `{error, {khepri, node_not_found, _}}` and the
`{ok, _} =` badmatch crashes the caller. This is especially severe when the
caller is the `khepri_machine` command apply loop: the badmatch aborts (and is
persisted with) the command, so it **replays and crashes the state machine on
every restart**, leaving the store unrecoverable.

## Relationship to 183a566

`183a566` ("khepri_machine: Use initial tree to list sprocs triggered by
deletions") already fixed the **known** way to reach this — deletion triggers
now evaluate against the pre-delete tree, where the node still exists.

This PR is complementary defense-in-depth: it makes `does_path_match/4` itself
total with respect to an absent node, so no current or future caller can
badmatch it into a persisted crash. A path condition that must query a node
which no longer exists cannot be met, so the path simply does not match (return
`false`). The post-lookup branch is extracted into `does_path_match_condition/7`
with no change to the matching logic.

Entirely reasonable to decline if you'd rather keep the assertion and rely on
callers always passing a tree in which the node exists.

## Test

`test/pattern_tree.erl` gains a direct `does_path_match/3` unit test that matches
a path absent from the tree using a path condition. Without this change it
reproduces the `node_not_found` badmatch; with it, `does_path_match/3` returns
`false`. `pattern_tree` 5/0, `triggers` 82/0 (incl. the 183a566 test), `xref`
clean.

## Background

Found in production: an event store built on Khepri/Ra scavenged (deleted)
streams that still had subscription triggers with path conditions registered,
hit this badmatch inside the state machine, and the persisted delete replayed
and bricked the store on every restart.
