### PR TITLE
khepri_tree: Unwrap the `child_created` tag in `starting_node_in_rev_parent_tree/1`

### DIFF
--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -1278,15 +1278,18 @@ special_component_to_node_name(?THIS_KHEPRI_NODE, []) ->
 
 -spec starting_node_in_rev_parent_tree(ReversedParentTree) -> Node when
       Node :: tree_node(),
-      ReversedParentTree :: [Node].
+      ReversedParentTree :: [Node | {Node, child_created}].
 %% @private
 
 starting_node_in_rev_parent_tree(ReversedParentTree) ->
-    hd(lists:reverse(ReversedParentTree)).
+    case hd(lists:reverse(ReversedParentTree)) of
+        {Node, child_created} -> Node;
+        Node                  -> Node
+    end.
 
 -spec starting_node_in_rev_parent_tree(ReversedParentTree, Node) -> Node when
       Node :: tree_node(),
-      ReversedParentTree :: [Node].
+      ReversedParentTree :: [Node | {Node, child_created}].
 %% @private
 
 starting_node_in_rev_parent_tree([], CurrentNode) ->

--- a/test/advanced_put.erl
+++ b/test/advanced_put.erl
@@ -300,3 +300,18 @@ invalid_compare_and_swap_call_test_() ->
             #{path := _}),
          khepri_adv:compare_and_swap(
            ?FUNCTION_NAME, [?KHEPRI_WILDCARD_STAR], foo_value1, foo_value2))]}.
+
+put_many_using_cond_on_self_that_evaluates_to_false_test_() ->
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, #{}},
+         khepri_adv:put_many(
+           ?FUNCTION_NAME,
+           [foo,
+            #if_all{conditions = [?THIS_KHEPRI_NODE, #if_has_payload{}]}],
+           value)),
+      ?_assertMatch(
+         {error, ?khepri_error(node_not_found, _)},
+         khepri:get(?FUNCTION_NAME, [foo]))]}.


### PR DESCRIPTION
`#walk.reversed_parent_tree` holds `[#node{} | {#node{}, child_created}]` — the `child_created` tag marks an ancestor that was just created earlier in the same walk (see the `add_node_child`/`handle_branch` call sites that push it). `starting_node_in_rev_parent_tree/1` read the oldest entry off this list with plain `hd(lists:reverse(...))` without unwrapping that tag, so if the walk's outermost ancestor happened to be tagged, the function would return the `{#node{}, child_created}` tuple itself instead of the `#node{}` inside it. That value then flows into `Walk#walk{node = StartingNode}`, but `#walk.node`'s type is `#node{} | delete` — a tagged tuple there doesn't match any of the `walk_down_the_tree1/1` clauses that pattern-match on `#node{}` explicitly.

This mirrors the existing tag-unwrapping already done for the same field when popping a single parent for `?PARENT_KHEPRI_NODE` navigation (see the `case ParentNode0 of {PN, child_created} -> PN; _ -> ParentNode0 end` a few clauses above `walk_down_the_tree1/1`'s third clause).