### PR TITLE
Allow configuring `props_to_return` in sprocs

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -523,6 +523,8 @@
               favor_option/0,
               query_options/0,
               tree_options/0,
+              known_prop_to_return/0,
+              unknown_prop_to_return/0,
               put_options/0,
 
               fold_fun/0,
@@ -2913,9 +2915,29 @@ register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
 %%
 %% ```
 %% my_stored_procedure(Props) ->
-%%     #{path := Path},
-%%       on_action => Action} = Props.
+%%     #{path := Path,
+%%       on_action := Action} = Props.
 %% '''
+%%
+%% The properties map always contains the following keys:
+%% <ul>
+%% <li>`path': the path to the tree node which changed and triggered the
+%% stored procedure.</li>
+%% <li>`on_action': the type of change, one of `create', `update' or
+%% `delete'.</li>
+%% </ul>
+%%
+%% In addition, the properties of the changed tree node can be included, as
+%% configured by the `props_to_return' key of the tree event filter (see
+%% {@link khepri_evf:tree_event_filter_props()}). By default this is `[]', so
+%% no node properties are included. Set it to `[payload]' to receive a `data'
+%% key when the changed tree node holds a data payload. For `create' and
+%% `update' actions, this is the new payload. For the `delete' action, this is
+%% the payload as it was just before the deletion.
+%%
+%% Including the changed tree node's properties requires an effective machine
+%% version of 4 or more. With older machine versions, only `path' and
+%% `on_action' are passed.
 %%
 %% The stored procedure is executed on the leader's Erlang node.
 %%

--- a/src/khepri_evf.erl
+++ b/src/khepri_evf.erl
@@ -23,8 +23,11 @@
 %%
 %% It takes a path pattern to monitor and optionally properties.
 
--type tree_event_filter_props() :: #{on_actions => [create | update | delete],
-                                     priority => khepri_evf:priority()}.
+-type tree_event_filter_props() ::
+        #{on_actions => [create | update | delete],
+          priority => khepri_evf:priority(),
+          props_to_return => [khepri:known_prop_to_return() |
+                              khepri:unknown_prop_to_return()]}.
 %% Tree event filter properties.
 %%
 %% The properties are:
@@ -32,6 +35,13 @@
 %% <li>`on_actions': a list of actions to filter among `create', `update' and
 %% `delete'; the default is to react to all of them.</li>
 %% <li>`priority': a {@link priority()}</li>
+%% <li>`props_to_return': the list of properties of the changed tree node to
+%% include in the properties map passed to the triggered stored procedure. It
+%% works like the `props_to_return' option of {@link khepri:tree_options()}.
+%% The default is `[]', meaning no tree node properties are included; set it to
+%% e.g. `[payload]' to receive the `data' key for tree nodes holding data.
+%% This requires an effective machine version of 4 or more; with older machine
+%% versions, no tree node properties are included.</li>
 %% </ul>
 %%
 %% A Khepri path, whether it is a native path or a Unix-like path, can be used

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -66,6 +66,18 @@
 %% </ul>
 %% </td>
 %% </tr>
