### PR TITLE
khepri_machine: Check actual command when setting common args

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -168,7 +168,9 @@
          convert_state/3,
          set_tree/2,
          reset_metrics/1,
-         compute_command_size/1]).
+         compute_command_size/1,
+         does_command_support_common_args/1,
+         get_command_common_args/1]).
 -endif.
 
 -compile({no_auto_import, [apply/3]}).
@@ -1114,10 +1116,7 @@ set_default_options(StoreId, Options) ->
 %% @private
 
 process_command(StoreId, Command, Options) ->
-    Command1 = case does_api_comply_with(uniform_commands, StoreId) of
-                   true  -> compute_command_size(Command);
-                   false -> Command
-               end,
+    Command1 = compute_command_size(Command),
     CommandType = select_command_type(Options),
     case CommandType of
         sync ->
@@ -1161,7 +1160,7 @@ process_sync_command(
             {
              DedupEnabledCommand,
              DedupAckCommand
-            } = case does_api_comply_with(uniform_commands, StoreId) of
+            } = case does_command_support_common_args(Command) of
                     true ->
                         %% With the uniform commands, the dedup attributes (ref
                         %% and expiry) are passed with the command in its
@@ -2338,9 +2337,63 @@ trigger_delayed_aux_queries_eval(State, SideEffects, _Meta) ->
     SideEffects1 = [{aux, trigger_delayed_aux_queries_eval} | SideEffects],
     {State, SideEffects1}.
 
-%% In `get_command_common_args/1' and `set_command_common_args/2', we list
-%% supported commands exhaustively on purpose: this will help us when a new
-%% command is introduced to not forget to update this function.
+%% In `does_command_support_common_args/1', `get_command_common_args/1' and
+%% `set_command_common_args/2', we list supported commands exhaustively on
+%% purpose: this will help us when a new command is introduced to not forget to
+%% update this function.
+
+-spec does_command_support_common_args(Command) -> SupportsCommonArgs when
+      Command :: khepri_machine:command() |
+                 khepri_machine:old_command() |
+                 ra_machine:builtin_command(),
+      SupportsCommonArgs :: boolean().
+
+does_command_support_common_args(#put_v{}) ->
+    true;
+does_command_support_common_args(#delete_v{}) ->
+    true;
+does_command_support_common_args(#tx_v{}) ->
+    true;
+does_command_support_common_args(#register_trigger_v{}) ->
+    true;
+does_command_support_common_args(#ack_triggered_v{}) ->
+    true;
+does_command_support_common_args(#register_projection_v{}) ->
+    true;
+does_command_support_common_args(#unregister_projections_v{}) ->
+    true;
+does_command_support_common_args(#dedup_ack_v{}) ->
+    true;
+does_command_support_common_args(#drop_dedups_v{}) ->
+    true;
+does_command_support_common_args(#request_snapshot{}) ->
+    true;
+does_command_support_common_args(#put{}) ->
+    false;
+does_command_support_common_args(#delete{}) ->
+    false;
+does_command_support_common_args(#tx{}) ->
+    false;
+does_command_support_common_args(#register_trigger{}) ->
+    false;
+does_command_support_common_args(#ack_triggered{}) ->
+    false;
+does_command_support_common_args(#register_projection{}) ->
+    false;
+does_command_support_common_args(#unregister_projection{}) ->
+    false;
+does_command_support_common_args(#unregister_projections{}) ->
+    false;
+does_command_support_common_args(#dedup{}) ->
+    false;
+does_command_support_common_args(#dedup_ack{}) ->
+    false;
+does_command_support_common_args(#drop_dedups{}) ->
+    false;
+does_command_support_common_args({machine_version, _OldMacVer, _NewMacVer}) ->
+    false;
+does_command_support_common_args(_UnknownCommand) ->
+    false.
 
 -spec get_command_common_args(Command) -> Ret when
       Command :: khepri_machine:command() |
@@ -2444,16 +2497,21 @@ set_dedup_args(Command, CommandRef, Expiry)
     Command1.
 
 compute_command_size(Command) ->
-    CommonArgs = get_command_common_args(Command),
-    CommonArgs1 = case CommonArgs of
-                      #common_v1{} -> CommonArgs;
-                      none         -> #common_v1{}
-                  end,
-    Command1 = set_command_common_args(Command, CommonArgs1),
-    CommandSize = erlang:external_size(Command1),
-    CommonArgs2 = CommonArgs1#common_v1{command_size = CommandSize},
-    Command2 = set_command_common_args(Command1, CommonArgs2),
-    Command2.
+    case does_command_support_common_args(Command) of
+        true ->
+            CommonArgs = get_command_common_args(Command),
+            CommonArgs1 = case CommonArgs of
+                              #common_v1{} -> CommonArgs;
+                              none         -> #common_v1{}
+                          end,
+            Command1 = set_command_common_args(Command, CommonArgs1),
+            CommandSize = erlang:external_size(Command1),
+            CommonArgs2 = CommonArgs1#common_v1{command_size = CommandSize},
+            Command2 = set_command_common_args(Command1, CommonArgs2),
+            Command2;
+        false ->
+            Command
+    end.
 
 %% @private
 

--- a/test/non_versioned_commands.erl
+++ b/test/non_versioned_commands.erl
@@ -194,11 +194,29 @@ convert_to_uniform_command_test() ->
                             OldRecord),
               case ExpectedNewRecord of
                   same ->
+                      if
+                          is_record(OldRecord, dedup) ->
+                              ?assertNot(khepri_machine:does_command_support_common_args(OldRecord));
+                          true ->
+                              ?assert(khepri_machine:does_command_support_common_args(OldRecord))
+                      end,
                       ?assertEqual(OldRecord, NewRecord);
                   _ ->
+                      ?assertNot(khepri_machine:does_command_support_common_args(OldRecord)),
+                      ?assert(khepri_machine:does_command_support_common_args(NewRecord)),
+                      ?assertEqual(
+                         none,
+                         khepri_machine:get_command_common_args(OldRecord)),
                       ExpectedNewRecord1 = (
                         khepri_machine:compute_command_size(
                           ExpectedNewRecord)),
                       ?assertEqual(ExpectedNewRecord1, NewRecord)
               end
       end, Records).
+
+ra_builtin_commands_test() ->
+    MachineVersion = {machine_version, 0, 1},
+    ?assertNot(khepri_machine:does_command_support_common_args(MachineVersion)),
+    ?assertEqual(
+       none,
+       khepri_machine:get_command_common_args(MachineVersion)).


### PR DESCRIPTION
… instead of checking if the `uniform_commands` behaviour is active.

## Why

The code was basically this:

```erlang
Command = case does_api_comply_with(uniform_commands, StoreId) of
              true  -> #versioned_command{};
              false -> #nonversion_command{}
          end
case does_api_comply_with(uniform_commands, StoreId) of
    true ->
        %% Expect that `Command` is versioned.
        do_something_with_versioned_command(Command);
    false ->
        %% Expect that `Command` is non-versioned.
        do_something_with_nonversioned_command(Command)
end
```

Here, we checked `uniform_commands` twice to decide what command to create and what to do with it. However the check is not atomic: the behaviour could become active between both checks. If this happens, we end with a non-versioned command, running some code that expects a versioned command on it.

## How

The second part of the code should check the actual command to decide what to do, not look again at the behaviour state. In other words, we should check `uniform_commands` only when we create the command.