### PR TITLE
khepri_machine: Add `where` trigger option

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -414,6 +414,23 @@
 %% khepri_machine:split_command_options/2} and {@link
 %% khepri_machine:split_put_options/2} must be adapted.
 
+-type trigger_options() :: #{where =>
+                             khepri_event_handler:trigger_exec_loc() | local}.
+%% Options specific to trigger registrations.
+%%
+%% <ul>
+%% <li>`where' allows to indicate on which member(s) of the cluster a
+%% triggered action should be executed. With `{member, MemberNode}', if the
+%% target member is not part of the cluster at the time the action is
+%% triggered, the trigger is executed on the leader. The special value `local'
+%% means that the node running `khepri_machine:register_trigger/5' will
+%% execute the trigger (if it is a member of the cluster at the time the
+%% action is triggered).</li>
+%% </ul>
+%%
+%% NOTE: When this list of trigger options is modified, {@link
+%% khepri_machine:split_command_options/2} must be adapted.
+
 -type fold_fun() :: fun((khepri_path:native_path(),
                          khepri:node_props(),
                          khepri:fold_acc()) -> khepri:fold_acc()).
@@ -524,6 +541,7 @@
               query_options/0,
               tree_options/0,
               put_options/0,
+              trigger_options/0,
 
               fold_fun/0,
               fold_acc/0,
@@ -2848,7 +2866,7 @@ register_trigger(TriggerId, EventFilter, StoredProcPath) ->
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
-      Options :: command_options(),
+      Options :: command_options() | khepri:trigger_options(),
       Ret :: ok | error().
 %% @doc Registers a trigger.
 %%
@@ -2881,7 +2899,7 @@ register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
-      Options :: command_options(),
+      Options :: command_options() | khepri:trigger_options(),
       Ret :: ok | error().
 %% @doc Registers a trigger.
 %%

--- a/src/khepri_event_handler.erl
+++ b/src/khepri_event_handler.erl
@@ -42,7 +42,7 @@
 %% It is the stored procedure pointed to by the path in the triggered action's
 %% arguments.
 
--type trigger_exec_loc() :: leader | {member, node()}.
+-type trigger_exec_loc() :: leader | {member, node()} | all_members.
 %% Where to execute the triggered action.
 %%
 %% It supports the following locations:
@@ -51,6 +51,8 @@
 %% action is triggered.</li>
 %% <li>`{member, Member}': the action is executed on the given node if it is a
 %% member of the cluster, or the leader otherwise.</li>
+%% <li>`all_members': the action is executed on all members of the
+%% cluster.</li>
 %% </ul>
 
 -type trigger_descriptor() :: #khepri_trigger{}.

--- a/src/khepri_event_handler.erl
+++ b/src/khepri_event_handler.erl
@@ -42,13 +42,15 @@
 %% It is the stored procedure pointed to by the path in the triggered action's
 %% arguments.
 
--type trigger_exec_loc() :: leader.
+-type trigger_exec_loc() :: leader | {member, node()}.
 %% Where to execute the triggered action.
 %%
 %% It supports the following locations:
 %% <ul>
 %% <li>`leader': the action is executed on the leader node at the time the
 %% action is triggered.</li>
+%% <li>`{member, Member}': the action is executed on the given node if it is a
+%% member of the cluster, or the leader otherwise.</li>
 %% </ul>
 
 -type trigger_descriptor() :: #khepri_trigger{}.

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -84,6 +84,9 @@
 %% `#register_trigger_v2{}' command and `#triggered_v2{}', stored in the
 %% machine state. The extended mechanism continues to support stored procedure
 %% (the previous mechanism is not used with version 4).</li>
+%% <li>Started to cache the list of cluster member nodenames in the machine
+%% state. The machine state was modified to add the `cached_members' list at
+%% its end.</li>
 %% </ul>
 %% </td>
 %% </tr>
@@ -160,6 +163,7 @@
          get_metrics/1,
          get_init_args/1,
          get_dedups/1,
+         get_cached_members/1,
          get_store_id/1]).
 
 -ifdef(TEST).
@@ -202,7 +206,8 @@
                    #unregister_projections_v{} |
                    #dedup_ack_v{} |
                    #drop_dedups_v{} |
-                   #request_snapshot{}.
+                   #request_snapshot{} |
+                   #cache_members_list{}.
 %% Commands specific to this Ra machine.
 
 -type old_command() :: #put{} |
@@ -247,17 +252,18 @@
          metrics = #{} :: khepri_machine:metrics(),
 
          %% Added in machine version 1.
-         dedups = #{} :: khepri_machine:dedups_map()}).
+         dedups = #{} :: khepri_machine:dedups_map(),
 
--opaque state_v1() :: #khepri_machine{}.
-%% State of this Ra state machine, version 1.
-%%
-%% Note that this type is used also for machine version 2. Machine version 2
-%% changes the type of an opaque member of the {@link khepri_tree} record and
-%% doesn't need any changes to the `khepri_machine' type. See the moduledoc of
-%% this module for more information about version 2.
+         %% Added in machine version 4.
+         cached_members :: khepri_machine:cached_members_list() |
+                           undefined}).
 
--type state() :: state_v1() | khepri_machine_v0:state().
+-opaque state_v4() :: #khepri_machine{}.
+%% State of this Ra state machine, version 4.
+
+-type state() :: state_v4() |
+                 khepri_machine_v1:state() |
+                 khepri_machine_v0:state().
 %% State of this Ra state machine.
 
 -type triggers_map() :: #{khepri:trigger_id() =>
@@ -272,7 +278,7 @@
                               }}.
 %% Internal triggers map in the machine state (v2).
 %%
-%% This new format was introduced in version 3 of the state machine to take
+%% This new format was introduced in version 4 of the state machine to take
 %% into account the execution of an MFA or the send of a message to a process.
 
 -type metrics() :: #{applied_command_count => non_neg_integer(),
@@ -298,6 +304,9 @@
 
 -type dedups_map() :: #{reference() => {any(), integer()}}.
 %% Map to handle command deduplication.
+
+-type cached_members_list() :: [node() | node()].
+%% Non-empty list of cluster member nodenames.
 
 -type aux_state() :: #khepri_machine_aux{}.
 %% Auxiliary state of this Ra state machine.
@@ -339,7 +348,8 @@
                          multi_table_projections |
                          uniform_commands |
                          request_snapshot |