+%% <tr>
+%% <td style="text-align: right; vertical-align: top;">4</td>
+%% <td>
+%% <ul>
+%% <li>Tree node properties of the changed tree node are now included in the
+%% properties map passed to triggered stored procedures. The properties to
+%% include can be configured per-trigger using the `props_to_return' key of
+%% the tree event filter (see {@link khepri_evf:tree_event_filter_props()}).
+%% </li>
+%% </ul>
+%% </td>
+%% </tr>
 %% </table>
 
 -module(khepri_machine).
@@ -113,8 +125,8 @@
          split_query_options/2,
          split_command_options/2,
          split_put_options/1,
-         insert_or_update_node/6,
-         delete_matching_nodes/4,
+         insert_or_update_node/7,
+         delete_matching_nodes/5,
          handle_tx_exception/1,
          process_query/3,
          process_command/3,
@@ -1577,18 +1589,18 @@ restore_projection(Projection, Tree, PathPattern) ->
 %% @private
 
 apply(
-  Meta,
+  #{machine_version := MacVer} = Meta,
   #put{path = PathPattern, payload = Payload, options = TreeAndPutOptions},
   State) ->
     {TreeOptions, PutOptions} = split_put_options(TreeAndPutOptions),
     Ret = insert_or_update_node(
-            State, PathPattern, Payload, PutOptions, TreeOptions, []),
+            State, PathPattern, Payload, PutOptions, TreeOptions, MacVer, []),
     post_apply(Ret, Meta);
 apply(
-  Meta,
+  #{machine_version := MacVer} = Meta,
   #delete{path = PathPattern, options = TreeOptions},
   State) ->
-    Ret = delete_matching_nodes(State, PathPattern, TreeOptions, []),
+    Ret = delete_matching_nodes(State, PathPattern, TreeOptions, MacVer, []),
     post_apply(Ret, Meta);
 apply(
   Meta,
@@ -2210,20 +2222,23 @@ failed_to_locate_sproc(Reason) ->
     khepri_tx:abort(Reason).
 
 -spec insert_or_update_node(
-    State, PathPattern, Payload, PutOptions, TreeOptions, SideEffects) ->
+    State, PathPattern, Payload, PutOptions, TreeOptions, MacVer,
+    SideEffects) ->
     Ret when
       State :: state(),
       PathPattern :: khepri_path:native_pattern(),
       Payload :: khepri_payload:payload(),
       PutOptions :: khepri:put_options(),
       TreeOptions :: khepri:tree_options(),
+      MacVer :: ra_machine:version(),
       SideEffects :: ra_machine:effects(),
       Ret :: {State, Result, ra_machine:effects()},
       Result :: khepri_machine:write_ret().
 %% @private
 
 insert_or_update_node(
-  State, PathPattern, Payload, PutOptions, TreeOptions, SideEffects) ->
+  State, PathPattern, Payload, PutOptions, TreeOptions, MacVer,
+  SideEffects) ->
     Tree = get_tree(State),
     Ret1 = khepri_tree:insert_or_update_node(
              Tree, PathPattern, Payload, PutOptions, TreeOptions),
@@ -2231,24 +2246,26 @@ insert_or_update_node(
         {ok, Tree1, AppliedChanges, Ret2} ->
             State1 = set_tree(State, Tree1),
             {State2, SideEffects1} = add_tree_change_side_effects(
-                                       State, State1, AppliedChanges,
+                                       State, State1, AppliedChanges, MacVer,
                                        SideEffects),
             {State2, {ok, Ret2}, SideEffects1};
         Error ->
             {State, Error, SideEffects}
     end.
 
--spec delete_matching_nodes(State, PathPattern, TreeOptions, SideEffects) ->
+-spec delete_matching_nodes(
+    State, PathPattern, TreeOptions, MacVer, SideEffects) ->
     Ret when
       State :: state(),
       PathPattern :: khepri_path:native_pattern(),
       TreeOptions :: khepri:tree_options(),
+      MacVer :: ra_machine:version(),
       SideEffects :: ra_machine:effects(),
       Ret :: {State, Result, ra_machine:effects()},
       Result :: khepri_machine:write_ret().
 %% @private
 
-delete_matching_nodes(State, PathPattern, TreeOptions, SideEffects) ->
+delete_matching_nodes(State, PathPattern, TreeOptions, MacVer, SideEffects) ->
     Tree = get_tree(State),
     Ret = khepri_tree:delete_matching_nodes(
             Tree, PathPattern, #{}, TreeOptions),
@@ -2256,7 +2273,7 @@ delete_matching_nodes(State, PathPattern, TreeOptions, SideEffects) ->
         {ok, Tree1, AppliedChanges, Ret2} ->
             State1 = set_tree(State, Tree1),
             {State2, SideEffects1} = add_tree_change_side_effects(
-                                       State, State1, AppliedChanges,
+                                       State, State1, AppliedChanges, MacVer,
                                        SideEffects),
             {State2, {ok, Ret2}, SideEffects1};
         Error ->
@@ -2264,7 +2281,7 @@ delete_matching_nodes(State, PathPattern, TreeOptions, SideEffects) ->
     end.
 
 add_tree_change_side_effects(
-  InitialState, NewState, AppliedChanges, SideEffects) ->
+  InitialState, NewState, AppliedChanges, MacVer, SideEffects) ->
     %% We make a map where for each affected tree node, we indicate the type
     %% of change.
     Changes = maps:map(
@@ -2278,7 +2295,7 @@ add_tree_change_side_effects(
     NewSideEffects = create_projection_side_effects(
                        InitialState, NewState, Changes),
     {NewState1, NewSideEffects1} = add_trigger_side_effects(
-                                     InitialState, NewState, Changes,
+                                     InitialState, NewState, Changes, MacVer,
                                      NewSideEffects),
     SideEffects1 = lists:reverse(NewSideEffects1, SideEffects),
     {NewState1, SideEffects1}.
@@ -2359,7 +2376,7 @@ evaluate_projection(
     Effect = {aux, Trigger},
     [Effect | Effects].
 
-add_trigger_side_effects(InitialState, NewState, Changes, SideEffects) ->
+add_trigger_side_effects(InitialState, NewState, Changes, MacVer, SideEffects) ->
     %% We want to consider the new state (with the updated tree), but we want
     %% to use triggers from the initial state, in case they were updated too.
     %% In other words, we want to evaluate triggers in the state they were at
@@ -2374,7 +2391,8 @@ add_trigger_side_effects(InitialState, NewState, Changes, SideEffects) ->
             InitialTree = get_tree(InitialState),
             NewTree = get_tree(NewState),
             TriggeredStoredProcs = list_triggered_sprocs(
-                                     InitialTree, NewTree, Changes, Triggers),
+                                     InitialTree, NewTree, Changes, Triggers,
+                                     MacVer),
 
             %% We record the list of triggered stored procedures in the state
             %% machine's state. This is used to guaranty at-least-once
@@ -2397,7 +2415,7 @@ add_trigger_side_effects(InitialState, NewState, Changes, SideEffects) ->
             {NewState1, [SideEffect | SideEffects]}
     end.
 
-list_triggered_sprocs(InitialTree, NewTree, Changes, Triggers) ->
+list_triggered_sprocs(InitialTree, NewTree, Changes, Triggers, MacVer) ->
     TriggeredStoredProcs =
     maps:fold(
       fun(Path, Change, TSP) ->
@@ -2411,7 +2429,8 @@ list_triggered_sprocs(InitialTree, NewTree, Changes, Triggers) ->
               maps:fold(
                 fun(TriggerId, TriggerProps, TSP1) ->
                         evaluate_trigger(
-                          Tree, Path, Change, TriggerId, TriggerProps, TSP1)
+                          Tree, Path, Change, TriggerId, TriggerProps, MacVer,
+                          TSP1)
                 end, TSP, Triggers)
       end, [], Changes),
     sort_triggered_sprocs(TriggeredStoredProcs).
@@ -2421,6 +2440,7 @@ evaluate_trigger(
   #{sproc := StoredProcPath,
     event_filter := #evf_tree{path = PathPattern,
                               props = EventFilterProps} = EventFilter},
+  MacVer,
   TriggeredStoredProcs) ->
     %% For each trigger based on a tree event:
     %%   1. we verify the path of the changed tree node matches the monitored
@@ -2455,8 +2475,21 @@ evaluate_trigger(
                 StoredProc ->
                     %% TODO: Use a record to format
                     %% stored procedure arguments?
-                    EventProps = #{path => Path,
-                                   on_action => Change},
+                    %%
+                    %% We include the properties of the changed tree node in
+                    %% the event properties. For `create' and `update', `Tree'
+                    %% is the new tree, so these are the new node properties.
+                    %% For `delete', `Tree' is the initial tree, so these are
+                    %% the properties as they were just before the deletion.
+                    %% The list of properties to include is taken from the
+                    %% event filter's `props_to_return' (empty by default,
+                    %% meaning no node properties are included unless the
+                    %% trigger opts in, e.g. with `[payload]' to get the
+                    %% `data' key for nodes holding data).
+                    NodeProps = changed_node_props(
+                                  Tree, Path, EventFilterProps, MacVer),
+                    EventProps = NodeProps#{path => Path,
+                                            on_action => Change},
                     Triggered = #triggered{
                                    id = TriggerId,
                                    event_filter = EventFilter,
