### PR TITLE
khepri_config: Make machine configuration opaque to the machine itself

### DIFF
--- a/src/khepri_config.erl
+++ b/src/khepri_config.erl
@@ -1,0 +1,69 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2021-2026 Broadcom. All Rights Reserved. The term "Broadcom"
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+%% @doc
+%% Khepri machine config V0 handling functions.
+%%
+%% @hidden
+
+-module(khepri_config).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-include("src/khepri_config.hrl").
+
+-export([new/1]).
+
+%% Internal functions to access the opaque #config{} state.
+-export([get_store_id/1,
+         get_snapshot_interval/1]).
+
+%% Record representing the state machine configuration.
+-record(config,
+        {store_id :: khepri:store_id(),
+         member :: ra:server_id(),
+         snapshot_interval = ?SNAPSHOT_INTERVAL :: non_neg_integer()}).
+
+-opaque machine_config() :: #config{}.
+%% Configuration record, holding read-only or rarely changing fields.
+
+-export_type([machine_config/0]).
+
+-spec new(Params) -> Config when
+      Params :: khepri_machine:machine_init_args(),
+      Config :: khepri_config:machine_config().
+%% @doc Creates a new opaque configuration record.
+
+new(#{store_id := StoreId,
+      member := Member} = Params) ->
+    Config = case Params of
+                 #{snapshot_interval := SnapshotInterval} ->
+                     #config{store_id = StoreId,
+                             member = Member,
+                             snapshot_interval = SnapshotInterval};
+                 _ ->
+                     #config{store_id = StoreId,
+                             member = Member}
+             end,
+    Config.
+
+-spec get_store_id(Config) -> StoreId when
+      Config :: khepri_config:machine_config(),
+      StoreId :: khepri:store_id().
+%% @doc Returns the store ID from the given machine configuration.
+
+get_store_id(#config{store_id = StoreId}) ->
+    StoreId.
+
+-spec get_snapshot_interval(Config) -> SnapshotInterval when
+      Config :: khepri_config:machine_config(),
+      SnapshotInterval :: non_neg_integer().
+%% @doc Returns the snapshot interval from the given machine configuration.
+
+get_snapshot_interval(#config{snapshot_interval = SnapshotInterval}) ->
+    SnapshotInterval.

--- a/src/khepri_config.hrl
+++ b/src/khepri_config.hrl
@@ -1,0 +1,10 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2021-2026 Broadcom. All Rights Reserved. The term "Broadcom"
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+%% TODO: Query this value from Ra itself.
+-define(SNAPSHOT_INTERVAL, 4096).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -183,12 +183,9 @@
                                atom() => any()}.
 %% Structure passed to {@link init/1}.
 
--type machine_config() :: #config{}.
-%% Configuration record, holding read-only or rarely changing fields.
-
 %% State machine's internal state record.
 -record(khepri_machine,
-        {config = #config{} :: khepri_machine:machine_config(),
+        {config :: khepri_config:machine_config(),
          tree = khepri_tree:new() :: khepri_tree:tree(),
          triggers = #{} :: khepri_machine:triggers_map(),
          emitted_triggers = [] :: [khepri_machine:triggered()],
@@ -263,7 +260,6 @@
               machine_init_args/0,
               state/0,
               state_v1/0,
-              machine_config/0,
               triggers_map/0,
               metrics/0,
               dedups_map/0,
@@ -1359,7 +1355,7 @@ init(Params) ->
     State = khepri_machine_v0:init(Params),
 
     InitialMacVer = 0,
-    #config{store_id = StoreId} = get_config(State),
+    StoreId = get_store_id(State),
     cache_effective_machine_version(StoreId, InitialMacVer),
 
     %% Create initial "schema" if provided.
@@ -1766,7 +1762,7 @@ apply(Meta, {machine_version, OldMacVer, NewMacVer}, OldState) ->
     %% We cache the effective machine version for fast query from any
     %% processes. This is useful because this machine version is used to
     %% determine what a user of Khepri can or cannot do.
-    #config{store_id = StoreId} = get_config(NewState),
+    StoreId = get_store_id(NewState),
     cache_effective_machine_version(StoreId, NewMacVer),
     post_apply(Ret, Meta);
 apply(#{machine_version := MacVer} = Meta, UnknownCommand, State) ->
@@ -1814,7 +1810,7 @@ post_apply({_State, _Result, _SideEffects} = Ret, Meta) ->
 bump_applied_command_count(
   {State, Result, SideEffects},
   #{index := RaftIndex}) ->
-    #config{snapshot_interval = SnapshotInterval} = get_config(State),
+    SnapshotInterval = get_snapshot_interval(State),
     Metrics = get_metrics(State),
     AppliedCmdCount0 = maps:get(applied_command_count, Metrics, 0),
     AppliedCmdCount = AppliedCmdCount0 + 1,
@@ -1931,7 +1927,7 @@ snapshot_installed(
 %% @private
 
 emitted_triggers_to_side_effects(State) ->
-    #config{store_id = StoreId} = get_config(State),
+    StoreId = get_store_id(State),
     EmittedTriggers = get_emitted_triggers(State),
     case EmittedTriggers of
         [_ | _] ->
@@ -1957,7 +1953,7 @@ emitted_triggers_to_side_effects(State) ->
 %% @private
 
 overview(State) ->
-    #config{store_id = StoreId} = get_config(State),
+    StoreId = get_store_id(State),
     Tree = get_tree(State),
     KeepWhileConds = get_keep_while_conds(State),
     Triggers = get_triggers(State),
@@ -2370,7 +2366,7 @@ add_trigger_side_effects(InitialState, NewState, Changes, SideEffects) ->
             {NewState, SideEffects};
         false ->
             EmittedTriggers = get_emitted_triggers(InitialState),
-            #config{store_id = StoreId} = get_config(NewState),
+            StoreId = get_store_id(NewState),
             InitialTree = get_tree(InitialState),
             NewTree = get_tree(NewState),
             TriggeredStoredProcs = list_triggered_sprocs(
@@ -2577,7 +2573,7 @@ ensure_is_state(State) ->
 
 -spec get_config(State) -> Config when
       State :: khepri_machine:state(),
-      Config :: khepri_machine:machine_config().
+      Config :: khepri_config:machine_config().
 %% @doc Returns the config from the given state.
 %%
 %% @private
@@ -2801,8 +2797,21 @@ set_dedups(State, _Dedups) ->
 %% @private
 
 get_store_id(State) ->
-    #config{store_id = StoreId} = get_config(State),
+    Config = get_config(State),
+    StoreId = khepri_config:get_store_id(Config),
     StoreId.
+
+-spec get_snapshot_interval(State) -> SnapshotInterval when
+      State :: khepri_machine:state(),
+      SnapshotInterval :: non_neg_integer().
+%% @doc Returns the snapshot interval from the given state configuration.
+%%
+%% @private
+
+get_snapshot_interval(State) ->
+    Config = get_config(State),
+    SnapshotInterval = khepri_config:get_snapshot_interval(Config),
+    SnapshotInterval.
 
 -spec assert_equal(State1, State2) -> ok when
       State1 :: khepri_machine:state(),

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -8,15 +8,6 @@
 
 -include("src/khepri_node.hrl").
 
-%% TODO: Query this value from Ra itself.
--define(SNAPSHOT_INTERVAL, 4096).
-
-%% Record representing the state machine configuration.
--record(config,
-        {store_id :: khepri:store_id(),
-         member :: ra:server_id(),
-         snapshot_interval = ?SNAPSHOT_INTERVAL :: non_neg_integer()}).
-
 -record(khepri_machine_aux,
         {store_id :: khepri:store_id(),
          delayed_aux_queries = [] :: [khepri_machine:delayed_aux_query()]}).

--- a/src/khepri_machine_v0.erl
+++ b/src/khepri_machine_v0.erl
@@ -31,7 +31,7 @@
          state_to_list/1]).
 
 -record(khepri_machine,
-        {config = #config{} :: khepri_machine:machine_config(),
+        {config :: khepri_config:machine_config(),
          tree = khepri_tree:new() :: khepri_tree:tree_v0(),
          triggers = #{} ::
            #{khepri:trigger_id() =>
@@ -52,17 +52,8 @@
       State :: state().
 %% @private
 
-init(#{store_id := StoreId,
-       member := Member} = Params) ->
-    Config = case Params of
-                 #{snapshot_interval := SnapshotInterval} ->
-                     #config{store_id = StoreId,
-                             member = Member,
-                             snapshot_interval = SnapshotInterval};
-                 _ ->
-                     #config{store_id = StoreId,
-                             member = Member}
-             end,
+init(Params) ->
+    Config = khepri_config:new(Params),
     #khepri_machine{config = Config}.
 
 %% -------------------------------------------------------------------
@@ -81,7 +72,7 @@ is_state(State) ->
 
 -spec get_config(State) -> Config when
       State :: khepri_machine_v0:state(),
-      Config :: khepri_machine:machine_config().
+      Config :: khepri_config:machine_config().
 %% @doc Returns the config from the given state.
 %%
 %% @private


### PR DESCRIPTION
## Why

We are about to add new parameters which will require new fields to the `#config{}` record.

## How

Much like we have `khepri_machine.erl` and `khepri_machine_v0.erl`, move the configuration code from `khepri_machine.erl` to `khepri_config.erl`, make the `#config{}` record an opaque type and prepare the ground for a new version of `#config{}`.