### PR TITLE
khepri_machine: Make all commands uniform and versioned

### DIFF
--- a/src/khepri_import_export.erl
+++ b/src/khepri_import_export.erl
@@ -401,8 +401,9 @@ do_import(StoreId, Module, ModulePriv) ->
 %% @private
 
 handle_backup_items(StoreId, [Command | Rest]) ->
+    Command1 = khepri_machine:convert_to_uniform_command(Command),
     Options = #{},
-    case khepri_machine:process_command(StoreId, Command, Options) of
+    case khepri_machine:process_command(StoreId, Command1, Options) of
         {ok, _}            -> handle_backup_items(StoreId, Rest);
         {error, _} = Error -> Error
     end;

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -66,6 +66,14 @@
 %% </ul>
 %% </td>
 %% </tr>
+%% <tr>
+%% <td style="text-align: right; vertical-align: top;">4</td>
+%% <td>
+%% <ul>
+%% <li>Added uniform commands, replacing all existing commands.</li>
+%% </ul>
+%% </td>
+%% </tr>
 %% </table>
 
 -module(khepri_machine).
@@ -120,7 +128,8 @@
          process_command/3,
          does_api_comply_with/2,
          wait_for_effective_machine_version/3,
-         wait_for_effective_behaviour/3]).
+         wait_for_effective_behaviour/3,
+         convert_to_uniform_command/1]).
 
 %% Internal functions to access the opaque #khepri_machine{} state.
 -export([is_state/1,
@@ -152,19 +161,28 @@
 
 -type triggered() :: #triggered{}.
 
--type command() :: #put{} |
-                   #delete{} |
-                   #tx{} |
-                   #register_trigger{} |
-                   #ack_triggered{} |
-                   #register_projection{} |
-                   #unregister_projections{} |
+-type command() :: #put_v{} |
+                   #delete_v{} |
+                   #tx_v{} |
+                   #register_trigger_v{} |
+                   #ack_triggered_v{} |
+                   #register_projection_v{} |
+                   #unregister_projections_v{} |
                    #dedup{} |
-                   #dedup_ack{} |
-                   #drop_dedups{}.
+                   #dedup_ack_v{} |
+                   #drop_dedups_v{}.
 %% Commands specific to this Ra machine.
 
--type old_command() :: #unregister_projection{}.
+-type old_command() :: #put{} |
+                       #delete{} |
+                       #tx{} |
+                       #register_trigger{} |
+                       #ack_triggered{} |
+                       #register_projection{} |
+                       #unregister_projection{} |
+                       #unregister_projections{} |
+                       #dedup_ack{} |
+                       #drop_dedups{}.
 %% Old commands that are still accepted by the Ra machine but never created.
 %%
 %% Even though Khepri no longer creates these commands, they may still be
@@ -177,6 +195,7 @@
                                member := ra:server_id(),
                                snapshot_interval => non_neg_integer(),
                                commands => [command() |
+                                            old_command() |
                                             {machine_version,
                                              non_neg_integer(),
                                              non_neg_integer()}],
@@ -382,9 +401,20 @@ put(StoreId, PathPattern, Payload, Options)
     Payload1 = khepri_payload:prepare(Payload),
     {CommandOptions, TreeAndPutOptions} = split_command_options(
                                             StoreId, Options),
-    Command = #put{path = PathPattern1,
-                   payload = Payload1,
-                   options = TreeAndPutOptions},
+    Command = case does_api_comply_with(uniform_commands, StoreId) of
+                  true ->
+                      {TreeOptions, PutOptions} = split_put_options(
+                                                    TreeAndPutOptions),
+                      CommandArgs = #put_v1{path = PathPattern1,
+                                            payload = Payload1,
+                                            put_options = PutOptions,
+                                            tree_options = TreeOptions},
+                      #put_v{args = CommandArgs};
+                  false ->
+                      #put{path = PathPattern1,
+                           payload = Payload1,
+                           options = TreeAndPutOptions}
+              end,
     process_command(StoreId, Command, CommandOptions);
 put(_StoreId, PathPattern, Payload, _Options) ->
     ?khepri_misuse(invalid_payload, #{path => PathPattern,
@@ -410,9 +440,16 @@ delete(StoreId, PathPattern, Options) when ?IS_KHEPRI_STORE_ID(StoreId) ->
     PathPattern1 = khepri_path:from_string(PathPattern),
     khepri_path:ensure_is_valid(PathPattern1),
     {CommandOptions, TreeOptions} = split_command_options(StoreId, Options),
-    %% TODO: Ensure `PutOptions' are not set this map.
-    Command = #delete{path = PathPattern1,
-                      options = TreeOptions},
+    %% TODO: Ensure `PutOptions' are not set in `Options'.
+    Command = case does_api_comply_with(uniform_commands, StoreId) of
+                  true ->
+                      CommandArgs = #delete_v1{path = PathPattern1,
+                                               tree_options = TreeOptions},
+                      #delete_v{args = CommandArgs};
+                  false ->
+                      #delete{path = PathPattern1,
+                              options = TreeOptions}
+              end,
     process_command(StoreId, Command, CommandOptions).
 
 -spec transaction(StoreId, FunOrPath, Args, ReadWrite, Options) -> Ret when
