### PR TITLE
khepri_machine: reduce memory used when updating and restoring projections

### DIFF
--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -1531,12 +1531,13 @@ restore_projection(Projection, Tree, PathPattern) ->
     _ = khepri_projection:init(Projection),
     TreeOptions = #{props_to_return => ?PROJECTION_PROPS_TO_RETURN,
                     include_root_props => true},
-    case khepri_tree:find_matching_nodes(Tree, PathPattern, TreeOptions) of
-        {ok, MatchingNodes} ->
-            maps:foreach(fun(Path, Props) ->
-                                 khepri_projection:trigger(
-                                   Projection, Path, #{}, Props)
-                         end, MatchingNodes);
+    Fun = fun(Path, Props, Acc) ->
+                  khepri_projection:trigger(Projection, Path, #{}, Props),
+                  Acc
+          end,
+    case khepri_tree:fold(Tree, PathPattern, Fun, ok, TreeOptions) of
+        {ok, ok} ->
+            ok;
         Error ->
             ?LOG_DEBUG(
                "Failed to recover projection ~s due to an error: ~p",

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -2842,24 +2842,8 @@ update_projection(Pattern, Projection, OldTree, NewTree) ->
                     include_root_props => true},
     case khepri_tree:find_matching_nodes(OldTree, Pattern, TreeOptions) of
         {ok, OldMatchingNodes} ->
-            Result = khepri_tree:find_matching_nodes(
-                       NewTree, Pattern, TreeOptions),
-            case Result of
-                {ok, NewMatchingNodes} ->
-                    Updates = diff_matching_nodes(
-                                OldMatchingNodes, NewMatchingNodes),
-                    maps:foreach(
-                      fun(Path, {OldProps, NewProps}) ->
-                              khepri_projection:trigger(
-                                Projection, Path, OldProps, NewProps)
-                      end, Updates);
-                Error ->
-                    ?LOG_DEBUG(
-                       "Failed to refresh projection ~s due to an error "
-                       "finding matching nodes in the new tree: ~p",
-                       [khepri_projection:name(Projection), Error],
-                       #{domain => [khepri, ra_machine]})
-            end;
+            update_projection1(
+              Pattern, Projection, NewTree, TreeOptions, OldMatchingNodes);
         Error ->
             ?LOG_DEBUG(
                "Failed to refresh projection ~s due to an error finding "
@@ -2868,24 +2852,41 @@ update_projection(Pattern, Projection, OldTree, NewTree) ->
                #{domain => [khepri, ra_machine]})
     end.
 
--spec diff_matching_nodes(OldNodeProps, NewNodeProps) -> Changes when
-      OldNodeProps :: khepri:node_props_map(),
-      NewNodeProps :: khepri:node_props_map(),
-      OldProps :: khepri:node_props(),
-      NewProps :: khepri:node_props(),
-      Changes :: #{khepri_path:native_path() => {OldProps, NewProps}}.
-%% @private
+update_projection1(
+  Pattern, Projection, NewTree, TreeOptions, OldMatchingNodes) ->
+    %% Folds over the new tree, looking up (and removing) each matching path
+    %% from `OldMatchingNodes' to trigger the projection immediately, instead
+    %% of materializing the new tree's matching node props into a second map
+    %% and diffing it against the first into a third.
+    Fun = fun(Path, NewProps, RemainingOldNodeProps) ->
+                  case maps:take(Path, RemainingOldNodeProps) of
+                      {OldProps, RemainingOldNodeProps1} ->
+                          khepri_projection:trigger(
+                            Projection, Path, OldProps, NewProps),
+                          RemainingOldNodeProps1;
+                      error ->
+                          khepri_projection:trigger(
+                            Projection, Path, #{}, NewProps),
+                          RemainingOldNodeProps
+                  end
+          end,
+    Ret = khepri_tree:fold(
+           NewTree, Pattern, Fun, OldMatchingNodes, TreeOptions),
+    case Ret of
+        {ok, RemainingOldNodeProps} ->
+            trigger_remaining(Projection, RemainingOldNodeProps);
+        Error ->
+            ?LOG_DEBUG(
+               "Failed to refresh projection ~s due to an error finding "
+               "matching nodes in the new tree: ~p",
+               [khepri_projection:name(Projection), Error],
+               #{domain => [khepri, ra_machine]})
+    end.
 
-diff_matching_nodes(OldNodeProps, NewNodeProps) ->
-    CommonProps = maps:intersect_with(
-                    fun(_Path, OldProps, NewProps) -> {OldProps, NewProps} end,
-                    OldNodeProps, NewNodeProps),
-    CommonPaths = maps:keys(CommonProps),
-    AllProps = maps:fold(
-                 fun(Path, OldProps, Acc) ->
-                        Acc#{Path => {OldProps, #{}}}
-                 end, CommonProps, maps:without(CommonPaths, OldNodeProps)),
-    maps:fold(
-      fun(Path, NewProps, Acc) ->
-              Acc#{Path => {#{}, NewProps}}
-      end, AllProps, maps:without(CommonPaths, NewNodeProps)).
+trigger_remaining(Projection, OldMatchingNodes) ->
+    %% The paths remaining in `OldMatchingNodes' after folding over the new
+    %% tree only matched in the old tree, i.e. they were deleted.
+    maps:foreach(
+      fun(Path, OldProps) ->
+              khepri_projection:trigger(Projection, Path, OldProps, #{})
+      end, OldMatchingNodes).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -60,6 +60,7 @@
 %% </table>
 
 -module(khepri_machine).
+-feature(maybe_expr, enable).
 -behaviour(ra_machine).
 
 -include_lib("kernel/include/logger.hrl").
@@ -2840,53 +2841,107 @@ set_of_projections(ProjectionTree) ->
 update_projection(Pattern, Projection, OldTree, NewTree) ->
     TreeOptions = #{props_to_return => ?PROJECTION_PROPS_TO_RETURN,
                     include_root_props => true},
-    case khepri_tree:find_matching_nodes(OldTree, Pattern, TreeOptions) of
-        {ok, OldMatchingNodes} ->
-            update_projection1(
-              Pattern, Projection, NewTree, TreeOptions, OldMatchingNodes);
+    maybe
+        %% Counts both sides, materializes the smaller side's matching node
+        %% props, then folds over the larger side. This bounds peak memory to
+        %% the smaller tree (plus some bookkeeping), instead of always
+        %% materializing the old tree regardless of which side is actually
+        %% larger.
+        {ok, OldCount} ?= count_matching_nodes(OldTree, Pattern),
+        {ok, NewCount} ?= count_matching_nodes(NewTree, Pattern),
+        case OldCount =< NewCount of
+            true ->
+                update_projection1(
+                  Pattern, Projection, old, OldTree, NewTree, TreeOptions);
+            false ->
+                update_projection1(
+                  Pattern, Projection, new, NewTree, OldTree, TreeOptions)
+        end
+    else
         Error ->
             ?LOG_DEBUG(
                "Failed to refresh projection ~s due to an error finding "
-               "matching nodes in the old tree: ~p",
+               "matching nodes: ~p",
                [khepri_projection:name(Projection), Error],
                #{domain => [khepri, ra_machine]})
     end.
 
+count_matching_nodes(Tree, Pattern) ->
+    khepri_tree:fold(
+      Tree, Pattern, fun khepri_tree:count_node_cb/3, 0,
+      #{include_root_props => true}).
+
 update_projection1(
-  Pattern, Projection, NewTree, TreeOptions, OldMatchingNodes) ->
-    %% Folds over the new tree, looking up (and removing) each matching path
-    %% from `OldMatchingNodes' to trigger the projection immediately, instead
-    %% of materializing the new tree's matching node props into a second map
-    %% and diffing it against the first into a third.
-    Fun = fun(Path, NewProps, RemainingOldNodeProps) ->
-                  case maps:take(Path, RemainingOldNodeProps) of
-                      {OldProps, RemainingOldNodeProps1} ->
-                          khepri_projection:trigger(
-                            Projection, Path, OldProps, NewProps),
-                          RemainingOldNodeProps1;
+  Pattern, Projection, MaterializedSide, MaterializedTree, FoldedTree,
+  TreeOptions) ->
+    %% Materializes the smaller side (`MaterializedTree') into a map, then
+    %% folds over the larger side (`FoldedTree') to trigger the projection for
+    %% each matching path as it is found.
+    Ret = khepri_tree:find_matching_nodes(
+            MaterializedTree, Pattern, TreeOptions),
+    case Ret of
+        {ok, MaterializedNodeProps} ->
+            fold_and_trigger(
+              Pattern, Projection, MaterializedSide, MaterializedNodeProps,
+              FoldedTree, TreeOptions);
+        Error ->
+            ?LOG_DEBUG(
+               "Failed to refresh projection ~s due to an error finding "
+               "matching nodes in the ~s tree: ~p",
+               [khepri_projection:name(Projection), MaterializedSide,
+                Error],
+               #{domain => [khepri, ra_machine]})
+    end.
+
+fold_and_trigger(
+  Pattern, Projection, MaterializedSide, MaterializedNodeProps, FoldedTree,
+  TreeOptions) ->
+    %% Folds over `FoldedTree', looking up (and removing) each matching path
+    %% from `MaterializedNodeProps' to trigger the projection immediately.
+    Fun = fun(Path, FoldedProps, RemainingNodeProps) ->
+                  case maps:take(Path, RemainingNodeProps) of
+                      {MaterializedProps, RemainingNodeProps1} ->
+                          trigger_projection(
+                            Projection, MaterializedSide, Path,
+                            MaterializedProps, FoldedProps),
+                          RemainingNodeProps1;
                       error ->
-                          khepri_projection:trigger(
-                            Projection, Path, #{}, NewProps),
-                          RemainingOldNodeProps
+                          trigger_projection(
+                            Projection, MaterializedSide, Path,
+                            #{}, FoldedProps),
+                          RemainingNodeProps
                   end
           end,
     Ret = khepri_tree:fold(
-           NewTree, Pattern, Fun, OldMatchingNodes, TreeOptions),
+            FoldedTree, Pattern, Fun, MaterializedNodeProps, TreeOptions),
     case Ret of
-        {ok, RemainingOldNodeProps} ->
-            trigger_remaining(Projection, RemainingOldNodeProps);
+        {ok, RemainingNodeProps} ->
+            trigger_remaining(
+              Projection, MaterializedSide, RemainingNodeProps);
         Error ->
+            FoldedSide = other_projection_side(MaterializedSide),
             ?LOG_DEBUG(
                "Failed to refresh projection ~s due to an error finding "
-               "matching nodes in the new tree: ~p",
-               [khepri_projection:name(Projection), Error],
+               "matching nodes in the ~s tree: ~p",
+               [khepri_projection:name(Projection), FoldedSide, Error],
                #{domain => [khepri, ra_machine]})
     end.
 
-trigger_remaining(Projection, OldMatchingNodes) ->
-    %% The paths remaining in `OldMatchingNodes' after folding over the new
-    %% tree only matched in the old tree, i.e. they were deleted.
+trigger_remaining(Projection, MaterializedSide, NodeProps) ->
+    %% The paths remaining in `NodeProps' after folding over the other side
+    %% only matched on `MaterializedSide'.
     maps:foreach(
-      fun(Path, OldProps) ->
-              khepri_projection:trigger(Projection, Path, OldProps, #{})
-      end, OldMatchingNodes).
+      fun(Path, MaterializedProps) ->
+              trigger_projection(
+                Projection, MaterializedSide, Path, MaterializedProps, #{})
+      end, NodeProps).
+
+other_projection_side(old) ->
+    new;
+other_projection_side(new) ->
+    old.
+
+trigger_projection(Projection, old, Path, OldProps, NewProps) ->
+    khepri_projection:trigger(Projection, Path, OldProps, NewProps);
+trigger_projection(Projection, new, Path, NewProps, OldProps) ->
+    khepri_projection:trigger(Projection, Path, OldProps, NewProps).


### PR DESCRIPTION
## Why

Refreshing a projection (`update_projection/4`) and restoring one after
recovery/snapshot (`restore_projection/3`) both fully materialized the
matching subtree into one or more `#{Path => NodeProps}` maps before
triggering the projection callback for each entry. On a large tree with
several registered projections, this showed up as a significant share of
the memory allocated while a node recovered its own state after a restart,
or while a follower caught up after a bulk write/delete on the leader.

## How

- `restore_projection/3` now folds directly over the tree and triggers the
  projection as each match is found, instead of collecting every match
  into a map first.
- `update_projection/4` now counts the matching nodes on both the old and
  new side (cheap), materializes whichever side is smaller into a map, and
  folds over the larger side, triggering the projection immediately for
  each match and removing it from the materialized map as it goes. This
  bounds peak memory to the smaller side regardless of which tree happens
  to be larger, instead of always fully materializing both sides (plus a
  diff of the two) as before.

Effectiveness tested using the attached tprof-based tests against `main` before rebasing on v0.17.x.

main:
```
restore_projection/3 (nodes=50000) allocated 9903121 words total (198.06 words/node, ceiling 190 words/node)
update_projection/4 (old=50000, new=500) allocated 12985157 words total (259.70 words/node of the larger side, ceiling 190 words/node)
update_projection/4 (old=50000, new=500) took 63635 us total (ceiling 175000 us)
update_projection/4 (old=500, new=50000) allocated 12985106 words total (259.70 words/node of the larger side, ceiling 190 words/node)
update_projection/4 (old=500, new=50000) took 71159 us total (ceiling 175000 us)
```

this PR:
```
reduce-projection-memory-usage:
restore_projection/3 (nodes=50000) allocated 6700668 words total (134.01 words/node, ceiling 190 words/node)
update_projection/4 (old=50000, new=500) allocated 8957554 words total (179.15 words/node of the larger side, ceiling 190 words/node)
update_projection/4 (old=50000, new=500) took 31300 us total (ceiling 175000 us)
update_projection/4 (old=500, new=50000) allocated 8957541 words total (179.15 words/node of the larger side, ceiling 190 words/node)
update_projection/4 (old=500, new=50000) took 35260 us total (ceiling 175000 us)
```

tprof-based tests used above:

[restore_projection_memory.erl.gz](https://github.com/user-attachments/files/30227150/restore_projection_memory.erl.gz)
[snapshot_projection_memory.erl.gz](https://github.com/user-attachments/files/30227151/snapshot_projection_memory.erl.gz)
