### PR TITLE
khepri_machine: propagate process_command/process_query errors from transactions

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -242,6 +242,16 @@
 -type tx_ret() :: khepri:ok(khepri_tx:tx_fun_result()) |
                   khepri_tx:tx_abort() |
                   no_return().
+%% Return value of a transaction.
+%%
+%% A successful transaction returns `{ok, Result}'. A failure is reported as a
+%% bare `{error, Reason}' tuple, never wrapped in `{ok, _}'. This covers both
+%% an aborted transaction (see {@link khepri_tx:abort/1}) and an infrastructure
+%% error surfaced while dispatching the transaction (for example `{error,
+%% noproc}' or `{error, timeout}' when the store is not running). This matches
+%% how {@link khepri:handle_async_ret/2} propagates the same errors for
+%% asynchronous transactions. To return an error-shaped value as a successful
+%% result, wrap it explicitly, e.g. `{ok, {error, Reason}}'.
 
 -type async_ret() :: ok.
 
@@ -541,6 +551,8 @@ readonly_transaction(StoreId, Fun, Args, Options)
     case process_query(StoreId, Query, Options) of
         {exception, _, _, _} = Exception ->
             handle_tx_exception(Exception);
+        {error, _} = Error ->
+            Error;
         Ret ->
             {ok, Ret}
     end;
@@ -559,6 +571,8 @@ readonly_transaction(StoreId, PathPattern, Args, Options)
     case process_query(StoreId, Query, Options) of
         {exception, _, _, _} = Exception ->
             handle_tx_exception(Exception);
+        {error, _} = Error ->
+            Error;
         Ret ->
             {ok, Ret}
     end.

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -591,6 +591,8 @@ readwrite_transaction1(StoreId, StandaloneFunOrPath, Args, Options) ->
     case process_command(StoreId, Command, Options1) of
         {exception, _, _, _} = Exception ->
             handle_tx_exception(Exception);
+        {error, _} = Error ->
+            Error;
         ok = Ret ->
             CommandType = select_command_type(Options),
             case CommandType of

--- a/test/simple_tx_misc.erl
+++ b/test/simple_tx_misc.erl
@@ -696,3 +696,19 @@ tx_using_erl_eval_test_() ->
                fun local_fun_using_erl_eval/0,
                rw)
          end)]}.
+
+readwrite_transaction_propagates_infra_error_test() ->
+    %% When the store is not running, `process_command/3' returns an
+    %% infrastructure error such as `{error, noproc}'.
+    %% `readwrite_transaction1/3' must propagate that error tuple directly
+    %% instead of wrapping it as `{ok, {error, noproc}}'; a caller matching
+    %% on `{ok, Value}' would otherwise mistake the error for a successful
+    %% transaction result and crash downstream.
+    %%
+    %% A path-pattern transaction is used so the command reaches
+    %% `process_command/3' without going through stand-alone function
+    %% extraction. `?FUNCTION_NAME' is a store ID that is never started, so
+    %% the command cannot reach a Ra server.
+    ?assertEqual(
+       {error, noproc},
+       khepri:transaction(?FUNCTION_NAME, [foo], [], rw)).

--- a/test/simple_tx_misc.erl
+++ b/test/simple_tx_misc.erl
@@ -712,3 +712,15 @@ readwrite_transaction_propagates_infra_error_test() ->
     ?assertEqual(
        {error, noproc},
        khepri:transaction(?FUNCTION_NAME, [foo], [], rw)).
+
+readonly_transaction_propagates_infra_error_test() ->
+    %% Same expectation as the read-write case, but for a read-only
+    %% transaction going through `process_query/3'. The infrastructure error
+    %% must be propagated verbatim rather than wrapped as
+    %% `{ok, {error, noproc}}'.
+    %%
+    %% `?FUNCTION_NAME' is a store ID that is never started, so the query
+    %% cannot reach a Ra server.
+    ?assertEqual(
+       {error, noproc},
+       khepri:transaction(?FUNCTION_NAME, [foo], [], ro)).


### PR DESCRIPTION
## Problem

The sync transaction paths in `khepri_machine` wrapped every non-exception result with `{ok, Ret}` via a catch-all clause. When `process_command/3` (read-write) or `process_query/3` (read-only) returned an infrastructure error such as `{error, noproc}` (store not running) or `{error, timeout}`, the catch-all turned it into `{ok, {error, Reason}}`.

A caller matching on `{ok, Value}` then received an error tuple as the transaction result, mistaking a dispatch failure for a successful transaction and crashing downstream.

## Fix

Add an explicit `{error, _} = Error -> Error` clause before the catch-all in:

- `readwrite_transaction1/3`
- both `readonly_transaction/4` clauses (function and path-pattern)

so infrastructure errors propagate verbatim.

This aligns sync transactions with the convention already used by `khepri:handle_async_ret/2`, which propagates `{error, _}` directly and raises only `{exception, _, _, _}`. `tx_ret()` already includes `{error, Reason}` via `tx_abort()`, so the public return shape is unchanged. `tx_ret()` is documented accordingly.

## Tests

Regression tests for both the read-write and read-only paths, issuing a path-pattern transaction against a store that is never started so the command/query reaches `process_command/3` / `process_query/3` and returns `{error, noproc}`. Each test fails without the corresponding `{error, _}` clause (producing `{ok, {error, noproc}}`) and passes with it.

## Note for reviewers

A transaction body that *returns* a bare `{error, Reason}` value (rather than aborting) now surfaces as `{error, Reason}` instead of `{ok, {error, Reason}}`. This is consistent with how `handle_async_ret/2` already treats asynchronous transactions and with `tx_abort()`. To return an error-shaped value as a successful result, wrap it explicitly (`{ok, {error, Reason}}`); this is documented on `tx_ret()`.