@@ -582,7 +619,14 @@ readwrite_transaction(
     readwrite_transaction1(StoreId, PathPattern1, Args, Options).
 
 readwrite_transaction1(StoreId, StandaloneFunOrPath, Args, Options) ->
-    Command = #tx{'fun' = StandaloneFunOrPath, args = Args},
+    Command = case does_api_comply_with(uniform_commands, StoreId) of
+                  true ->
+                      CommandArgs = #tx_v1{'fun' = StandaloneFunOrPath,
+                                           args = Args},
+                      #tx_v{args = CommandArgs};
+                  false ->
+                      #tx{'fun' = StandaloneFunOrPath, args = Args}
+              end,
     Options1 = maps:merge(#{protect_against_dups => true}, Options),
     case process_command(StoreId, Command, Options1) of
         {exception, _, _, _} = Exception ->
@@ -643,9 +687,18 @@ register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options)
     EventFilter1 = khepri_evf:wrap(EventFilter),
     StoredProcPath1 = khepri_path:from_string(StoredProcPath),
     khepri_path:ensure_is_valid(StoredProcPath1),
-    Command = #register_trigger{id = TriggerId,
+    Command = case does_api_comply_with(uniform_commands, StoreId) of
+                  true ->
+                      CommandArgs = #register_trigger_v1{
+                                       id = TriggerId,
+                                       sproc = StoredProcPath1,
+                                       event_filter = EventFilter1},
+                      #register_trigger_v{args = CommandArgs};
+                  false ->
+                      #register_trigger{id = TriggerId,
                                 sproc = StoredProcPath1,
-                                event_filter = EventFilter1},
+                                event_filter = EventFilter1}
+              end,
     process_command(StoreId, Command, Options).
 
 -spec register_projection(StoreId, PathPattern, Projection, Options) ->
@@ -687,8 +740,16 @@ register_projection(
 
             PathPattern = khepri_path:from_string(PathPattern0),
             khepri_path:ensure_is_valid(PathPattern),
-            Command = #register_projection{pattern = PathPattern,
-                                           projection = Projection},
+            Command = case does_api_comply_with(uniform_commands, StoreId) of
+                          true ->
+                              CommandArgs = #register_projection_v1{
+                                               pattern = PathPattern,
+                                               projection = Projection},
+                              #register_projection_v{args = CommandArgs};
+                          false ->
+                              #register_projection{pattern = PathPattern,
+                                                   projection = Projection}
+                      end,
             process_command(StoreId, Command, Options1);
         {error, _Reason} = Error ->
             Error
@@ -718,7 +779,13 @@ unregister_projections(StoreId, Names, Options)
   when ?IS_KHEPRI_STORE_ID(StoreId) andalso
        (Names =:= all orelse is_list(Names)) andalso
        is_map(Options) ->
-    Command = #unregister_projections{names = Names},
+    Command = case does_api_comply_with(uniform_commands, StoreId) of
+                  true ->
+                      CommandArgs = #unregister_projections_v1{names = Names},
+                      #unregister_projections_v{args = CommandArgs};
+                  false ->
+                      #unregister_projections{names = Names}
+              end,
     process_command(StoreId, Command, Options).
 
 -spec ack_triggers_execution(StoreId, TriggeredStoredProcs) ->
@@ -735,7 +802,14 @@ unregister_projections(StoreId, Names, Options)
 
 ack_triggers_execution(StoreId, TriggeredStoredProcs)
   when ?IS_KHEPRI_STORE_ID(StoreId) ->
-    Command = #ack_triggered{triggered = TriggeredStoredProcs},
+    Command = case does_api_comply_with(uniform_commands, StoreId) of
+                  true ->
+                      CommandArgs = #ack_triggered_v1{
+                                       triggered = TriggeredStoredProcs},
+                      #ack_triggered_v{args = CommandArgs};
+                  false ->
+                      #ack_triggered{triggered = TriggeredStoredProcs}
+              end,
     process_command(StoreId, Command, #{async => true}).
 
 -spec get_keep_while_conds_state(StoreId, Options) -> Ret when
@@ -914,7 +988,7 @@ set_default_options(StoreId, Options) ->
 
 -spec process_command(StoreId, Command, Options) -> Ret when
       StoreId :: khepri:store_id(),
-      Command :: command(),
+      Command :: command() | old_command(),
       Options :: khepri:command_options(),
       Ret :: any().
 %% @doc Processes a command which is appended to the Ra log and processed by
@@ -974,7 +1048,13 @@ process_sync_command(
             DedupCommand = #dedup{ref = CommandRef,
                                   expiry = Expiry,
                                   command = Command},
-            DedupAck = #dedup_ack{ref = CommandRef},
+            DedupAck = case does_api_comply_with(uniform_commands, StoreId) of
+                           true ->
+                               CommandArgs = #dedup_ack_v1{ref = CommandRef},
+                               #dedup_ack_v{args = CommandArgs};
+                           false ->
+                               #dedup_ack{ref = CommandRef}
+                       end,
             Ret = do_process_sync_command(
                     StoreId, DedupCommand, Options),
 
@@ -1462,6 +1542,7 @@ handle_aux(leader, cast, tick, AuxState, IntState) ->
     case ra_aux:effective_machine_version(IntState) of
         EffectiveMacVer
           when EffectiveMacVer >= ?API_BEHAV_MACVER(expire_dedups_from_tick) ->
+            #khepri_machine_aux{store_id = StoreId} = AuxState1,
             State = ra_aux:machine_state(IntState),
             Timestamp = erlang:system_time(millisecond),
             Dedups = get_dedups(State),
@@ -1478,7 +1559,20 @@ handle_aux(leader, cast, tick, AuxState, IntState) ->
                           [] ->
                               [];
                           _ ->
-                              DropDedups = #drop_dedups{refs = RefsToDrop},
+                              UseUniformCommands = does_api_comply_with(
+                                                     uniform_commands,
+                                                     StoreId),
+                              DropDedups = case UseUniformCommands of
+                                               true ->
+                                                   CommandArgs = (
+                                                     #drop_dedups_v1{
+                                                        refs = RefsToDrop}),
+                                                   #drop_dedups_v{
+                                                      args = CommandArgs};
+                                               false ->
+                                                   #drop_dedups{
+                                                      refs = RefsToDrop}
+                                           end,
                               [{append, DropDedups}]
                       end,
             {no_reply, AuxState1, IntState, Effects};
