### PR TITLE
Optimize `keep_while` cascade deletes

### DIFF
--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -18,6 +18,7 @@
 -include("include/khepri.hrl").
 -include("src/khepri_error.hrl").
 -include("src/khepri_node.hrl").
+-include("src/khepri_tree.hrl").
 
 -export([new/0,
          get_root/1,
@@ -40,7 +41,8 @@
          convert_tree/3]).
 
 -ifdef(TEST).
--export([unopacify/1]).
+-export([unopacify/1,
+         siblings_chunks/2]).
 -endif.
 
 -record(tree, {root = #node{} :: khepri_tree:tree_node(),
@@ -1823,11 +1825,18 @@ paths_to_patterns([], PatternsToDelete) ->
                                   Path = ParentPath ++ [Component],
                                   [Path | Acc];
                               (ParentPath, Siblings, Acc) ->
-                                  %% Many siblings are deleted. We use a
-                                  %% single pattern that matches any siblings.
-                                  Pattern0 = #if_any{conditions = Siblings},
-                                  Pattern1 = ParentPath ++ [Pattern0],
-                                  [Pattern1 | Acc]
+                                  %% Many siblings are deleted. We use
+                                  %% patterns that match any siblings,
+                                  %% capped at `?MAX_SIBLINGS_PER_PATTERN'
+                                  Chunks = siblings_chunks(
+                                             Siblings,
+                                             ?MAX_SIBLINGS_PER_PATTERN),
+                                  lists:foldl(
+                                    fun(Chunk, Acc1) ->
+                                        Pattern0 = #if_any{conditions = Chunk},
+                                        Pattern1 = ParentPath ++ [Pattern0],
+                                        [Pattern1 | Acc1]
+                                    end, Acc, Chunks)
                           end, [], PatternsToDelete),
     PatternsToDelete1.
 
@@ -1861,6 +1870,28 @@ path_to_pattern([Component | Rest], ParentPath, PatternsToDelete) ->
             PatternsToDelete1 = PatternsToDelete#{ParentPath => Siblings1},
             PatternsToDelete1
     end.
+
+-spec siblings_chunks(List, Count) -> Chunks when
+      List :: [any(), ...],
+      Count :: pos_integer(),
+      Chunks :: [Chunk],
+      Chunk :: [any(), ...].
+%% @private
+
+siblings_chunks(List, Count) when Count > 0 ->
+    siblings_chunks(List, Count, Count, [], []).
+
+siblings_chunks([], _Count, _Remaining, Acc, Chunks) when Acc =/= [] ->
+    Chunk = lists:reverse(Acc),
+    Chunks1 = [Chunk | Chunks],
+    lists:reverse(Chunks1);
+siblings_chunks(List, Count, 0, Acc, Chunks) ->
+    Chunk = lists:reverse(Acc),
+    Chunks1 = [Chunk | Chunks],
+    siblings_chunks(List, Count, Count, [], Chunks1);
+siblings_chunks([Elem | Rest], Count, Remaining, Acc, Chunks) ->
+    Acc1 = [Elem | Acc],
+    siblings_chunks(Rest, Count, Remaining - 1, Acc1, Chunks).
 
 remove_expired_nodes1(
   [PathToDelete | Rest],

--- a/src/khepri_tree.hrl
+++ b/src/khepri_tree.hrl
@@ -1,0 +1,11 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2026 Broadcom. All Rights Reserved. The term "Broadcom"
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+%% Maximum number of siblings grouped into a single `if_any' pattern by
+%% `paths_to_patterns/1'.
+-define(MAX_SIBLINGS_PER_PATTERN, 1000).

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -13,6 +13,7 @@
 -include("include/khepri.hrl").
 -include("src/khepri_machine.hrl").
 -include("src/khepri_error.hrl").
+-include("src/khepri_tree.hrl").
 -include("test/helpers.hrl").
 
 %% khepri:get_root/1 is unexported when compiled without `-DTEST'. Likewise
@@ -695,6 +696,10 @@ child_list_version_bumped_by_update_and_keep_while_test() ->
 %% Delete a single tree node that has many other tree nodes depending on it.
 %% This should complete quickly (milliseconds). However it took dozens of
 %% seconds before the fix in Khepri 0.17.4.
+%%
+%% `NumDependents' is more than twice `khepri_tree''s per-pattern sibling
+%% cap, so this also exercises splitting the dependents across several
+%% `if_any' patterns, not just the single-pattern case.
 delete_node_with_many_dependents_test_() ->
     {timeout, 30, fun delete_node_with_many_dependents/0}.
 
@@ -703,7 +708,7 @@ delete_node_with_many_dependents() ->
                      payload = khepri_payload:data(value)}],
     S0 = khepri_machine:init(?MACH_PARAMS(Commands)),
 
-    NumDependents = 1000,
+    NumDependents = ?MAX_SIBLINGS_PER_PATTERN * 5 div 2,
     DependentPaths = lists:map(
                        fun(I) ->
                                ChildName = integer_to_binary(I),
@@ -742,6 +747,23 @@ delete_node_with_many_dependents() ->
       fun(DependentPath) ->
               ?assert(maps:is_key(DependentPath, DeletedNodes))
       end, DependentPaths).
+
+siblings_chunks_test() ->
+    ?assertEqual([[a]], khepri_tree:siblings_chunks([a], 2)),
+    ?assertEqual([[a, b]], khepri_tree:siblings_chunks([a, b], 2)),
+    ?assertEqual([[a, b], [c]], khepri_tree:siblings_chunks([a, b, c], 2)),
+    ?assertEqual(
+       [[a, b], [c, d]],
+       khepri_tree:siblings_chunks([a, b, c, d], 2)),
+    ?assertError(
+       function_clause,
+       erlang:apply(khepri_tree, siblings_chunks, [[], 2])),
+    ?assertError(
+       function_clause,
+       erlang:apply(khepri_tree, siblings_chunks, [[a], 0])),
+    ?assertError(
+       function_clause,
+       erlang:apply(khepri_tree, siblings_chunks, [[a], -1])).
 
 %% Cascading deletions through a chain of dependencies where each node depends
 %% on the previous one. This should complete quickly (milliseconds). However


### PR DESCRIPTION
This PR optimizes a scenario where lots of nodes depend on a single node. Real-world examples include deleting a queue with lots of bindings (relatively rare scenario for RabbitMQ). For example:
```
make run-broker
wget https://github.com/rabbitmq/sample-configs/blob/main/topic-bindings/q0-with-100k-topic-bindings.json
rabbitmqctl import_definitions q0-with-100k-topic-bindings.json
rabbitmqctl delete_queue q0
```
The last command actually times out after 30 seconds without this PR on my machine, because Khepri needs ~150 seconds to process this deletion. With this PR, it completes in under 3 seconds.

For reference, flamegraphs captured at different stages of the deletion process:

<img width="1200" height="2134" alt="khepri-2" src="https://github.com/user-attachments/assets/87cc6438-7f02-4b39-b37b-8f8df08021cb" />
<img width="1200" height="2134" alt="khepri-1" src="https://github.com/user-attachments/assets/7976cc21-e16d-42c7-9f25-9d8849a46c8c" />
