### PR TITLE
khepri_tx_adv: Fix crash converting delete return to legacy format

### DIFF
--- a/src/khepri_tx_adv.erl
+++ b/src/khepri_tx_adv.erl
@@ -1148,7 +1148,10 @@ maybe_write_ret_to_legacy_ret(PathPattern, {ok, NodePropsMap} = Ret) ->
             Ret;
         false ->
             {true, Path} = khepri_path:targets_specific_node(PathPattern),
-            NodeProps = maps:get(Path, NodePropsMap),
+            %% `Path' may not be in the `NodePropsMap' if it did not exist in
+            %% the first place before a delete. That's why we default to an
+            %% empty `NodeProps'.
+            NodeProps = maps:get(Path, NodePropsMap, #{}),
             {ok, NodeProps}
     end;
 maybe_write_ret_to_legacy_ret(_PathPattern, {error, _} = Error) ->

--- a/test/advanced_tx_delete.erl
+++ b/test/advanced_tx_delete.erl
@@ -32,6 +32,28 @@ delete_non_existing_node_test_() ->
                                                  node_is_target => true})},
          khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
 
+delete_non_existing_node_using_legacy_ret_test_() ->
+    MacVer = 1,
+    {setup,
+     fun() ->
+             test_ra_server_helpers:setup(
+               ?FUNCTION_NAME, #{machine_version => MacVer})
+     end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [?_assertEqual(
+         {ok, {ok, #{}}},
+         begin
+             Fun = fun() ->
+                           khepri_tx_adv:delete([foo])
+                   end,
+             khepri:transaction(?FUNCTION_NAME, Fun, rw)
+         end),
+      ?_assertEqual(
+         {error, ?khepri_error(node_not_found, #{node_name => foo,
+                                                 node_path => [foo],
+                                                 node_is_target => true})},
+         khepri_adv:get(?FUNCTION_NAME, [foo]))]}.
+
 delete_existing_node_test_() ->
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,


### PR DESCRIPTION
## What

`khepri_tx_adv:maybe_write_ret_to_legacy_ret/2` crashes with `{badkey, Path}` when converting a write's return value to the legacy (pre-0.17.0) format, if the targeted node is no longer present in `NodePropsMap`:

    NodeProps = maps:get(Path, NodePropsMap),   %% crashes if Path is gone

This conversion only runs when the transaction is applied on a cluster member that doesn't support `uniform_write_ret` yet (machine version < 2), e.g. during a mixed-version rolling upgrade. If a concurrent command removes the target node first, the write legitimately returns `{ok, #{}}` — a case `legacy_ret()`'s own type spec already allows for, but the conversion never handled.

## Where this was found

A RabbitMQ `quorum_queue_SUITE` mixed-version test (`concurrent_vhost_delete_with_quorum_queue`) that races two
concurrent `rabbit_vhost:delete` calls against the same vhost hits this ~10-20% of the time:

    {badkey,[rabbitmq,vhosts,<<"concurrent_delete_vhost">>,queues,<<"qq_5">>]}
    ...
    {khepri_tx_adv,maybe_write_ret_to_legacy_ret,2,
        [{file,"src/khepri_tx_adv.erl"},{line,1151}]}
    {rabbit_db_queue,'-delete_in_khepri/3-fun-0-',3, ...}

## Fix

Default to `#{}` via `maps:get(Path, NodePropsMap, #{})`.