@@ -1574,35 +1668,40 @@ restore_projection(Projection, Tree, PathPattern) ->
 
 apply(
   Meta,
-  #put{path = PathPattern, payload = Payload, options = TreeAndPutOptions},
+  #put_v{args = #put_v1{path = PathPattern,
+                        payload = Payload,
+                        put_options = PutOptions,
+                        tree_options = TreeOptions}},
   State) ->
-    {TreeOptions, PutOptions} = split_put_options(TreeAndPutOptions),
     Ret = insert_or_update_node(
             State, PathPattern, Payload, PutOptions, TreeOptions, []),
     post_apply(Ret, Meta);
 apply(
   Meta,
-  #delete{path = PathPattern, options = TreeOptions},
+  #delete_v{args = #delete_v1{path = PathPattern,
+                              tree_options = TreeOptions}},
   State) ->
     Ret = delete_matching_nodes(State, PathPattern, TreeOptions, []),
     post_apply(Ret, Meta);
 apply(
   Meta,
-  #tx{'fun' = StandaloneFun, args = Args},
+  #tx_v{args = #tx_v1{'fun' = StandaloneFun,
+                      args = Args}},
   State) when ?IS_HORUS_FUN(StandaloneFun) ->
     Ret = khepri_tx_adv:run(State, StandaloneFun, Args, true, Meta),
     post_apply(Ret, Meta);
 apply(
   Meta,
-  #tx{'fun' = PathPattern, args = Args},
+  #tx_v{args = #tx_v1{'fun' = PathPattern,
+                      args = Args}},
   State) when ?IS_KHEPRI_PATH_PATTERN(PathPattern) ->
     Ret = locate_sproc_and_execute_tx(State, PathPattern, Args, true, Meta),
     post_apply(Ret, Meta);
 apply(
   Meta,
-  #register_trigger{id = TriggerId,
-                    sproc = StoredProcPath,
-                    event_filter = EventFilter},
+  #register_trigger_v{args = #register_trigger_v1{id = TriggerId,
+                                                  sproc = StoredProcPath,
+                                                  event_filter = EventFilter}},
   State) ->
     Triggers = get_triggers(State),
     StoredProcPath1 = khepri_path:realpath(StoredProcPath),
@@ -1618,7 +1717,7 @@ apply(
     post_apply(Ret, Meta);
 apply(
   Meta,
-  #ack_triggered{triggered = ProcessedTriggers},
+  #ack_triggered_v{args = #ack_triggered_v1{triggered = ProcessedTriggers}},
   State) ->
     EmittedTriggers = get_emitted_triggers(State),
     EmittedTriggers1 = EmittedTriggers -- ProcessedTriggers,
@@ -1627,7 +1726,9 @@ apply(
     post_apply(Ret, Meta);
 apply(
   Meta,
-  #register_projection{pattern = PathPattern, projection = Projection},
+  #register_projection_v{
+     args = #register_projection_v1{pattern = PathPattern,
+                                    projection = Projection}},
   State) ->
     ProjectionName = khepri_projection:name(Projection),
     ProjectionTree = get_projections(State),