@@ -2468,7 +2501,8 @@ evaluate_trigger(
             TriggeredStoredProcs
     end;
 evaluate_trigger(
-  _Root, _Path, _Change, _TriggerId, _TriggerProps, TriggeredStoredProcs) ->
+  _Root, _Path, _Change, _TriggerId, _TriggerProps, _MacVer,
+  TriggeredStoredProcs) ->
     TriggeredStoredProcs.
 
 find_stored_proc(Tree, StoredProcPath) ->
@@ -2484,6 +2518,23 @@ find_stored_proc(Tree, StoredProcPath) ->
     case Ret of
         {ok, #{StoredProcPath := #{sproc := StoredProc}}} -> StoredProc;
         _                                                 -> undefined
+    end.
+
+changed_node_props(Tree, Path, EventFilterProps, MacVer) ->
+    case does_api_comply_with(node_props_in_trigger_props, MacVer) of
+        true ->
+            PropsToReturn = maps:get(
+                              props_to_return, EventFilterProps,
+                              ?DEFAULT_TRIGGER_PROPS_TO_RETURN),
+            TreeOptions = #{expect_specific_node => true,
+                            props_to_return => PropsToReturn},
+            Ret = khepri_tree:find_matching_nodes(Tree, Path, TreeOptions),
+            case Ret of
+                {ok, #{Path := NodeProps}} -> NodeProps;
+                _                          -> #{}
+            end;
+        false ->
+            #{}
     end.
 
 sort_triggered_sprocs(TriggeredStoredProcs) ->
@@ -2865,6 +2916,8 @@ convert_state1(State, 1, 2) ->
     Tree1 = khepri_tree:convert_tree(Tree, 1, 2),
     set_tree(State, Tree1);
 convert_state1(State, 2, 3) ->
+    State;
+convert_state1(State, 3, 4) ->
     State.
 
 -spec update_projections(OldState, NewState) -> ok when

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -24,7 +24,7 @@
 %% The current/latest version of the state machine is defined in this macro
 %% instead of `khepri_machine:version/0' only. This way, it can be used in
 %% function specs too.
--define(LATEST_MACVER, 3).
+-define(LATEST_MACVER, 4).
 
 %% Map API behaviours with the state machine version they were introduced in.
 -define(API_BEHAV_MACVER_MAP,
@@ -35,7 +35,9 @@
           indirect_deletes_in_ret     => 2,
           uniform_write_ret           => 2,
 
-          multi_table_projections     => 3}).
+          multi_table_projections     => 3,
+
+          node_props_in_trigger_props => 4}).
 
 %% Get the state machine version the given API behaviour was introduced in.
 %% This is similar to `khepri_machine:api_behaviour_to_machine_version/1' but

--- a/src/khepri_node.hrl
+++ b/src/khepri_node.hrl
@@ -19,6 +19,15 @@
                                   payload_version,
                                   delete_reason]).
 