-                         extended_trigger.
+                         extended_trigger |
+                         cached_members_list.
 %% Name of a state machine API behaviour.
 
 -export_type([write_ret/0,
@@ -348,11 +358,12 @@
 
               machine_init_args/0,
               state/0,
-              state_v1/0,
+              state_v4/0,
               triggers_map/0,
               triggers_map_v2/0,
               metrics/0,
               dedups_map/0,
+              cached_members_list/0,
               props/0,
               triggered/0,
               triggered_v2/0,
@@ -1600,6 +1611,36 @@ init_aux(StoreId) ->
       Effects :: ra_machine:effects().
 %% @private
 
+handle_aux(leader, cast, eval, AuxState, IntState) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
+    EffectiveMacVer = ra_aux:effective_machine_version(IntState),
+    CachesMembersList = does_api_comply_with(
+                          cached_members_list, EffectiveMacVer),
+    SideEffects1 = case CachesMembersList of
+                       true ->
+                           State = ra_aux:machine_state(IntState),
+                           Cluster = ra_aux:members_info(IntState),
+                           Members1 = maps:fold(
+                                        fun({_StoreId, Node}, _, Acc) ->
+                                                [Node | Acc]
+                                        end, [], Cluster),
+                           Members2 = lists:sort(Members1),
+                           case khepri_machine:get_cached_members(State) of
+                               Members2 ->
+                                   [];
+                               _ ->
+                                   Command1 = #cache_members_list{
+                                                 args = #cache_members_list_v1{
+                                                           members = Members2}},
+                                   Command2 = compute_command_size(Command1),
+                                   SideEffect1 = {append, Command2},
+                                   [SideEffect1]
+                           end;
+                       false ->
+                           []
+                   end,
+    {no_reply, AuxState1, IntState, SideEffects1};
 handle_aux(
   _RaState, {call, From},
   {query, _QueryFun, Options} = AuxQuery,
@@ -2057,6 +2098,17 @@ do_apply(
     {State1, SideEffects} = release_cursor(State, RaftIndex, Reason, []),
     Ret = {State1, ok, SideEffects},
     post_apply(Ret, Meta, Command);
+do_apply(
+  #{machine_version := MacVer} = Meta,
+  #cache_members_list{
+     args = #cache_members_list_v1{members = Members}} = Command,
+  State) when MacVer >= ?API_BEHAV_MACVER(cached_members_list) ->
+    %% `#cached_members_list{}' is emitted by the `handle_aux/5' clause for
+    %% the `eval' effect to periodically update our internal copy of the
+    %% cluster member nodenames list.
+    State1 = set_cached_members(State, Members),
+    Ret = {State1, ok},
+    post_apply(Ret, Meta, Command);
 do_apply(Meta, {machine_version, OldMacVer, NewMacVer} = Command, OldState) ->
     NewState = convert_state(OldState, OldMacVer, NewMacVer),
     Ret = {NewState, ok},
@@ -2193,7 +2245,8 @@ convert_to_uniform_command(Command)
        is_record(Command, unregister_projections_v) orelse
        is_record(Command, dedup_ack_v) orelse
        is_record(Command, drop_dedups_v) orelse
-       is_record(Command, request_snapshot) ->
+       is_record(Command, request_snapshot) orelse
+       is_record(Command, cache_members_list) ->
     %% These are all uniform/versioned commands already. We list them
     %% explicitly to reduce the risk of programming errors with wildcard
     %% pattern matching.
@@ -2369,6 +2422,8 @@ does_command_support_common_args(#drop_dedups_v{}) ->
     true;
 does_command_support_common_args(#request_snapshot{}) ->
     true;
+does_command_support_common_args(#cache_members_list{}) ->
+    true;
 does_command_support_common_args(#put{}) ->
     false;
 does_command_support_common_args(#delete{}) ->
@@ -2423,6 +2478,8 @@ get_command_common_args(#drop_dedups_v{common = CommonArgs}) ->
     CommonArgs;
 get_command_common_args(#request_snapshot{common = CommonArgs}) ->
     CommonArgs;
+get_command_common_args(#cache_members_list{common = CommonArgs}) ->
+    CommonArgs;
 get_command_common_args(#put{}) ->
     none;
 get_command_common_args(#delete{}) ->
@@ -2474,7 +2531,9 @@ set_command_common_args(#dedup_ack_v{} = Command, CommonArgs) ->
 set_command_common_args(#drop_dedups_v{} = Command, CommonArgs) ->
     Command#drop_dedups_v{common = CommonArgs};
 set_command_common_args(#request_snapshot{} = Command, CommonArgs) ->
-    Command#request_snapshot{common = CommonArgs}.
+    Command#request_snapshot{common = CommonArgs};
+set_command_common_args(#cache_members_list{} = Command, CommonArgs) ->
+    Command#cache_members_list{common = CommonArgs}.
 
 -spec set_dedup_args(Command, CommandRef, Expiry) -> NewCommand when
       Command :: khepri_machine:command(),
@@ -3213,7 +3272,7 @@ clear_compiled_projection_tree() ->
 %% @private
 
 is_state(State) ->
-    is_record(State, khepri_machine) orelse khepri_machine_v0:is_state(State).
+    is_record(State, khepri_machine) orelse khepri_machine_v1:is_state(State).
 
 -spec ensure_is_state(State) -> ok when
       State :: khepri_machine:state().
@@ -3235,12 +3294,12 @@ ensure_is_state(State) ->
 get_config(#khepri_machine{config = Config}) ->
     Config;
 get_config(State) ->
-    khepri_machine_v0:get_config(State).
+    khepri_machine_v1:get_config(State).
 
 -spec set_config(State, Config) -> NewState when
-      State :: khepri_machine:state_v1(),
+      State :: khepri_machine:state_v4(),
       Config :: khepri_config:machine_config_v1(),
-      NewState :: khepri_machine:state_v1().
+      NewState :: khepri_machine:state_v4().
 %% @doc Replaces the config in the given state.
 %%
 %% There is no need to support `khepri_machine_v0' because the configuration is
@@ -3262,7 +3321,7 @@ set_config(#khepri_machine{} = State, Config) ->
 get_tree(#khepri_machine{tree = Tree}) ->
     Tree;
 get_tree(State) ->
-    khepri_machine_v0:get_tree(State).
+    khepri_machine_v1:get_tree(State).
 
 -spec set_tree(State, Tree) -> NewState when
       State :: khepri_machine:state(),
@@ -3275,7 +3334,7 @@ get_tree(State) ->
 set_tree(#khepri_machine{} = State, Tree) ->
     State#khepri_machine{tree = Tree};
 set_tree(State, Tree) ->
-    khepri_machine_v0:set_tree(State, Tree).
+    khepri_machine_v1:set_tree(State, Tree).
 
 -spec get_root(State) -> Root when
       State :: khepri_machine:state(),
@@ -3325,7 +3384,7 @@ get_keep_while_conds_revidx(State) ->
 get_triggers(#khepri_machine{triggers = Triggers}) ->
     Triggers;
 get_triggers(State) ->
-    khepri_machine_v0:get_triggers(State).
+    khepri_machine_v1:get_triggers(State).
 
 -spec set_triggers(State, Triggers) -> NewState when
       State :: khepri_machine:state(),
@@ -3339,7 +3398,7 @@ get_triggers(State) ->
 set_triggers(#khepri_machine{} = State, Triggers) ->
     State#khepri_machine{triggers = Triggers};
 set_triggers(State, Triggers) ->
-    khepri_machine_v0:set_triggers(State, Triggers).
+    khepri_machine_v1:set_triggers(State, Triggers).
 
 -spec get_emitted_triggers(State) -> EmittedTriggers when
       State :: khepri_machine:state(),
@@ -3351,7 +3410,7 @@ set_triggers(State, Triggers) ->
 get_emitted_triggers(#khepri_machine{emitted_triggers = EmittedTriggers}) ->
     EmittedTriggers;
 get_emitted_triggers(State) ->
-    khepri_machine_v0:get_emitted_triggers(State).
+    khepri_machine_v1:get_emitted_triggers(State).
 
 -spec set_emitted_triggers(State, EmittedTriggers) -> NewState when
       State :: khepri_machine:state(),
@@ -3364,7 +3423,7 @@ get_emitted_triggers(State) ->
 set_emitted_triggers(#khepri_machine{} = State, EmittedTriggers) ->
     State#khepri_machine{emitted_triggers = EmittedTriggers};
 set_emitted_triggers(State, EmittedTriggers) ->
-    khepri_machine_v0:set_emitted_triggers(State, EmittedTriggers).
+    khepri_machine_v1:set_emitted_triggers(State, EmittedTriggers).
 
 -spec get_projections(State) -> Projections when
       State :: khepri_machine:state(),
@@ -3376,7 +3435,7 @@ set_emitted_triggers(State, EmittedTriggers) ->
 get_projections(#khepri_machine{projections = Projections}) ->
     Projections;
 get_projections(State) ->
-    khepri_machine_v0:get_projections(State).
+    khepri_machine_v1:get_projections(State).
 
 -spec has_projection(ProjectionTree, ProjectionName) -> boolean() when
       ProjectionTree :: khepri_machine:projection_tree(),
@@ -3408,7 +3467,7 @@ has_projection(ProjectionTree, Name) when is_atom(Name) ->
 set_projections(#khepri_machine{} = State, Projections) ->
     State#khepri_machine{projections = Projections};
 set_projections(State, Projections) ->
-    khepri_machine_v0:set_projections(State, Projections).
+    khepri_machine_v1:set_projections(State, Projections).
 
 -spec get_metrics(State) -> Metrics when
       State :: khepri_machine:state(),
@@ -3420,7 +3479,7 @@ set_projections(State, Projections) ->
 get_metrics(#khepri_machine{metrics = Metrics}) ->
     Metrics;
 get_metrics(State) ->
-    khepri_machine_v0:get_metrics(State).
+    khepri_machine_v1:get_metrics(State).
 
 -spec set_metrics(State, Metrics) -> NewState when
       State :: khepri_machine:state(),
@@ -3433,7 +3492,7 @@ get_metrics(State) ->
 set_metrics(#khepri_machine{} = State, Metrics) ->
     State#khepri_machine{metrics = Metrics};
 set_metrics(State, Metrics) ->
-    khepri_machine_v0:set_metrics(State, Metrics).
+    khepri_machine_v1:set_metrics(State, Metrics).
 
 -spec get_init_args(State) -> InitArgs when
       State :: khepri_machine:state(),
@@ -3471,8 +3530,8 @@ set_init_args(State, InitArgs) ->
 
 get_dedups(#khepri_machine{dedups = Dedups}) ->
     Dedups;
-get_dedups(_State) ->
-    #{}.
+get_dedups(State) ->
+    khepri_machine_v1:get_dedups(State).
 
 -spec set_dedups(State, Dedups) -> NewState when
       State :: khepri_machine:state(),
@@ -3484,7 +3543,32 @@ get_dedups(_State) ->
 
 set_dedups(#khepri_machine{} = State, Dedups) ->
     State#khepri_machine{dedups = Dedups};
-set_dedups(State, _Dedups) ->
+set_dedups(State, Dedups) ->
+    khepri_machine_v1:set_dedups(State, Dedups).
+
+-spec get_cached_members(State) -> Members when
+      State :: khepri_machine:state(),
+      Members :: khepri_machine:cached_members_list() | undefined.
+%% @doc Returns the cached list of cluster members from the given state.
+%%
+%% @private
+
+get_cached_members(#khepri_machine{cached_members = Members}) ->
+    Members;
+get_cached_members(_State) ->
+    undefined.
+
+-spec set_cached_members(State, Members) -> NewState when
+      State :: khepri_machine:state(),
+      Members :: khepri_machine:cached_members_list(),
+      NewState :: khepri_machine:state().
+%% @doc Sets the cached list of cluster members in the given state.
+%%
+%% @private
+
+set_cached_members(#khepri_machine{} = State, Members) ->
+    State#khepri_machine{cached_members = Members};
+set_cached_members(State, _Members) ->
     State.
 
 -spec get_store_id(State) -> StoreId when
@@ -3545,7 +3629,7 @@ assert_equal(#khepri_machine{} = State1, #khepri_machine{} = State2) ->
     ?assertEqual(State1, State2),
     ok;
 assert_equal(State1, State2) ->
-    khepri_machine_v0:assert_equal(State1, State2).
+    khepri_machine_v1:assert_equal(State1, State2).
 
 -ifdef(TEST).
 -spec make_virgin_state(InitArgs) -> State when
@@ -3600,18 +3684,26 @@ convert_state1(State, 1, 2) ->
 convert_state1(State, 2, 3) ->
     State;
 convert_state1(State, 3, 4) ->
-    Params = get_init_args(State),
-    Config0 = get_config(State),
-    Config1 = khepri_config:convert_config(Config0, 0, 1, Params),
-    State1 = set_config(State, Config1),
+    %% To go from version 3 to version 4, we add the `cached_members' fields
+    %% at the end of the record. The default value is `undefined'.
+    ?assert(khepri_machine_v1:is_state(State)),
+    Fields0 = khepri_machine_v1:state_to_list(State),
+    Fields1 = Fields0 ++ [undefined],
+    State1 = list_to_tuple(Fields1),
+    ?assert(is_state(State1)),
 
-    Triggers = get_triggers(State1),
+    Params = get_init_args(State1),
+    Config0 = get_config(State1),
+    Config1 = khepri_config:convert_config(Config0, 0, 1, Params),
+    State2 = set_config(State1, Config1),
+
+    Triggers = get_triggers(State2),
     Triggers1 = maps:map(
                   fun(_TriggerId, Trigger) ->
                           trigger_v1_to_v2(Trigger)
                   end, Triggers),
-    State2 = set_triggers(State1, Triggers1),
-    State2.
+    State3 = set_triggers(State2, Triggers1),
+    State3.
 
 trigger_v1_to_v2(#{sproc := StoredProcPath} = Trigger) ->
     Trigger1 = Trigger#{action => {sproc, StoredProcPath},

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -87,6 +87,9 @@
 %% <li>Started to cache the list of cluster member nodenames in the machine
 %% state. The machine state was modified to add the `cached_members' list at
 %% its end.</li>
+%% <li>Added the `where' option for triggers, to allow the caller to decide on
+%% which cluster member(s) the trigger action is executed. See {@link
+%% khepri:trigger_options()}.</li>
 %% </ul>
 %% </td>
 %% </tr>
@@ -752,7 +755,7 @@ handle_tx_exception(
       TriggerId :: khepri:trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       StoredProcPath :: khepri_path:path(),
-      Options :: khepri:command_options(),
+      Options :: khepri:command_options() | khepri:trigger_options(),
       Ret :: ok | khepri:error().
 %% @doc Registers a trigger.
 %%
@@ -762,6 +765,7 @@ handle_tx_exception(
 %%        stored procedure.
 %% @param StoredProcPath the path to the stored procedure to execute when the
 %%        corresponding event occurs.
+%% @param Options command and trigger options map.
 %%
 %% @returns `ok' if the trigger was registered, an `{error, Reason}' tuple
 %% otherwise.
@@ -772,35 +776,63 @@ register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options)
     EventFilter1 = khepri_evf:wrap(EventFilter),
     StoredProcPath1 = khepri_path:from_string(StoredProcPath),
     khepri_path:ensure_is_valid(StoredProcPath1),
+    {CommandOptions, NonCommandOptions} = split_command_options(
+                                            StoreId, Options),
     case does_api_comply_with(uniform_commands, StoreId) of
         true ->
             register_trigger_versioned(
               StoreId, TriggerId, EventFilter1, StoredProcPath1,
-              Options);
+              CommandOptions, NonCommandOptions);
         false ->
             register_trigger_nonversioned(
               StoreId, TriggerId, EventFilter1, StoredProcPath1,
-              Options)
+              CommandOptions, NonCommandOptions)
     end.
 
 register_trigger_nonversioned(
-  StoreId, TriggerId, EventFilter, StoredProcPath, Options) ->
-    Command = #register_trigger{id = TriggerId,
-                                event_filter = EventFilter,
-                                sproc = StoredProcPath},
-    process_command(StoreId, Command, Options).
+  StoreId, TriggerId, EventFilter, StoredProcPath,
+  CommandOptions, NonCommandOptions) ->
+    UnsupportedOptions = maps:filter(
+                           fun
+                               (where, _) -> true;
+                               (_, _)     -> false
+                           end, NonCommandOptions),
+    if
+        UnsupportedOptions =:= #{} ->
+            Command = #register_trigger{id = TriggerId,
+                                        event_filter = EventFilter,
+                                        sproc = StoredProcPath},
+            process_command(StoreId, Command, CommandOptions);
+        true ->
+            ?khepri_misuse(
+               unsupported_trigger_options,
+               #{trigger_id => TriggerId,
+                 event_filter => EventFilter,
+                 options => UnsupportedOptions})
+    end.
 
 register_trigger_versioned(
-  StoreId, TriggerId, EventFilter, StoredProcPath, Options) ->
+  StoreId, TriggerId, EventFilter, StoredProcPath,
+  CommandOptions, NonCommandOptions) ->
     ?assert(does_api_comply_with(extended_trigger, StoreId)),
     StoredProcPath1 = khepri_path:realpath(StoredProcPath),
     Action = {sproc, StoredProcPath1},
+    NonCommandOptions1 = case NonCommandOptions of
+                             #{where := local} ->
+                                 %% Interpret the `local' value and replace it
+                                 %% with this node name.
+                                 Where = {member, node()},
+                                 NonCommandOptions#{where => Where};
+                             _ ->
+                                 NonCommandOptions
+                         end,
     CommandArgs = #register_trigger_v1{
                      id = TriggerId,
                      event_filter = EventFilter,
-                     action = Action},
+                     action = Action,
+                     options = NonCommandOptions1},
     Command = #register_trigger_v{args = CommandArgs},
-    process_command(StoreId, Command, Options).
+    process_command(StoreId, Command, CommandOptions).
 
 -spec register_projection(StoreId, PathPattern, Projection, Options) ->
     Ret when
@@ -1015,7 +1047,9 @@ split_query_options(StoreId, Options) ->
       StoreId :: khepri:store_id(),
       Options :: CommandOptions | NonCommandOptions,
       CommandOptions :: khepri:command_options(),
-      NonCommandOptions :: khepri:tree_options() | khepri:put_options().
+      NonCommandOptions :: khepri:tree_options() |
+                           khepri:put_options() |
+                           khepri:trigger_options().
 %% @private
 
 split_command_options(StoreId, Options) ->
@@ -1043,6 +1077,11 @@ split_command_options(StoreId, Options) ->
               KeepWhile1 = khepri_condition:ensure_native_keep_while(
                              KeepWhile),
               NC1 = NC#{keep_while => KeepWhile1},
+              {C, NC1};
+          (where, Where, {C, NC}) ->
+              %% `where' is kept in `NonCommandOptions' here. The state
+              %% machine will extract it in `apply()'.
+              NC1 = NC#{where => Where},
               {C, NC1}
       end, {#{}, #{}}, Options1).
 
@@ -1606,8 +1645,9 @@ init_aux(StoreId) ->
       Command :: any(),
       AuxState :: aux_state(),
       IntState :: ra_aux:internal_state(),
-      Ret :: {no_reply, AuxState, IntState} |
-             {no_reply, AuxState, IntState, Effects},
+      Ret :: {no_reply, NewAuxState, IntState} |
+             {no_reply, NewAuxState, IntState, Effects},
+      NewAuxState :: aux_state(),
       Effects :: ra_machine:effects().
 %% @private
 
@@ -1707,8 +1747,34 @@ handle_aux(leader, cast, tick, AuxState, IntState) ->
     AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
     SideEffects0 = [],
     SideEffects1 = handle_expired_dedups(AuxState1, IntState, SideEffects0),
+    SideEffects2 = handle_irrelevant_triggers(AuxState1, IntState, SideEffects1),
 
-    {no_reply, AuxState1, IntState, SideEffects1};
+    {no_reply, AuxState1, IntState, SideEffects2};
+handle_aux(
+  RaState, cast,
+  {handle_triggered_actions, TriggeredActions},
+  #khepri_machine_aux{store_id = StoreId} = AuxState,
+  IntState) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
+    Cluster = ra_aux:members_info(IntState),
+    TriggeredActions1 = lists:filter(
+                          fun
+                              (#triggered_v2{where = {member, MemberNode}}) ->
+                                  %% If the target member is not a cluster
+                                  %% member, we run the trigger on the leader.
+                                  MemberNode =:= node() orelse
+                                  (RaState =:= leader andalso
+                                   begin
+                                       Member = {StoreId, MemberNode},
+                                       IsMember = maps:is_key(Member, Cluster),
+                                       not IsMember
+                                   end);
+                              (#triggered_v2{where = _}) ->
+                                  false
+                          end, TriggeredActions),
+    khepri_event_handler:handle_triggered_actions(StoreId, TriggeredActions1),
+    {no_reply, AuxState1, IntState};
 handle_aux(_RaState, _Type, _Command, AuxState, IntState) ->
     AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
     {no_reply, AuxState1, IntState}.
@@ -1814,6 +1880,34 @@ handle_expired_dedups(AuxState, IntState, SideEffects) ->
             end;
         _ ->
             SideEffects
+    end.
+
+handle_irrelevant_triggers(AuxState, IntState, SideEffects) ->
+    %% Now that we can run triggers on followers, we need to verify if they
+    %% are still in the cluster at the time of execution. If they are not in
+    %% the cluster anymore, we can remove the non-acked emitted triggers from
+    %% the machine state because they won't be acked.
+    #khepri_machine_aux{store_id = StoreId} = AuxState,
+    Cluster = ra_aux:members_info(IntState),
+    State = ra_aux:machine_state(IntState),
+    EmittedTriggers = get_emitted_triggers(State),
+    CancelledTriggers = lists:filter(
+                          fun
+                              (#triggered_v2{where = {member, Node}}) ->
+                                  PossibleMember = {StoreId, Node},
+                                  not maps:is_key(PossibleMember, Cluster);
+                              (_) ->
+                                  false
+                          end, EmittedTriggers),
+    case CancelledTriggers of
+        [] ->
+            SideEffects;
+        _ ->
+            Command = #ack_triggered_v{
+                         args = #ack_triggered_v1{
+                                   triggered = CancelledTriggers}},
+            SideEffect = {append, Command},
+            [SideEffect | SideEffects]
     end.
 
 restore_projection(Projection, Tree, PathPattern) ->
@@ -1965,13 +2059,15 @@ do_apply(
   #register_trigger_v{
      args = #register_trigger_v1{id = TriggerId,
                                  event_filter = EventFilter,
-                                 action = Action}} = Command,
+                                 action = Action,
+                                 options = Options}} = Command,
   State) ->
     Triggers = get_triggers(State),
     EventFilter1 = normalize_event_filter(EventFilter),
+    Where = maps:get(where, Options, leader),
     Triggers1 = Triggers#{TriggerId => #{event_filter => EventFilter1,
                                          action => Action,
-                                         where => leader}},
+                                         where => Where}},
     State1 = set_triggers(State, Triggers1),
     Ret = {State1, ok},
     post_apply(Ret, Meta, Command);
@@ -2576,7 +2672,7 @@ compute_command_size(Command) ->
 %% @private
 
 state_enter(leader, State) ->
-    SideEffects = emitted_triggers_to_side_effects(State),
+    SideEffects = emitted_triggers_to_side_effects(State, leader),
     SideEffects;
 state_enter(recovered, _State) ->
     SideEffects = [{aux, restore_projections},
@@ -2603,24 +2699,57 @@ snapshot_installed(
     OldState1 = convert_state(OldState, OldMacVer, NewMacVer),
     ok = update_projections(OldState1, NewState),
     ok = clear_compiled_projection_tree(),
-    SideEffects = [{aux, cache_effective_machine_version}],
-    SideEffects.
+
+    SideEffects1 = [{aux, cache_effective_machine_version}],
+
+    %% Triggers might have been emitted to run on this Ra member between the
+    %% old state and the new one. Let's filter all new emitted triggers and
+    %% reschedule execution if any. The fact that they should run on this Ra
+    %% member is verified in the aux handler.
+    EmittedTriggers1 = get_emitted_triggers(OldState),
+    EmittedTriggers2 = get_emitted_triggers(NewState),
+    NewlyEmittedTriggers = EmittedTriggers2 -- EmittedTriggers1,
+    SideEffects2 = emitted_triggers_to_side_effects(
+                     NewState, follower, NewlyEmittedTriggers, SideEffects1),
+
+    SideEffects2.
 
 %% @private
 
-emitted_triggers_to_side_effects(State) ->
+emitted_triggers_to_side_effects(State, RaState) ->
     StoreId = get_store_id(State),
     EmittedTriggers = get_emitted_triggers(State),
-    case EmittedTriggers of
-        [_ | _] ->
-            SideEffect = {mod_call,
-                          khepri_event_handler,
-                          handle_triggered_actions,
-                          [StoreId, EmittedTriggers]},
-            [SideEffect];
-        [] ->
-            []
-    end.
+    emitted_triggers_to_side_effects(StoreId, RaState, EmittedTriggers, []).
+
+emitted_triggers_to_side_effects(
+  StoreId, RaState, TriggeredActions, SideEffects) ->
+    {ModCalls, AuxEvents} = split_actions_executed_on_leader(
+                              TriggeredActions),
+    SideEffects1 = case ModCalls of
+                       [] ->
+                           SideEffects;
+                       _ when RaState =/= leader ->
+                           SideEffects;
+                       _ ->
+                           %% We emit a `mod_call' effect to wake up the event
+                           %% handler process so it doesn't have to poll the
+                           %% internal list.
+                           SideEffect1 = {mod_call,
+                                          khepri_event_handler,
+                                          handle_triggered_actions,
+                                          [StoreId, ModCalls]},
+                           [SideEffect1 | SideEffects]
+                   end,
+    SideEffects2 = case AuxEvents of
+                       [] ->
+                           SideEffects1;
+                       _ ->
+                           SideEffect2 = {aux,
+                                          {handle_triggered_actions,
+                                           AuxEvents}},
+                           [SideEffect2 | SideEffects1]
+                   end,
+    SideEffects2.
 
 -spec overview(State) -> Overview when
       State :: khepri_machine:state(),
@@ -3069,13 +3198,9 @@ add_trigger_side_effects(InitialState, NewState, Events, SideEffects) ->
             NewState1 = set_emitted_triggers(
                           NewState, EmittedTriggers ++ TriggeredActions),
 
-            %% We emit a `mod_call' effect to wake up the event handler
-            %% process so it doesn't have to poll the internal list.
-            SideEffect = {mod_call,
-                          khepri_event_handler,
-                          handle_triggered_actions,
-                          [StoreId, TriggeredActions]},
-            {NewState1, [SideEffect | SideEffects]}
+            SideEffects1 = emitted_triggers_to_side_effects(
+                             StoreId, leader, TriggeredActions, SideEffects),
+            {NewState1, SideEffects1}
     end.
 
 list_triggered_actions(InitialState, NewState, Events, Triggers) ->
@@ -3218,6 +3343,16 @@ get_trigger_id_and_event_filter(
 get_trigger_id_and_event_filter(
   #triggered_v2{id = Id, event_filter = EventFilter}) ->
     {Id, EventFilter}.
+
+split_actions_executed_on_leader(TriggeredActions) ->
+    lists:partition(
+      fun
+          (#triggered{}) ->
+              %% Old triggers are always executed on the leader.
+              true;
+          (#triggered_v2{where = Where}) ->
+              Where =:= leader
+      end, TriggeredActions).
 
 -spec get_compiled_projection_tree(ProjectionTree) -> CompiledProjectionTree
     when

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1760,6 +1760,8 @@ handle_aux(
     Cluster = ra_aux:members_info(IntState),
     TriggeredActions1 = lists:filter(
                           fun
+                              (#triggered_v2{where = all_members}) ->
+                                  true;
                               (#triggered_v2{where = {member, MemberNode}}) ->
                                   %% If the target member is not a cluster
                                   %% member, we run the trigger on the leader.
@@ -1770,7 +1772,8 @@ handle_aux(
                                        IsMember = maps:is_key(Member, Cluster),
                                        not IsMember
                                    end);
-                              (#triggered_v2{where = _}) ->
+                              (#triggered_v2{where = Where}) ->
+                                  ?assertNotEqual(all_members, Where),
                                   false
                           end, TriggeredActions),
     khepri_event_handler:handle_triggered_actions(StoreId, TriggeredActions1),
@@ -3195,6 +3198,9 @@ add_trigger_side_effects(InitialState, NewState, Events, SideEffects) ->
             %% This could lead to multiple execution of the same trigger,
             %% therefore the action must be idempotent.
             EmittedTriggers = get_emitted_triggers(InitialState),
+            %% FIXME: Add several copies of the emitted trigger (or use a
+            %% refcount) if where = all_members. We need that for the ack
+            %% mechanism.
             NewState1 = set_emitted_triggers(
                           NewState, EmittedTriggers ++ TriggeredActions),
 
@@ -3294,8 +3300,24 @@ evaluate_action(State, Event, TriggerId, Trigger, TriggeredActions)
                                    where = Where,
                                    event = Event}
                         end,
-            [Triggered | TriggeredActions]
+            evaluate_where_option(State, Triggered, TriggeredActions)
     end.
+
+evaluate_where_option(
+  _State, #triggered{} = Triggered, TriggeredActions) ->
+    [Triggered | TriggeredActions];
+evaluate_where_option(
+  _State, #triggered_v2{where = Where} = Triggered, TriggeredActions)
+  when Where =/= all_members ->
+    [Triggered | TriggeredActions];
+evaluate_where_option(
+  State, #triggered_v2{where = all_members} = Triggered, TriggeredActions) ->
+    Members = get_cached_members(State),
+    Triggered1 = lists:map(
+                   fun(Member) ->
+                           Triggered#triggered_v2{where = {member, Member}}
+                   end, Members),
+    Triggered1 ++ TriggeredActions.
 
 find_stored_proc(Tree, StoredProcPath) ->
     TreeOptions = #{expect_specific_node => true,

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -30,7 +30,8 @@
 
           uniform_commands            => 4,
           request_snapshot            => 4,
-          extended_trigger            => 4}).
+          extended_trigger            => 4,
+          cached_members_list         => 4}).
 
 %% Get the state machine version the given API behaviour was introduced in.
 %% This is similar to `khepri_machine:api_behaviour_to_machine_version/1' but
@@ -269,7 +270,7 @@
 %% Arguments to the snapshot request command, version 1.
 %%
 %% <ul>
-%% <li>`reasaon' is string dscribing the reason why a snapshot is
+%% <li>`reason' is string dscribing the reason why a snapshot is
 %% requested.</li>
 %% </ul>
 
@@ -279,6 +280,23 @@
 %%
 %% <ul>
 %% <li>`args' contains the snapshot request-specific attributes.</li>
+%% <li>`common' contains the attributes shared by all commands.</li>
+%% </ul>
+
+-record(cache_members_list_v1,
+        {members :: khepri_machine:cached_members_list()}).
+%% Arguments to cluster members cached list update command.
+%%
+%% <ul>
+%% <li>`members' is a list of clustered Erlang node names.</li>
+%% </ul>
+
+-record(cache_members_list, {args :: #cache_members_list_v1{},
+                             common = none :: #common_v1{} | none}).
+%% Command to update the list of cluster members cached in the machine state.
+%%
+%% <ul>
+%% <li>`args' contains the command-specific attributes.</li>
 %% <li>`common' contains the attributes shared by all commands.</li>
 %% </ul>
 

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -122,7 +122,8 @@
 -record(register_trigger_v1,
         {id :: khepri:trigger_id(),
          event_filter :: khepri_evf:event_filter(),
-         action :: khepri_event_handler:trigger_action()}).
+         action :: khepri_event_handler:trigger_action(),
+         options = #{} :: khepri:trigger_options()}).
 %% Trigger registration-specific attributes.
 %%
 %% <ul>

--- a/src/khepri_machine_v1.erl
+++ b/src/khepri_machine_v1.erl
@@ -1,0 +1,281 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright © 2025 Broadcom. All Rights Reserved. The term "Broadcom"
+%% refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+%% @doc
+%% Khepri machine state V1 handling functions.
+%%
+%% @hidden
+
+-module(khepri_machine_v1).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-include("src/khepri_machine.hrl").
+
+%% Internal functions to access the opaque #khepri_machine{} state.
+-export([is_state/1,
+         get_config/1,
+         get_tree/1, set_tree/2,
+         get_triggers/1, set_triggers/2,
+         get_emitted_triggers/1, set_emitted_triggers/2,
+         get_projections/1, set_projections/2,
+         get_metrics/1, set_metrics/2,
+         get_dedups/1, set_dedups/2,
+         assert_equal/2,
+         state_to_list/1]).
+
+-record(khepri_machine,
+        {config :: khepri_config:machine_config(),
+         tree = khepri_tree:new() :: khepri_tree:tree(),
+         triggers = #{} :: khepri_machine:triggers_map() |
+                           khepri_machine:triggers_map_v2(),
+         emitted_triggers = [] :: [khepri_machine:triggered()],
+         projections = khepri_pattern_tree:empty() ::
+                       khepri_machine:projection_tree(),
+         metrics = #{} :: khepri_machine:metrics(),
+
+         %% Added in machine version 1.
+         dedups = #{} :: khepri_machine:dedups_map()}).
+
+-opaque state() :: #khepri_machine{}.
+%% State of this Ra state machine, version 1.
+%%
+%% Note that this type is used also for machine version 2 and 3.
+%%
+%% Machine version 2 changes the type of an opaque member of the {@link
+%% khepri_tree} record and doesn't need any changes to the `khepri_machine'
+%% type.
+%%
+%% Machine version 3 did not change the machine state record.
+%%
+%% See the moduledoc of {@link khepri_machine} for more information about
+%% version 2.
+
+-export_type([state/0]).
+
+%% -------------------------------------------------------------------
+%% State record management functions.
+%% -------------------------------------------------------------------
+
+-spec is_state(State) -> IsState when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      IsState :: boolean().
+%% @doc Tells if the given argument is a valid state.
+%%
+%% @private
+
+is_state(State) ->
+    is_record(State, khepri_machine) orelse khepri_machine_v0:is_state(State).
+
+-spec get_config(State) -> Config when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Config :: khepri_config:machine_config().
+%% @doc Returns the config from the given state.
+%%
+%% @private
+
+get_config(#khepri_machine{config = Config}) ->
+    Config;
+get_config(State) ->
+    khepri_machine_v0:get_config(State).
+
+-spec get_tree(State) -> Tree when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Tree :: khepri_tree:tree().
+%% @doc Returns the tree from the given state.
+%%
+%% @private
+
+get_tree(#khepri_machine{tree = Tree}) ->
+    Tree;
+get_tree(State) ->
+    khepri_machine_v0:get_tree(State).
+
+-spec set_tree(State, Tree) -> NewState when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Tree :: khepri_tree:tree(),
+      NewState :: khepri_machine_v1:state() |
+                  khepri_machine_v0:state().
+%% @doc Sets the tree in the given state.
+%%
+%% @private
+
+set_tree(#khepri_machine{} = State, Tree) ->
+    State#khepri_machine{tree = Tree};
+set_tree(State, Tree) ->
+    khepri_machine_v0:set_tree(State, Tree).
+
+-spec get_triggers(State) -> Triggers when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Triggers :: khepri_machine:triggers_map().
+%% @doc Returns the triggers from the given state.
+%%
+%% @private
+
+get_triggers(#khepri_machine{triggers = Triggers}) ->
+    Triggers;
+get_triggers(State) ->
+    khepri_machine_v0:get_triggers(State).
+
+-spec set_triggers(State, Triggers) -> NewState when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Triggers :: khepri_machine:triggers_map(),
+      NewState :: khepri_machine_v1:state() |
+                  khepri_machine_v0:state().
+%% @doc Sets the triggers in the given state.
+%%
+%% @private
+
+set_triggers(#khepri_machine{} = State, Triggers) ->
+    State#khepri_machine{triggers = Triggers};
+set_triggers(State, Triggers) ->
+    khepri_machine_v0:set_triggers(State, Triggers).
+
+-spec get_emitted_triggers(State) -> EmittedTriggers when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      EmittedTriggers :: [khepri_machine:triggered()].
+%% @doc Returns the emitted_triggers from the given state.
+%%
+%% @private
+
+get_emitted_triggers(#khepri_machine{emitted_triggers = EmittedTriggers}) ->
+    EmittedTriggers;
+get_emitted_triggers(State) ->
+    khepri_machine_v0:get_emitted_triggers(State).
+
+-spec set_emitted_triggers(State, EmittedTriggers) -> NewState when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      EmittedTriggers :: [khepri_machine:triggered()],
+      NewState :: khepri_machine_v1:state() |
+                  khepri_machine_v0:state().
+%% @doc Sets the emitted_triggers in the given state.
+%%
+%% @private
+
+set_emitted_triggers(#khepri_machine{} = State, EmittedTriggers) ->
+    State#khepri_machine{emitted_triggers = EmittedTriggers};
+set_emitted_triggers(State, EmittedTriggers) ->
+    khepri_machine_v0:set_emitted_triggers(State, EmittedTriggers).
+
+-spec get_projections(State) -> Projections when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Projections :: khepri_machine:projection_tree().
+%% @doc Returns the projections from the given state.
+%%
+%% @private
+
+get_projections(#khepri_machine{projections = Projections}) ->
+    Projections;
+get_projections(State) ->
+    khepri_machine_v0:get_projections(State).
+
+-spec set_projections(State, Projections) -> NewState when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Projections :: khepri_machine:projection_tree(),
+      NewState :: khepri_machine_v1:state() |
+                  khepri_machine_v0:state().
+%% @doc Sets the projections in the given state.
+%%
+%% @private
+
+set_projections(#khepri_machine{} = State, Projections) ->
+    State#khepri_machine{projections = Projections};
+set_projections(State, Projections) ->
+    khepri_machine_v0:set_projections(State, Projections).
+
+-spec get_metrics(State) -> Metrics when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Metrics :: khepri_machine:metrics().
+%% @doc Returns the metrics from the given state.
+%%
+%% @private
+
+get_metrics(#khepri_machine{metrics = Metrics}) ->
+    Metrics;
+get_metrics(State) ->
+    khepri_machine_v0:get_metrics(State).
+
+-spec set_metrics(State, Metrics) -> NewState when
+      State :: khepri_machine_v1:state() |
+                  khepri_machine_v0:state(),
+      Metrics :: khepri_machine:metrics(),
+      NewState :: khepri_machine_v1:state() |
+                  khepri_machine_v0:state().
+%% @doc Sets the metrics in the given state.
+%%
+%% @private
+
+set_metrics(#khepri_machine{} = State, Metrics) ->
+    State#khepri_machine{metrics = Metrics};
+set_metrics(State, Metrics) ->
+    khepri_machine_v0:set_metrics(State, Metrics).
+
+-spec get_dedups(State) -> Dedups when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Dedups :: khepri_machine:dedups_map().
+%% @doc Returns the dedups from the given state.
+%%
+%% @private
+
+get_dedups(#khepri_machine{dedups = Dedups}) ->
+    Dedups;
+get_dedups(_State) ->
+    #{}.
+
+-spec set_dedups(State, Dedups) -> NewState when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Dedups :: khepri_machine:dedups_map(),
+      NewState :: khepri_machine_v1:state() |
+                  khepri_machine_v0:state().
+%% @doc Sets the dedups in the given state.
+%%
+%% @private
+
+set_dedups(#khepri_machine{} = State, Dedups) ->
+    State#khepri_machine{dedups = Dedups};
+set_dedups(State, _Dedups) ->
+    State.
+
+-spec state_to_list(State) -> Fields when
+      State :: khepri_machine_v1:state() |
+               khepri_machine_v0:state(),
+      Fields :: [any()].
+%% @doc Returns the fields of the state as a list.
+%%
+%% @private
+
+state_to_list(#khepri_machine{} = State) ->
+    tuple_to_list(State);
+state_to_list(State) ->
+    khepri_machine_v0:state_to_list(State).
+
+-spec assert_equal(State1, State2) -> ok when
+      State1 :: khepri_machine_v1:state() |
+                khepri_machine_v0:state(),
+      State2 :: khepri_machine_v1:state() |
+                khepri_machine_v0:state().
+
+assert_equal(#khepri_machine{} = State1, #khepri_machine{} = State2) ->
+    ?assertEqual(State1, State2),
+    ok;
+assert_equal(State1, State2) ->
+    khepri_machine_v0:assert_equal(State1, State2),
+    ok.

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -54,7 +54,12 @@
          async_command_leader_change_in_three_node_cluster/1,
          spam_txs_during_election/1,
          spam_changes_during_unregister_projections/1,
-         can_wait_for_effective_behaviour/1]).
+         can_wait_for_effective_behaviour/1,
+         trigger_runs_on_leader/1,
+         trigger_runs_on_follower/1,
+         trigger_runs_on_local_member/1,
+         trigger_runs_on_leader_if_non_member_target/1,
+         trigger_options_rejected_before_v3/1]).
 
 all() ->
     [
@@ -73,7 +78,8 @@ groups() ->
            can_start_store_in_specified_data_dir_on_single_node,
            requesting_snapshot_on_old_machine_does_not_crash,
            can_set_snapshot_interval,
-           can_use_snapshot_strategy_from_macver4
+           can_use_snapshot_strategy_from_macver4,
+           trigger_options_rejected_before_v3
           ]},
          {parallel, [parallel],
           [
@@ -111,7 +117,11 @@ groups() ->
            async_command_leader_change_in_three_node_cluster,
            spam_txs_during_election,
            spam_changes_during_unregister_projections,
-           can_wait_for_effective_behaviour
+           can_wait_for_effective_behaviour,
+           trigger_runs_on_leader,
+           trigger_runs_on_follower,
+           trigger_runs_on_local_member,
+           trigger_runs_on_leader_if_non_member_target
           ]}
         ]}
       ]}
@@ -2844,3 +2854,272 @@ can_wait_for_effective_behaviour(Config) ->
          Config, FirstNode,
          khepri_cluster, wait_for_effective_machine_version,
          [{StoreId, FirstNode}, 1000000, 500])).
+
+trigger_runs_on_leader(Config) ->
+    trigger_runs_on_where(Config, ?FUNCTION_NAME, leader).
+
+trigger_runs_on_follower(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1 | _] = maps:keys(PropsPerNode),
+    trigger_runs_on_where(Config, ?FUNCTION_NAME, {member, Node1}).
+
+trigger_runs_on_local_member(Config) ->
+    trigger_runs_on_where(Config, ?FUNCTION_NAME, local).
+
+trigger_runs_on_leader_if_non_member_target(Config) ->
+    trigger_runs_on_where(Config, ?FUNCTION_NAME, {member, node()}).
+
+trigger_runs_on_where(Config, Testcase, Where) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    [Node1, Node2, Node3] = Nodes = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    RaSystem = helpers:get_ra_system_name(Config),
+    StoreId = RaSystem,
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 helpers:call(
+                   Config, Node, khepri, start, [RaSystem, StoreId]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 helpers:call(
+                   Config, Node, khepri_cluster, join, [StoreId, Node3]))
+      end, [Node1, Node2]),
+
+    Path = [foo],
+    EventFilter = khepri_evf:tree(Path),
+    StoredProcPath = [sproc],
+
+    ct:pal("Put store procedure"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, put,
+         [StoreId, StoredProcPath, make_sproc(self(), Testcase)])),
+
+    ct:pal("Register trigger"),
+    RegisterNode = Node2,
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, RegisterNode,
+         khepri, register_trigger,
+         [StoreId, Testcase, EventFilter, StoredProcPath,
+          #{where => Where}])),
+
+    ct:pal("Put a value in the store to trigger the stored procedure"),
+    ?assertEqual(
+       ok,
+       helpers:call(Config, Node1, khepri, put, [StoreId, Path, value])),
+
+    case Where of
+        leader ->
+            {_, LeaderNode} = helpers:get_leader_in_store(
+                                Config, StoreId, Nodes),
+
+            ct:pal("Wait for the trigger message from the leader node"),
+            receive
+                {sproc, Testcase, LeaderNode, _Props1} ->
+                    ok
+            after 60000 ->
+                      ct:pal(
+                        "Messages in inbox:~n~p",
+                        [erlang:process_info(self(), messages)]),
+                      ct:fail(
+                        "Did not receive the expected message from the "
+                        "trigger from ~s",
+                        [LeaderNode])
+            end,
+            receive
+                {sproc, Testcase, _MemberNode, _Props2} = Message ->
+                    ct:fail(
+                      "Received an unexpected message from the trigger:~n~p",
+                      [Message])
+            after 1000 ->
+                      ok
+            end;
+        {member, MemberNode}
+          when MemberNode =:= Node1 orelse
+               MemberNode =:= Node2 orelse
+               MemberNode =:= Node3 ->
+            %% We ensure the target member is not the leader.
+            {_, LeaderNode} = helpers:get_leader_in_store(
+                                Config, StoreId, Nodes),
+            [FutureLeader | _] = Nodes -- [MemberNode, LeaderNode],
+            ct:pal(
+              "Transter leadership from ~s to ~s",
+              [LeaderNode, FutureLeader]),
+            ?assertEqual(
+               ok,
+               helpers:call(
+                 Config, Node1, ra, transfer_leadership,
+                 [{StoreId, LeaderNode}, {StoreId, FutureLeader}])),
+
+            WantedLeaderId = {StoreId, FutureLeader},
+            wait_for_leader_to_be(Config, WantedLeaderId),
+            lists:foreach(
+              fun(Node) ->
+                      ?assertEqual(
+                         WantedLeaderId,
+                         helpers:get_leader_in_store(
+                           Config, StoreId, [Node])),
+                      ?assertNotEqual(FutureLeader, MemberNode)
+              end, Nodes),
+
+            ct:pal("Wait for the trigger message from a follower node"),
+            receive
+                {sproc, Testcase, MemberNode, _Props1} ->
+                    ok
+            after 60000 ->
+                      ct:pal(
+                        "Messages in inbox:~n~p",
+                        [erlang:process_info(self(), messages)]),
+                      ct:fail(
+                        "Did not receive the expected message from the "
+                        "trigger from ~s",
+                        [MemberNode])
+            end,
+            receive
+                {sproc, Testcase, _MemberNode, _Props2} = Message ->
+                    ct:fail(
+                      "Received an unexpected message from the trigger:~n~p",
+                      [Message])
+            after 1000 ->
+                      ok
+            end;
+        {member, _NonMemberNode} ->
+            %% The target node is not part of the cluster. In this case, the
+            %% message comes from the leader.
+            {_, LeaderNode} = helpers:get_leader_in_store(
+                                Config, StoreId, Nodes),
+
+            ct:pal("Wait for the trigger message from the leader node"),
+            receive
+                {sproc, Testcase, LeaderNode, _Props1} ->
+                    ok
+            after 60000 ->
+                      ct:pal(
+                        "Messages in inbox:~n~p",
+                        [erlang:process_info(self(), messages)]),
+                      ct:fail(
+                        "Did not receive the expected message from the "
+                        "trigger from ~s",
+                        [LeaderNode])
+            end,
+            receive
+                {sproc, Testcase, _MemberNode, _Props2} = Message ->
+                    ct:fail(
+                      "Received an unexpected message from the trigger:~n~p",
+                      [Message])
+            after 1000 ->
+                      ok
+            end;
+        local ->
+            ct:pal("Wait for the trigger message from the local node"),
+            receive
+                {sproc, Testcase, RegisterNode, _Props1} ->
+                    ok
+            after 60000 ->
+                      ct:pal(
+                        "Messages in inbox:~n~p",
+                        [erlang:process_info(self(), messages)]),
+                      ct:fail(
+                        "Did not receive the expected message from the "
+                        "trigger from ~s",
+                        [RegisterNode])
+            end,
+            receive
+                {sproc, Testcase, _MemberNode, _Props2} = Message ->
+                    ct:fail(
+                      "Received an unexpected message from the trigger:~n~p",
+                      [Message])
+            after 1000 ->
+                      ok
+            end
+    end,
+    ok.
+
+make_sproc(Pid, Testcase) ->
+    fun(Props) ->
+            Pid ! {sproc, Testcase, node(), Props}
+    end.
+
+wait_for_leader_to_be(Config, WantedLeaderId) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    Nodes = maps:keys(PropsPerNode),
+    wait_for_leader_to_be(Config, WantedLeaderId, Nodes, 60000).
+
+wait_for_leader_to_be(
+  Config,
+  {StoreId, _LeaderNode} = WantedLeaderId,
+  [Node | Rest] = Nodes,
+  TimeLeft) when TimeLeft >= 0 ->
+    LeaderId = helpers:call(
+                 Config, Node, ra_leaderboard, lookup_leader, [StoreId]),
+    case LeaderId of
+        WantedLeaderId ->
+            wait_for_leader_to_be(Config, WantedLeaderId, Rest, TimeLeft);
+        _ ->
+            Sleep = 500,
+            timer:sleep(Sleep),
+            TimeLeft1 = TimeLeft - Sleep,
+            wait_for_leader_to_be(Config, WantedLeaderId, Nodes, TimeLeft1)
+    end;
+wait_for_leader_to_be(_Config, _WantedLeaderId, [], _TimeLeft) ->
+    ok;
+wait_for_leader_to_be(_Config, WantedLeaderId, [Node | _], TimeLeft)
+  when TimeLeft < 0 ->
+    ct:fail(
+      "Timeout while waiting for leader to become ~0p on node ~p",
+      [WantedLeaderId, Node]).
+
+trigger_options_rejected_before_v3(Config) ->
+    RaSystem = helpers:get_ra_system_name(Config),
+    StoreId = RaSystem,
+
+    MacVer = 2,
+    meck:new(khepri_machine, [passthrough, no_link]),
+    meck:expect(khepri_machine, version, fun() -> MacVer end),
+
+    ct:pal("Start database"),
+    ?assertEqual(
+       {ok, StoreId},
+       khepri:start(RaSystem, StoreId)),
+
+    TriggerId = ?FUNCTION_NAME,
+    Path = [foo],
+    EventFilter = khepri_evf:tree(Path),
+    StoredProcPath = [sproc],
+
+    TriggerOptions = #{where => {member, node()}},
+    ?assertError(
+       ?khepri_exception(
+          unsupported_trigger_options,
+          #{trigger_id := TriggerId,
+            event_filter := EventFilter,
+            options := TriggerOptions}),
+       khepri:register_trigger(
+         StoreId, TriggerId, EventFilter, StoredProcPath, TriggerOptions)),
+
+    ?assertEqual(
+       ok,
+       khepri:register_trigger(
+         StoreId, TriggerId, EventFilter, StoredProcPath)),
+
+    ct:pal("Stop database"),
+    ?assertEqual(
+       ok,
+       khepri:stop(StoreId)),
+
+    meck:unload(khepri_machine),
+    ok.

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -58,6 +58,7 @@
          trigger_runs_on_leader/1,
          trigger_runs_on_follower/1,
          trigger_runs_on_local_member/1,
+         trigger_runs_on_all_members/1,
          trigger_runs_on_leader_if_non_member_target/1,
          trigger_options_rejected_before_v3/1]).
 
@@ -121,6 +122,7 @@ groups() ->
            trigger_runs_on_leader,
            trigger_runs_on_follower,
            trigger_runs_on_local_member,
+           trigger_runs_on_all_members,
            trigger_runs_on_leader_if_non_member_target
           ]}
         ]}
@@ -2866,6 +2868,9 @@ trigger_runs_on_follower(Config) ->
 trigger_runs_on_local_member(Config) ->
     trigger_runs_on_where(Config, ?FUNCTION_NAME, local).
 
+trigger_runs_on_all_members(Config) ->
+    trigger_runs_on_where(Config, ?FUNCTION_NAME, all_members).
+
 trigger_runs_on_leader_if_non_member_target(Config) ->
     trigger_runs_on_where(Config, ?FUNCTION_NAME, {member, node()}).
 
@@ -3038,6 +3043,31 @@ trigger_runs_on_where(Config, Testcase, Where) ->
                         "trigger from ~s",
                         [RegisterNode])
             end,
+            receive
+                {sproc, Testcase, _MemberNode, _Props2} = Message ->
+                    ct:fail(
+                      "Received an unexpected message from the trigger:~n~p",
+                      [Message])
+            after 1000 ->
+                      ok
+            end;
+        all_members ->
+            ct:pal("Wait for the trigger message from members"),
+            lists:foreach(
+              fun(Node) ->
+                      receive
+                          {sproc, Testcase, Node, _Props1} ->
+                              ok
+                      after 60000 ->
+                                ct:pal(
+                                  "Messages in inbox:~n~p",
+                                  [erlang:process_info(self(), messages)]),
+                                ct:fail(
+                                  "Did not receive the expected message "
+                                  "from the trigger from ~s",
+                                  [Node])
+                      end
+              end, Nodes),
             receive
                 {sproc, Testcase, _MemberNode, _Props2} = Message ->
                     ct:fail(

--- a/test/non_versioned_commands.erl
+++ b/test/non_versioned_commands.erl
@@ -187,7 +187,13 @@ convert_to_uniform_command_test() ->
                 same},
 
                {#drop_dedups_v{args = #drop_dedups_v1{refs = []}},
-                same}],
+                same},
+
+               {#cache_members_list{
+                   args = #cache_members_list_v1{
+                             members = [node()]}},
+                same}
+              ],
     lists:foreach(
       fun({OldRecord, ExpectedNewRecord}) ->
               NewRecord = khepri_machine:convert_to_uniform_command(


### PR DESCRIPTION
## Why

Historically, a triggered stored procedure was always executed on the leader at the time of the trigger. In the future, we will want this trigger to be executed on a specific member or all members.

This option allows the caller of `khepri:register_trigger/5` to indicate on which cluster member the action should run. This is only valid with the extended trigger support added in the parent commit.

This option supports the following values:
* `leader`: this is the same as the historical behaviour, i.e., the action is executed on the leader at the time of the trigger.
* `{member, MemberNode}`: the action is executed on the designated cluster member. If this node is not part of the cluster at the time of the trigger, it is executed on the leader.
* `local`: this is basically synonymous to `{member, node()}`, i.e., the action is executed on the node where `khepri_machine:register_trigger/5` was executed.
* `all_members`: the action is executed on all cluster members.

## How

There is no `mod_call` side effect in Ra to execute an arbitrary function call on a specific cluster member (or all of them). The `mod_call` side effect always runs on the leader.

Therefore, we use an `aux` handler, which is executed on all cluster members, to let each cluster member evaluate if it should executed the action or not.

There is a caveat though: if a follower skips command processing because it received a snapshot, it will not process the `aux` commands and thus will not execute the triggers that were suposed to run on it if it had seen all the commands sequentially.