@@ -1659,7 +1760,7 @@ apply(
     end;
 apply(
   Meta,
-  #unregister_projections{names = Names},
+  #unregister_projections_v{args = #unregister_projections_v1{names = Names}},
   State) ->
     RemoveProjection = case Names of
                            all ->
@@ -1698,16 +1799,6 @@ apply(
     Ret = {State1, Reply},
     post_apply(Ret, Meta);
 apply(
-  Meta,
-  #unregister_projection{name = Name},
-  State) ->
-    %% This command was replaced by `#unregister_projections{}'. Therefore,
-    %% convert it and recurse.
-    %%
-    %% For backward-compatibility; see {@link old_command()}.
-    NewCommand = #unregister_projections{names = [Name]},
-    apply(Meta, NewCommand, State);
-apply(
   #{machine_version := MacVer} = Meta,
   #dedup{ref = CommandRef, expiry = Expiry, command = Command},
   State)
@@ -1727,7 +1818,7 @@ apply(
     end;
 apply(
   #{machine_version := MacVer} = Meta,
-  #dedup_ack{ref = CommandRef},
+  #dedup_ack_v{args = #dedup_ack_v1{ref = CommandRef}},
   State)
   when is_reference(CommandRef) andalso
        MacVer >= ?API_BEHAV_MACVER(dedup_protection) ->
@@ -1743,9 +1834,9 @@ apply(
     post_apply(Ret, Meta);
 apply(
   #{machine_version := MacVer} = Meta,
-  #drop_dedups{refs = RefsToDrop},
+  #drop_dedups_v{args = #drop_dedups_v1{refs = RefsToDrop}},
   State) when MacVer >= ?API_BEHAV_MACVER(expire_dedups_from_tick) ->
-    %% `#drop_dedups{}' is emitted by the `handle_aux/5' clause for the `tick'
+    %% `#drop_dedups*{}' is emitted by the `handle_aux/5' clause for the `tick'
     %% effect to periodically drop dedups that have expired. This expiration
     %% was originally done in `post_apply/2' via `drop_expired_dedups/2' until
     %% machine version 2. Note that `drop_expired_dedups/2' is used until a
@@ -1765,6 +1856,19 @@ apply(Meta, {machine_version, OldMacVer, NewMacVer}, OldState) ->
     StoreId = get_store_id(NewState),
     cache_effective_machine_version(StoreId, NewMacVer),
     post_apply(Ret, Meta);
+apply(Meta, NonVersionedCommand, State)
+  when is_record(NonVersionedCommand, put) orelse
+       is_record(NonVersionedCommand, delete) orelse
+       is_record(NonVersionedCommand, tx) orelse
+       is_record(NonVersionedCommand, register_trigger) orelse
+       is_record(NonVersionedCommand, ack_triggered) orelse
+       is_record(NonVersionedCommand, register_projection) orelse
+       is_record(NonVersionedCommand, unregister_projection) orelse
+       is_record(NonVersionedCommand, unregister_projections) orelse
+       is_record(NonVersionedCommand, dedup_ack) orelse
+       is_record(NonVersionedCommand, drop_dedups) ->
+    Command = convert_to_uniform_command(NonVersionedCommand),
+    apply(Meta, Command, State);
 apply(#{machine_version := MacVer} = Meta, UnknownCommand, State) ->
     Error = ?khepri_exception(
                unknown_khepri_state_machine_command,
@@ -1781,6 +1885,99 @@ apply(#{machine_version := MacVer} = Meta, UnknownCommand, State) ->
                        line => ?LINE}]}],
     Ret = {State, Reply, SideEffects},
     post_apply(Ret, Meta).
+
+-spec convert_to_uniform_command(Command) -> NewCommand when
+      Command :: khepri_machine:command() |
+                 khepri_machine:old_command(),
+      NewCommand :: khepri_machine:command().
+
+convert_to_uniform_command(
+  #put{path = PathPattern,
+       payload = Payload,
+       options = TreeAndPutOptions}) ->
+    {TreeOptions, PutOptions} = split_put_options(TreeAndPutOptions),
+    CommandArgs = #put_v1{path = PathPattern,
+                          payload = Payload,
+                          put_options = PutOptions,
+                          tree_options = TreeOptions},
+    NewCommand = #put_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #delete{path = PathPattern,
+          options = TreeOptions}) ->
+    CommandArgs = #delete_v1{path = PathPattern,
+                             tree_options = TreeOptions},
+    NewCommand = #delete_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #tx{'fun' = StandaloneFun, args = Args}) ->
+    CommandArgs = #tx_v1{'fun' = StandaloneFun,
+                         args = Args},
+    NewCommand = #tx_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #register_trigger{id = TriggerId,
+                    sproc = StoredProcPath,
+                    event_filter = EventFilter}) ->
+    CommandArgs = #register_trigger_v1{id = TriggerId,
+                                       sproc = StoredProcPath,
+                                       event_filter = EventFilter},
+    NewCommand = #register_trigger_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #ack_triggered{triggered = ProcessedTriggers}) ->
+    CommandArgs = #ack_triggered_v1{triggered = ProcessedTriggers},
+    NewCommand = #ack_triggered_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #register_projection{pattern = PathPattern, projection = Projection}) ->
+    CommandArgs = #register_projection_v1{pattern = PathPattern,
+                                          projection = Projection},
+    NewCommand = #register_projection_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #unregister_projections{names = Names}) ->
+    CommandArgs = #unregister_projections_v1{names = Names},
+    NewCommand = #unregister_projections_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #unregister_projection{name = Name}) ->
+    %% This command was replaced by `#unregister_projections{}'. Therefore,
+    %% convert it and recurse.
+    %%
+    %% For backward-compatibility; see {@link old_command()}.
+    CommandArgs = #unregister_projections_v1{names = [Name]},
+    NewCommand = #unregister_projections_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #dedup{} = Command) ->
+    %% This command does not have a uniform/versioned equivalent as it will be
+    %% replaced in an upcoming commit.
+    Command;
+convert_to_uniform_command(
+  #dedup_ack{ref = CommandRef}) ->
+    CommandArgs = #dedup_ack_v1{ref = CommandRef},
+    NewCommand = #dedup_ack_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(
+  #drop_dedups{refs = RefsToDrop}) ->
+    CommandArgs = #drop_dedups_v1{refs = RefsToDrop},
+    NewCommand = #drop_dedups_v{args = CommandArgs},
+    NewCommand;
+convert_to_uniform_command(Command)
+  when is_record(Command, put_v) orelse
+       is_record(Command, delete_v) orelse
+       is_record(Command, tx_v) orelse
+       is_record(Command, register_trigger_v) orelse
+       is_record(Command, ack_triggered_v) orelse
+       is_record(Command, register_projection_v) orelse
+       is_record(Command, unregister_projections_v) orelse
+       is_record(Command, dedup_ack_v) orelse
+       is_record(Command, drop_dedups_v) ->
+    %% These are all uniform/versioned commands already. We list them
+    %% explicitly to reduce the risk of programming errors with wildcard
+    %% pattern matching.
+    Command.
 
 -spec post_apply(ApplyRet, Meta) -> {State, Result, SideEffects} when
       ApplyRet :: {State, Result} | {State, Result, SideEffects},
@@ -2874,6 +3071,8 @@ convert_state1(State, 1, 2) ->
     Tree1 = khepri_tree:convert_tree(Tree, 1, 2),
     set_tree(State, Tree1);
 convert_state1(State, 2, 3) ->
+    State;
+convert_state1(State, 3, 4) ->
     State.
 
 -spec update_projections(OldState, NewState) -> ok when

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -15,7 +15,7 @@
 %% The current/latest version of the state machine is defined in this macro
 %% instead of `khepri_machine:version/0' only. This way, it can be used in
 %% function specs too.
--define(LATEST_MACVER, 3).
+-define(LATEST_MACVER, 4).
 
 %% Map API behaviours with the state machine version they were introduced in.
 -define(API_BEHAV_MACVER_MAP,
@@ -26,7 +26,9 @@
           indirect_deletes_in_ret     => 2,
           uniform_write_ret           => 2,
 
-          multi_table_projections     => 3}).
+          multi_table_projections     => 3,
+
+          uniform_commands            => 4}).
 
 %% Get the state machine version the given API behaviour was introduced in.
 %% This is similar to `khepri_machine:api_behaviour_to_machine_version/1' but
@@ -38,45 +40,279 @@
 %% State machine commands.
 %% -------------------------------------------------------------------
 
--record(put, {path :: khepri_path:native_pattern(),
-              payload = ?NO_PAYLOAD :: khepri_payload:payload(),
-              options = #{} :: khepri:tree_options() | khepri:put_options()}).
+-record(common_v1, {}).
+%% Set of attributes shared by all commands.
 
--record(delete, {path :: khepri_path:native_pattern(),
-                 options = #{} :: khepri:tree_options()}).
+-record(put_v1,
+        {path :: khepri_path:native_pattern(),
+         payload = ?NO_PAYLOAD :: khepri_payload:payload(),
+         put_options = #{} :: khepri:put_options(),
+         tree_options = #{} :: khepri:tree_options()}).
+%% Put-specific attributes.
+%%
+%% <ul>
+%% <li>`path' is the path pattern of the tree node(s) to create or update.</li>
+%% <li>`payload' is the payload to store in the tree nodes matching the path
+%% pattern.</li>
+%% <li>`put_options' is a map of put-specific options.</li>
+%% <li>`tree_options' is a map of tree-handling options.</li>
+%% </ul>
 
--record(tx, {'fun' :: horus:horus_fun() | khepri_path:pattern(),
-             args = [] :: list()}).
+-record(put_v,
+        {args :: #put_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the put command.
+%%
+%% It is used to create or update one or more tree nodes.
+%%
+%% <ul>
+%% <li>`args' contains the put-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
 
--record(register_trigger, {id :: khepri:trigger_id(),
-                           event_filter :: khepri_evf:event_filter(),
-                           sproc :: khepri_path:native_path()}).
+-record(delete_v1,
+        {path :: khepri_path:native_pattern(),
+         tree_options = #{} :: khepri:tree_options()}).
+%% Delete-specific attributes.
+%%
+%% <ul>
+%% <li>`path' is the path pattern of the tree node(s) to delete.</li>
+%% <li>`tree_options' is a map of tree-handling options.</li>
+%% </ul>
 
--record(ack_triggered, {triggered :: [khepri_machine:triggered()]}).
+-record(delete_v,
+        {args :: #delete_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the delete command.
+%%
+%% It is used to delete one or more tree nodes.
+%%
+%% <ul>
+%% <li>`args' contains the delete-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
 
--record(register_projection, {pattern :: khepri_path:native_pattern(),
-                              projection :: khepri_projection:projection()}).
+-record(tx_v1,
+        {'fun' :: horus:horus_fun() | khepri_path:pattern(),
+         args = [] :: list()}).
+%% Transaction-specific attributes.
+%%
+%% <ul>
+%% <li>`fun' is the anonymous function of the transaction.</li>
+%% <li>`args' is a list of terms to pass to the transaction function.</li>
+%% </ul>
 
--record(unregister_projections, {names :: all | [khepri_projection:name()]}).
+-record(tx_v,
+        {args :: #tx_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the transaction command.
+%%
+%% It is used to execute a transaction on the store.
+%%
+%% <ul>
+%% <li>`args' contains the transaction-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
 
--record(dedup, {ref :: reference(),
-                expiry :: integer(),
-                command :: khepri_machine:command()}).
+-record(register_trigger_v1,
+        {id :: khepri:trigger_id(),
+         event_filter :: khepri_evf:event_filter(),
+         sproc :: khepri_path:native_path()}).
+%% Trigger registration-specific attributes.
+%%
+%% <ul>
+%% <li>`id' is of identifier of the trigger.</li>
+%% <li>`event_filter' is the event filter for that trigger.</li>
+%% <li>`sproc' is the path to the stored procedure associated with the
+%% trigger.</li>
+%% </ul>
 
--record(dedup_ack, {ref :: reference()}).
+-record(register_trigger_v,
+        {args :: #register_trigger_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the trigger registration command.
+%%
+%% It creates a trigger based on the given event filter and stored procedure.
+%%
+%% <ul>
+%% <li>`args' contains the trigger registration-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
 
--record(drop_dedups, {refs :: [reference()]}).
-%% A command introduced in machine version 2 which is meant to drop expired
-%% dedups.
+-record(ack_triggered_v1,
+        {triggered :: [khepri_machine:triggered()]}).
+%% Trigger ack-specific attributes.
+%%
+%% <ul>
+%% <li>`triggered' is a list of `#triggered{}' record.</li>
+%% </ul>
+
+-record(ack_triggered_v,
+        {args :: #ack_triggered_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the trigger ack command.
+%%
+%% It is used by the event handler to ack trigger execution.
+%%
+%% <ul>
+%% <li>`args' contains the trigger ack-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
+
+-record(register_projection_v1,
+        {pattern :: khepri_path:native_pattern(),
+         projection :: khepri_projection:projection()}).
+%% Projection registration-specific attributes.
+%%
+%% <ul>
+%% <li>`pattern' is the path pattern describing tree nodes to project.</li>
+%% <li>`projection' is the projection function descriptor.</li>
+%% </ul>
+
+-record(register_projection_v,
+        {args :: #register_projection_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the projection registration command.
+%%
+%% It is used to register a projection.
+%%
+%% <ul>
+%% <li>`args' contains the projection registration-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
+
+-record(unregister_projections_v1,
+        {names :: all | [khepri_projection:name()]}).
+%% Projection unregistration-specific attributes.
+%%
+%% <ul>
+%% <li>`names' is of projection names to unregister.</li>
+%% </ul>
+
+-record(unregister_projections_v,
+        {args :: #unregister_projections_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the projection unregistration command.
+%%
+%% It is used to unregister projections.
+%%
+%% <ul>
+%% <li>`args' contains the projection unregistration-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
+
+-record(dedup,
+        {ref :: reference(),
+         expiry :: integer(),
+         command :: khepri_machine:command() | khepri_machine:old_command()}).
+%% Command to help deduplicate the wrapped command in case it is submitted to
+%% the Ra leader multiple times.
+
+-record(dedup_ack_v1,
+        {ref :: reference()}).
+%% Dedup ack-specific attributes.
+%%
+%% <ul>
+%% <li>`ref' is a reference to the dedup command being acked.</li>
+%% </ul>
+
+-record(dedup_ack_v,
+        {args :: #dedup_ack_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the dedup ack command.
+%%
+%% It is used to acknowledge a deduplicated command got a replied.
+%%
+%% <ul>
+%% <li>`args' contains the dedup ack-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
+
+-record(drop_dedups_v1,
+        {refs :: [reference()]}).
+%% New versioned variant of the dedups drop command.
+%%
+%% It is used drop expired dedups. It is introduced in machine version 2.
 %%
 %% This is emitted internally by the `handle_aux/5' callback clause which
 %% handles the `tick' Ra aux effect.
+%%
+%% <ul>
+%% <li>`refs' is a list of references of dedups to drop.</li>
+%% </ul>
+
+-record(drop_dedups_v,
+        {args :: #drop_dedups_v1{},
+         common = none :: #common_v1{} | none}).
+%% Versioned variant of the dedup drop command.
+%%
+%% It is used to drop a list dedup references.
+%%
+%% <ul>
+%% <li>`args' contains the dedup drop-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
 
 %% -------------------------------------------------------------------
 %% Old commands, kept for backward-compatibility.
 %% -------------------------------------------------------------------
 
+-record(put, {path :: khepri_path:native_pattern(),
+              payload = ?NO_PAYLOAD :: khepri_payload:payload(),
+              options = #{} :: khepri:tree_options() | khepri:put_options()}).
+%% Non-versioned old variant of the put command.
+%%
+%% Replaced by `#pub_v{}'.
+
+-record(delete, {path :: khepri_path:native_pattern(),
+                 options = #{} :: khepri:tree_options()}).
+%% Old non-versioned variant of the delete command.
+%%
+%% Replaced by `#delete_v{}'.
+
+-record(tx, {'fun' :: horus:horus_fun() | khepri_path:pattern(),
+             args = [] :: list()}).
+%% Old non-versioned variant of the transaction command.
+%%
+%% Replaced by `#tx_v{}'.
+
+-record(register_trigger, {id :: khepri:trigger_id(),
+                           event_filter :: khepri_evf:event_filter(),
+                           sproc :: khepri_path:native_path()}).
+%% Old non-versioned variant of the trigger registration command.
+%%
+%% Replaced by `#register_trigger_v{}'.
+
+-record(ack_triggered, {triggered :: [khepri_machine:triggered()]}).
+%% Old non-versioned variant of the trigger ack command.
+%%
+%% Replaced by `#ack_triggered_v{}'.
+
+-record(register_projection, {pattern :: khepri_path:native_pattern(),
+                              projection :: khepri_projection:projection()}).
+%% Old non-versioned variant of the projection registration command.
+%%
+%% Replaced by `register_projection_v{}'.
+
 -record(unregister_projection, {name :: khepri_projection:name()}).
+%% Command to unregister one projection.
+%%
+%% Replaced by `#unregister_projections{}'.
+
+-record(unregister_projections, {names :: all | [khepri_projection:name()]}).
+%% Old non-versioned projection unregistration command.
+%%
+%% Replaced by `#unregister_projections_v{}'.
+
+-record(dedup_ack, {ref :: reference()}).
+%% Old non-versioned variant of the dedup ack command.
+%%
+%% Replaced by `#dedup_ack_v{}'.
+
+-record(drop_dedups, {refs :: [reference()]}).
+%% Old non-versioned variant of the dedups drop command.
+%%
+%% Replaced by `#drop_dedups_v{}'.
 
 %% -------------------------------------------------------------------
 %% State machine aux. effects.

--- a/test/non_versioned_commands.erl
+++ b/test/non_versioned_commands.erl
@@ -1,0 +1,201 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2026 Broadcom. All Rights Reserved. The term "Broadcom"
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(non_versioned_commands).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("src/khepri_machine.hrl").
+-include("test/helpers.hrl").
+
+non_versioned_put_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    Put = #put{path = [foo],
+               payload = khepri_payload:data(value),
+               options = #{props_to_return => [payload_version]}},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), Put, S0),
+    ?assertEqual({ok, #{[foo] => #{payload_version => 1}}}, Ret).
+
+non_versioned_delete_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    Delete = #delete{path = [foo],
+                     options = #{props_to_return => [payload_version]}},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), Delete, S0),
+    ?assertEqual({ok, #{}}, Ret).
+
+non_versioned_tx_test() ->
+    helpers:init_list_of_modules_to_skip(),
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    TxFun = fun() -> done end,
+    TxSF = khepri_tx_adv:to_standalone_fun(TxFun, rw),
+    Tx = #tx{'fun' = TxSF},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), Tx, S0),
+    ?assertEqual(done, Ret).
+
+non_versioned_register_trigger_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    RegisterTrigger = #register_trigger{id = ?FUNCTION_NAME,
+                                        event_filter = khepri_evf:tree([foo]),
+                                        sproc = [sproc]},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), RegisterTrigger, S0),
+    ?assertEqual(ok, Ret).
+
+non_versioned_ack_triggered_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    AckTriggered = #ack_triggered{triggered = []},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), AckTriggered, S0),
+    ?assertEqual(ok, Ret).
+
+non_versioned_register_projection_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    ProjectFun = fun(_Path, _Payload) -> ok end,
+    Projection = khepri_projection:new(?MODULE, ProjectFun),
+    RegisterProjection = #register_projection{pattern = [],
+                                              projection = Projection},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), RegisterProjection, S0),
+    ?assertEqual(ok, Ret).
+
+non_versioned_unregister_projection_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    UnregisterProjection = #unregister_projection{name = ?FUNCTION_NAME},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), UnregisterProjection, S0),
+    ?assertEqual({ok, #{}}, Ret).
+
+non_versioned_unregister_projections_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    UnregisterProjections = #unregister_projections{names = all},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), UnregisterProjections, S0),
+    ?assertEqual({ok, #{}}, Ret).
+
+non_versioned_dedup_ack_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    DedupAck = #dedup_ack{ref = make_ref()},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), DedupAck, S0),
+    ?assertEqual(ok, Ret).
+
+non_versioned_drop_dedups_test() ->
+    S0 = khepri_machine:init(?MACH_PARAMS()),
+
+    DropDedups = #drop_dedups{refs = []},
+    {_, Ret, _} = khepri_machine:apply(get_meta(), DropDedups, S0),
+    ?assertEqual(ok, Ret).
+
+get_meta() ->
+    EffectiveMacVer = maps:get(uniform_commands, ?API_BEHAV_MACVER_MAP) - 1,
+    Meta0 = ?META,
+    Meta = Meta0#{machine_version => EffectiveMacVer},
+    Meta.
+
+convert_to_uniform_command_test() ->
+    TxFun = fun() -> done end,
+    TxSF = khepri_tx_adv:to_standalone_fun(TxFun, rw),
+    ProjectFun = fun(_Path, _Payload) -> ok end,
+    Projection = khepri_projection:new(?MODULE, ProjectFun),
+    Ref = make_ref(),
+
+    Records = [{#put{path = []},
+                #put_v{args = #put_v1{path = []}}},
+
+               {#delete{path = []},
+                #delete_v{args = #delete_v1{path = []}}},
+
+               {#tx{'fun' = TxSF},
+                #tx_v{args = #tx_v1{'fun' = TxSF}}},
+
+               {#register_trigger{id = ?FUNCTION_NAME,
+                                  event_filter = khepri_evf:tree([foo]),
+                                  sproc = [sproc]},
+                #register_trigger_v{
+                   args = #register_trigger_v1{
+                             id = ?FUNCTION_NAME,
+                             event_filter = khepri_evf:tree([foo]),
+                             sproc = [sproc]}}},
+
+               {#ack_triggered{triggered = []},
+                #ack_triggered_v{args = #ack_triggered_v1{triggered = []}}},
+
+               {#register_projection{pattern = [], projection = Projection},
+                #register_projection_v{
+                   args = #register_projection_v1{
+                             pattern = [],
+                             projection = Projection}}},
+
+               {#unregister_projection{name = ?FUNCTION_NAME},
+                #unregister_projections_v{
+                   args = #unregister_projections_v1{
+                             names = [?FUNCTION_NAME]}}},
+
+               {#unregister_projections{names = all},
+                #unregister_projections_v{
+                   args = #unregister_projections_v1{
+                             names = all}}},
+
+               {#dedup{ref = Ref, expiry = 1, command = #put{path = []}},
+                same},
+
+               {#dedup_ack{ref = Ref},
+                #dedup_ack_v{args = #dedup_ack_v1{ref = Ref}}},
+
+               {#drop_dedups{refs = []},
+                #drop_dedups_v{args = #drop_dedups_v1{refs = []}}},
+
+               {#put_v{args = #put_v1{path = []}},
+                same},
+
+               {#delete_v{args = #delete_v1{path = []}},
+                same},
+
+               {#tx_v{args = #tx_v1{'fun' = TxSF}},
+                same},
+
+               {#register_trigger_v{
+                   args = #register_trigger_v1{
+                             id = ?FUNCTION_NAME,
+                             event_filter = khepri_evf:tree([foo]),
+                             sproc = [sproc]}},
+                same},
+
+               {#ack_triggered_v{args = #ack_triggered_v1{triggered = []}},
+                same},
+
+               {#register_projection_v{
+                   args = #register_projection_v1{
+                             pattern = [],
+                             projection = Projection}},
+                same},
+
+               {#unregister_projections_v{
+                   args = #unregister_projections_v1{
+                             names = [?FUNCTION_NAME]}},
+                same},
+
+               {#dedup_ack_v{args = #dedup_ack_v1{ref = Ref}},
+                same},
+
+               {#drop_dedups_v{args = #drop_dedups_v1{refs = []}},
+                same}],
+    lists:foreach(
+      fun({OldRecord, ExpectedNewRecord}) ->
+              NewRecord = khepri_machine:convert_to_uniform_command(
+                            OldRecord),
+              case ExpectedNewRecord of
+                  same ->
+                      ?assertEqual(OldRecord, NewRecord);
+                  _ ->
+                      ?assertEqual(ExpectedNewRecord, NewRecord)
+              end
+      end, Records).

--- a/test/protect_against_dups_option.erl
+++ b/test/protect_against_dups_option.erl
@@ -266,7 +266,7 @@ dedup_ack_on_old_machine_test() ->
     S0 = khepri_machine:convert_state(S00, 0, 1),
 
     CommandRef = make_ref(),
-    DedupAck = #dedup_ack{ref = CommandRef},
+    DedupAck = #dedup_ack_v{args = #dedup_ack_v1{ref = CommandRef}},
     MacVer = 0,
 
     Meta0 = ?META,


### PR DESCRIPTION
## Why

In the past, when we had to change a command, like when dedup support was added, we chose to wrap an existing command into a new command and put the new attribute in the outer command.

This cannot scale because we will end up with new layers of wrapped commands each time we will want to add an attribute.

## How

Let's rework all commands now to be more future-proof.

All commands are replaced by new `#..._v{}` variants; "v" for "versioned". These new versioned variants have all the same layout:
* The first record field, called `args`, contains a record representing the command-specific attributes.
* The second record field, called `common`, contains a record representing the attributes shared by all commands.

The command-specific and common attributes records are also versioned.

The command-specific attributes records are basically what the old command was. The only exception is the `#put_v1{}` record which split the put and tree options into separate fields.

The common attributes records is versioned too. As of this commit, the record is empty.

Here is an example of a new versioned put command:

```erlang
#put_v{args = #put_v1{path = Path,
                      payload = Payload,
                      put_options = PutOptions,
                      tree_options = TreeOptions},
       common = #common_v1{}}.
```

The `#dedup{}` command was not converted to this new method. A follow-up commit will convert it to common attributes. There will be no replacement for this command.

Note that future commands may not use hte `_v` suffix. It was used here because we need to keep old commands around.