+%% Default list of properties included in the event properties passed to a
+%% triggered stored procedure when the trigger's event filter doesn't specify
+%% its own `props_to_return'.
+%%
+%% This is empty by default: including the changed tree node's properties is
+%% opt-in and must be requested explicitly through the event filter's
+%% `props_to_return'.
+-define(DEFAULT_TRIGGER_PROPS_TO_RETURN, []).
+
 -record(node, {props = ?INIT_NODE_PROPS :: khepri_machine:props(),
                payload = ?NO_PAYLOAD :: khepri_payload:payload(),
                child_nodes = #{} :: #{khepri_path:component() := #node{}}}).

--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -232,10 +232,11 @@ put_many(PathPattern, Data, Options) ->
     khepri_machine:split_put_options(TreeAndPutOptions),
     TreeOptions1 = maybe_return_indirect_deletes(TreeOptions),
     %% TODO: Ensure `CommandOptions' is unset.
+    MacVer = get_tx_effective_machine_version(),
     Fun = fun(State1, SideEffects) ->
                   khepri_machine:insert_or_update_node(
                     State1, PathPattern1, Payload1, PutOptions, TreeOptions1,
-                    SideEffects)
+                    MacVer, SideEffects)
           end,
     handle_state_for_call(Fun).
 
@@ -429,9 +430,10 @@ delete_many(PathPattern, Options) ->
     TreeOptions1 = maybe_return_indirect_deletes(TreeOptions),
     %% TODO: Ensure `CommandOptions' is empty and `TreeOptions' doesn't
     %% contains put options.
+    MacVer = get_tx_effective_machine_version(),
     Fun = fun(State1, SideEffects) ->
                   khepri_machine:delete_matching_nodes(
-                    State1, PathPattern1, TreeOptions1, SideEffects)
+                    State1, PathPattern1, TreeOptions1, MacVer, SideEffects)
           end,
     handle_state_for_call(Fun).
 

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -442,6 +442,263 @@ filter_on_change_type_test_() ->
          ?_assertEqual(executed, receive_sproc_msg(DeletedKey))}]
       }]}.
 
