### PR TITLE
test/machine_code_called_from_ra: Use variable instead of hard-coding value

### DIFF
--- a/test/machine_code_called_from_ra.erl
+++ b/test/machine_code_called_from_ra.erl
@@ -171,4 +171,4 @@ submit_unknown_command_test_() ->
             #{command := UnknownCommand,
               machine_version := MacVer}),
          khepri_machine:process_command(
-           ?FUNCTION_NAME, unknown_command, #{}))]}.
+           ?FUNCTION_NAME, UnknownCommand, #{}))]}.


### PR DESCRIPTION
## Why

The `UnknownCommand` variable was already assigned and used. It was an oversight to not use it again in the last line of the test, and hard-code the command again.