+data_payload_is_passed_to_sproc_test_() ->
+    CreatedEventFilter = khepri_evf:tree(
+                           [foo], #{on_actions => [create],
+                                    props_to_return => [payload]}),
+    UpdatedEventFilter = khepri_evf:tree(
+                           [foo], #{on_actions => [update],
+                                    props_to_return => [payload]}),
+    DeletedEventFilter = khepri_evf:tree(
+                           [foo], #{on_actions => [delete],
+                                    props_to_return => [payload]}),
+    StoredProcPath = [sproc],
+    CreatedKey = {?FUNCTION_NAME, created},
+    UpdatedKey = {?FUNCTION_NAME, updated},
+    DeletedKey = {?FUNCTION_NAME, deleted},
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Storing a procedure for `created` change",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath ++ [created],
+              make_sproc_returning_props(self(), CreatedKey)))},
+
+        {"Storing a procedure for `updated` change",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath ++ [updated],
+              make_sproc_returning_props(self(), UpdatedKey)))},
+
+        {"Storing a procedure for `deleted` change",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath ++ [deleted],
+              make_sproc_returning_props(self(), DeletedKey)))},
+
+        {"Registering a `created` trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              created,
+              CreatedEventFilter,
+              StoredProcPath ++ [created]))},
+
+        {"Registering an `updated` trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              updated,
+              UpdatedEventFilter,
+              StoredProcPath ++ [updated]))},
+
+        {"Registering a `deleted` trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              deleted,
+              DeletedEventFilter,
+              StoredProcPath ++ [deleted]))},
+
+        {"Creating a node; the new payload should be passed",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, [foo], value1))},
+
+        {"Checking the `created` procedure received the new payload",
+         ?_assertEqual(
+            #{path => [foo], on_action => create, data => value1},
+            receive_sproc_msg_with_props(CreatedKey))},
+
+        {"Updating a node; the new payload should be passed",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, [foo], value2))},
+
+        {"Checking the `updated` procedure received the new payload",
+         ?_assertEqual(
+            #{path => [foo], on_action => update, data => value2},
+            receive_sproc_msg_with_props(UpdatedKey))},
+
+        {"Deleting a node; the payload before deletion should be passed",
+         ?_assertMatch(
+            ok,
+            khepri:delete(
+              ?FUNCTION_NAME, [foo]))},
+
+        {"Checking the `deleted` procedure received the old payload",
+         ?_assertEqual(
+            #{path => [foo], on_action => delete, data => value2},
+            receive_sproc_msg_with_props(DeletedKey))}]
+      }]}.
+
+no_data_key_when_node_has_no_payload_test_() ->
+    %% The trigger requests the payload but matches the intermediate node
+    %% `[foo]' which is created without a payload as a byproduct of creating
+    %% `[foo, bar]'. The `data' key is therefore absent.
+    EventFilter = khepri_evf:tree([foo], #{props_to_return => [payload]}),
+    StoredProcPath = [sproc],
+    Key = ?FUNCTION_NAME,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Storing a procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath,
+              make_sproc_returning_props(self(), Key)))},
+
+        {"Registering a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              StoredProcPath))},
+
+        {"Creating a node with a payload-less parent",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, [foo, bar], value))},
+
+        {"Checking the props don't contain a `data` key",
+         ?_assertEqual(
+            #{path => [foo], on_action => create},
+            receive_sproc_msg_with_props(Key))}]
+      }]}.
+
+props_to_return_in_event_filter_test_() ->
+    %% The event filter requests extra node properties to be passed to the
+    %% triggered stored procedure.
+    EventFilter = khepri_evf:tree(
+                    [foo],
+                    #{props_to_return => [payload, payload_version,
+                                          child_list_length]}),
+    StoredProcPath = [sproc],
+    Key = ?FUNCTION_NAME,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Storing a procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath,
+              make_sproc_returning_props(self(), Key)))},
+
+        {"Registering a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              StoredProcPath))},
+
+        {"Creating a node",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, [foo], value))},
+
+        {"Checking the props contain the requested node properties",
+         ?_assertEqual(
+            #{path => [foo], on_action => create, data => value,
+              payload_version => 1, child_list_length => 0},
+            receive_sproc_msg_with_props(Key))}]
+      }]}.
+
+empty_props_to_return_in_event_filter_test_() ->
+    %% An empty `props_to_return' yields only `path' and `on_action'.
+    EventFilter = khepri_evf:tree([foo], #{props_to_return => []}),
+    StoredProcPath = [sproc],
+    Key = ?FUNCTION_NAME,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Storing a procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath,
+              make_sproc_returning_props(self(), Key)))},
+
+        {"Registering a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              StoredProcPath))},
+
+        {"Creating a node",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, [foo], value))},
+
+        {"Checking the props only contain `path` and `on_action`",
+         ?_assertEqual(
+            #{path => [foo], on_action => create},
+            receive_sproc_msg_with_props(Key))}]
+      }]}.
+
+default_passes_only_path_and_on_action_test_() ->
+    %% By default (no `props_to_return' in the event filter), no node
+    %% properties are included: the feature is opt-in.
+    EventFilter = khepri_evf:tree([foo]),
+    StoredProcPath = [sproc],
+    Key = ?FUNCTION_NAME,
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Storing a procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath,
+              make_sproc_returning_props(self(), Key)))},
+
+        {"Registering a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              StoredProcPath))},
+
+        {"Creating a node with a payload",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, [foo], value))},
+
+        {"Checking the props only contain `path` and `on_action`",
+         ?_assertEqual(
+            #{path => [foo], on_action => create},
+            receive_sproc_msg_with_props(Key))}]
+      }]}.
+
+
 filter_on_pattern_test_() ->
     Path = [foo, bar],
     EventFilter = khepri_evf:tree([foo, #if_has_data{}]),
@@ -624,6 +881,11 @@ make_sproc(Pid, Key) ->
     fun(Props) ->
             #{on_action := OnAction, path := Path} = Props,
             Pid ! {sproc, Key, {OnAction, Path}}
+    end.
+
+make_sproc_returning_props(Pid, Key) ->
+    fun(Props) ->
+            Pid ! {sproc, Key, Props}
     end.
 
 receive_sproc_msg(Key) ->


### PR DESCRIPTION
With this change, you can configure `props_to_return` in the event filter options. This is mainly useful for giving the payload of the changed tree node to the registered stored procedure. For example:

    #{props_to_return => [payload]}

To introduce this change safely we need to bump the machine version to 4, and thread the machine version through the main insert_or_update_node and delete_matching_nodes helpers.

Closes #358.