### PR TITLE
Support process-lifetime-based triggers

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -391,25 +391,6 @@ of {@link khepri_export_erlang}.
 
 == Stored procedures and triggers ==
 
-=== Triggering a function after some event ===
-
-It is possible to associate events with an anonymous function to trigger its
-execution when something happens. This is what is usually called a
-<em>trigger</em> in databases and Khepri supports this feature.
-
-Currently, Khepri supports a single type of event, <em>tree changes</em>. This
-event is emitted whenever a tree node is being created, updated or deleted.
-
-Here is a summary of what happens when such an event is emitted:
-<ol>
-<li>Khepri looks up any <em>event filters</em> which could match the emitted
-event.</li>
-<li>If one or more event filters are found, their corresponding stored
-procedures are executed.</li>
-</ol>
-
-The indicated stored procedure must have been stored in the tree first.
-
 === Storing an anonymous function ===
 
 This is possible to store an anonymous function as the payload of a tree node:
@@ -430,9 +411,8 @@ messages, read or write from a disk, generate random numbers and so on.
 
 A stored procedure can accept any numbers of arguments too.
 
-It is possible to execute a stored procedure directly without configuring any
-triggers. To execute a stored procedure, you can call {@link
-khepri:run_sproc/3}. Here is an example:
+It is possible to execute a stored procedure directly. To execute a stored
+procedure, you can call {@link khepri:run_sproc/3}. Here is an example:
 
 ```
 Ret = khepri:run_sproc(
@@ -444,6 +424,33 @@ Ret = khepri:run_sproc(
 This works exactly like {@link erlang:apply/2}. The list of arguments passed
 to {@link khepri:run_sproc/3} must correspond to the stored procedure
 arity.
+
+It's also possible to executed a stored procedure after an event happened; see
+below.
+
+=== Triggering a function after some event ===
+
+Khepri can associate events with an anonymous function to trigger its execution
+when something happens. This is what is usually called a <em>trigger</em> in
+databases.
+
+Khepri supports the following types of event:
+<ul>
+<li><em>tree changes</em>. This event is emitted whenever a tree node is being
+created, updated or deleted.</li>
+<li><em>process termination</em>. This event is emitted when a monitored
+process exits.</li>
+</ul>
+
+Here is a summary of what happens when such an event is emitted:
+<ol>
+<li>Khepri looks up any <em>event filters</em> which could match the emitted
+event.</li>
+<li>If one or more event filters are found, their corresponding stored
+procedures are executed.</li>
+</ol>
+
+The indicated stored procedure must have been stored in the tree first.
 
 === Configuring a trigger ===
 
@@ -489,6 +496,36 @@ Neither the monitored path nor the stored procedure (pointed to by
 stored procedure doesn't exist when an event occurs, the event filter is
 simply ignored. A stored procedure can change after an event filter is
 registered as well.
+
+A process-based event filter can be created like this:
+```
+EventFilter = khepri_evf:process(Pid,                %% Required
+                                 #{priority => 10}). %% Optional
+'''
+
+This makes the Ra leader of the Khepri cluster monitor the given process. When
+the process exits or if it's not running in the first place, it will trigger
+the execution of the trigger action.
+
+If the monitored process is on a different Erlang node than the Ra leader, the
+loss of connection between the two nodes (i.e. the `noconnection' exit reason)
+is handled in a specific way:
+<ul>
+<li>If the remote node is a member of the Khepri cluster, Khepri will start to
+monitor that node after receiving the `noconnection' exit reaison. Then two
+things can happen:
+<ul>
+<li>The node comes back online. In this case, processes that are supposed to
+run on it are monitored again. If the node was restarted and the processes were
+killed, this new monitoring will detect this situation.</li>
+<li>The node is removed from the cluster. In this case, it is unlikely to come
+back. Thus, the processes that were running on it are considered as dead.</li>
+</ul></li>
+<li>If the remote node is not a member of the Khepri cluster, Khepri will
+consider that the processes supposed to run on this node are dead, even if this
+is network partition and the node and its processes could be reachable again in
+the future.</li>
+</ul>
 
 The stored procedure used for a trigger must accept a single argument, a map
 containing properties of the emitted event:

--- a/src/khepri_event_handler.erl
+++ b/src/khepri_event_handler.erl
@@ -148,11 +148,16 @@ prepare_action_arg(
     Arg.
 
 event_type(#ev_tree{}) ->
-    tree.
+    tree;
+event_type(#ev_process{}) ->
+    process.
 
 event_to_props(#ev_tree{path = Path, change = Change}) ->
     #{path => Path,
-     change => Change}.
+      change => Change};
+event_to_props(#ev_process{pid = Pid, change = Change}) ->
+    #{pid => Pid,
+      change => Change}.
 
 action_to_props({sproc, _StoredProc}) ->
     #{}.

--- a/src/khepri_evf.erl
+++ b/src/khepri_evf.erl
@@ -14,6 +14,7 @@
 -include("src/khepri_evf.hrl").
 
 -export([tree/1, tree/2,
+         process/1, process/2,
          wrap/1,
          get_priority/1,
          set_priority/2]).
@@ -38,12 +39,30 @@
 %% as a tree event filter. It will be automatically converted to a tree event
 %% filter with default properties.
 
--type event_filter() :: tree_event_filter().
+-type process_event_filter() :: #evf_process{}.
+%% A process event filter.
+%%
+%% It takes a PID to monitor and optionally properties.
+
+-type process_event_filter_props() :: #{priority => khepri_evf:priority()}.
+%% Tree event filter properties.
+%%
+%% The properties are:
+%% <ul>
+%% <li>`priority': a {@link priority()}</li>
+%% </ul>
+%%
+%% A Khepri path, whether it is a native path or a Unix-like path, can be used
+%% as a tree event filter. It will be automatically converted to a tree event
+%% filter with default properties.
+
+-type event_filter() :: tree_event_filter() | process_event_filter().
 %% An event filter.
 %%
 %% The following event filters are supported:
 %% <ul>
 %% <li>Tree event filter ({@link tree_event_filter()}</li>
+%% <li>Process event filter ({@link process_event_filter()}</li>
 %% </ul>
 %%
 %% An event filter can be explicitly constructed using the functions provided
@@ -52,7 +71,8 @@
 %% filter type for more details.
 
 -type event_filter_or_compat() :: khepri_evf:event_filter() |
-                                  khepri_path:pattern().
+                                  khepri_path:pattern() |
+                                  pid().
 %% An event filter, or any type that can be automatically converted to an
 %% event filter.
 %%
@@ -79,15 +99,27 @@
 %% `delete').</li>
 %% </ul>
 
--type event() :: tree_event().
+-type process_event() :: #ev_process{}.
+%% An event record representing a monitored process that exited.
+%%
+%% The event has the following fields:
+%% <ul>
+%% <li>`pid': the PID of the terminated process</li>
+%% <li>`reason': the exit reason</li>
+%% </ul>
+
+-type event() :: tree_event() | process_event().
 %% An record representing an event.
 
 -export_type([event_filter/0,
               event_filter_or_compat/0,
               tree_event_filter/0,
               tree_event_filter_props/0,
+              process_event_filter/0,
+              process_event_filter_props/0,
               priority/0,
               tree_event/0,
+              process_event/0,
               event/0]).
 
 -spec tree(PathPattern) -> EventFilter when
@@ -113,6 +145,28 @@ tree(PathPattern, Props) when ?IS_KHEPRI_PATH_PATTERN_OR_COMPAT(PathPattern) ->
     #evf_tree{path = PathPattern1,
               props = Props}.
 
+-spec process(Pid) -> EventFilter when
+      Pid :: pid(),
+      EventFilter :: khepri_evf:process_event_filter().
+%% @doc Constructs a process event filter.
+%%
+%% @see process/2.
+
+process(Pid) ->
+    process(Pid, #{}).
+
+-spec process(Pid, Props) -> EventFilter when
+      Pid :: pid(),
+      Props :: khepri_evf:process_event_filter_props(),
+      EventFilter :: khepri_evf:process_event_filter().
+%% @doc Constructs a process event filter.
+%%
+%% @see process_event_filter().
+
+process(Pid, Props) ->
+    #evf_process{pid = Pid,
+                 props = Props}.
+
 -spec wrap(Input) -> EventFilter when
       Input :: khepri_evf:event_filter_or_compat(),
       EventFilter :: khepri_evf:event_filter().
@@ -127,7 +181,9 @@ tree(PathPattern, Props) when ?IS_KHEPRI_PATH_PATTERN_OR_COMPAT(PathPattern) ->
 wrap(EventFilter) when ?IS_KHEPRI_EVENT_FILTER(EventFilter) ->
     EventFilter;
 wrap(PathPattern) when ?IS_KHEPRI_PATH_PATTERN_OR_COMPAT(PathPattern) ->
-    tree(PathPattern).
+    tree(PathPattern);
+wrap(Pid) when is_pid(Pid) ->
+    process(Pid).
 
 -spec get_priority(EventFilter) -> Priority when
       EventFilter :: khepri_evf:event_filter(),
@@ -139,6 +195,8 @@ wrap(PathPattern) when ?IS_KHEPRI_PATH_PATTERN_OR_COMPAT(PathPattern) ->
 %% @returns the priority.
 
 get_priority(#evf_tree{props = Props}) ->
+    get_priority1(Props);
+get_priority(#evf_process{props = Props}) ->
     get_priority1(Props).
 
 get_priority1(#{priority := Priority}) -> Priority;
@@ -156,7 +214,10 @@ get_priority1(_)                       -> 0.
 
 set_priority(#evf_tree{props = Props} = EventFilter, Priority) ->
     Props1 = set_priority1(Props, Priority),
-    EventFilter#evf_tree{props = Props1}.
+    EventFilter#evf_tree{props = Props1};
+set_priority(#evf_process{props = Props} = EventFilter, Priority) ->
+    Props1 = set_priority1(Props, Priority),
+    EventFilter#evf_process{props = Props1}.
 
 set_priority1(Props, Priority) when is_integer(Priority) ->
     Props#{priority => Priority}.

--- a/src/khepri_evf.hrl
+++ b/src/khepri_evf.hrl
@@ -8,12 +8,16 @@
 
 -record(evf_tree, {path :: khepri_path:native_pattern(),
                    props = #{} :: khepri_evf:tree_event_filter_props()}).
-%-record(evf_process, {pid :: pid(),
-%                      props = #{} :: #{on_reason => ets:match_pattern(),
-%                                       priority => integer()}}).
+
+-record(evf_process, {pid :: pid(),
+                      props = #{} :: khepri_evf:process_event_filter_props()}).
 
 -define(IS_KHEPRI_EVENT_FILTER(EventFilter),
-        (is_record(EventFilter, evf_tree))).
+        (is_record(EventFilter, evf_tree) orelse
+         is_record(EventFilter, evf_process))).
 
 -record(ev_tree, {path :: khepri_path:native_path(),
                   change :: create | update | delete}).
+
+-record(ev_process, {pid :: pid(),
+                     change :: {'DOWN', any()}}).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -90,6 +90,8 @@
 %% <li>Added the `where' option for triggers, to allow the caller to decide on
 %% which cluster member(s) the trigger action is executed. See {@link
 %% khepri:trigger_options()}.</li>
+%% <li>Added support for process-lifetime-based triggers. The trigger can be
+%% executed when a process exits.</li>
 %% </ul>
 %% </td>
 %% </tr>
@@ -1746,10 +1748,12 @@ handle_aux(
 handle_aux(leader, cast, tick, AuxState, IntState) ->
     AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
     SideEffects0 = [],
-    SideEffects1 = handle_expired_dedups(AuxState1, IntState, SideEffects0),
-    SideEffects2 = handle_irrelevant_triggers(AuxState1, IntState, SideEffects1),
+    SideEffects1 = handle_irrelevant_triggers(AuxState1, IntState, SideEffects0),
+    {AuxState2, SideEffects2} = handle_down_procs(
+                                  AuxState1, IntState, SideEffects1),
+    SideEffects3 = handle_expired_dedups(AuxState2, IntState, SideEffects2),
 
-    {no_reply, AuxState1, IntState, SideEffects2};
+    {no_reply, AuxState2, IntState, SideEffects3};
 handle_aux(
   RaState, cast,
   {handle_triggered_actions, TriggeredActions},
@@ -1778,6 +1782,45 @@ handle_aux(
                           end, TriggeredActions),
     khepri_event_handler:handle_triggered_actions(StoreId, TriggeredActions1),
     {no_reply, AuxState1, IntState};
+handle_aux(
+  _RaState, cast,
+  {down, Pid, Reason},
+  #khepri_machine_aux{store_id = StoreId,
+                      maybe_down_procs = MaybeDownProcs} = AuxState,
+  IntState)
+  when not is_map_key(Pid, MaybeDownProcs) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
+    Node = node(Pid),
+    PossibleMember = {StoreId, Node},
+    Cluster = ra_aux:members_info(IntState),
+    IsMember = maps:is_key(PossibleMember, Cluster),
+    case IsMember of
+        true ->
+            MaybeDownProcs1 = MaybeDownProcs#{Pid => Reason},
+            AuxState2 = AuxState1#khepri_machine_aux{
+                          maybe_down_procs = MaybeDownProcs1},
+            SideEffect = [{monitor, node, Node}],
+            {no_reply, AuxState2, IntState, [SideEffect]};
+        false ->
+            Command = {really_down, Pid, Reason},
+            SideEffect = [{append, Command}],
+            {no_reply, AuxState1, IntState, [SideEffect]}
+    end;
+handle_aux(
+  _RaState, cast,
+  {down, Pid, Reason},
+  #khepri_machine_aux{maybe_down_procs = MaybeDownProcs} = AuxState,
+  IntState)
+  when is_map_key(Pid, MaybeDownProcs) ->
+    AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
+
+    MaybeDownProcs1 = maps:remove(Pid, MaybeDownProcs),
+    AuxState2 = AuxState1#khepri_machine_aux{
+                  maybe_down_procs = MaybeDownProcs1},
+    Command = {really_down, Pid, Reason},
+    SideEffect = [{append, Command}],
+    {no_reply, AuxState2, IntState, [SideEffect]};
 handle_aux(_RaState, _Type, _Command, AuxState, IntState) ->
     AuxState1 = handle_delayed_aux_queries(AuxState, IntState),
     {no_reply, AuxState1, IntState}.
@@ -1912,6 +1955,43 @@ handle_irrelevant_triggers(AuxState, IntState, SideEffects) ->
             SideEffect = {append, Command},
             [SideEffect | SideEffects]
     end.
+
+handle_down_procs(
+  #khepri_machine_aux{store_id = StoreId,
+                      maybe_down_procs = MaybeDownProcs} = AuxState,
+  IntState, SideEffects) ->
+    %% In `maybe_down_procs', we have processes that run on a member of the
+    %% cluster and we are waiting for that node to come back up to monitor
+    %% these processes again (they are referenced by triggers).
+    %%
+    %% However, the member might have been removed from the cluster after
+    %% going down. Therefore, we need to verify on a regular basis if this
+    %% node is still part of the cluster. If that's not the case anymore, we
+    %% can consider these processes as dead, because it's unlikely that the
+    %% node will come back up.
+    Cluster = ra_aux:members_info(IntState),
+    {MaybeDownProcs1,
+     SideEffects1} = maps:fold(
+                       fun(Pid, Reason, {MD, SE} = Acc) ->
+                               Node = node(Pid),
+                               PossibleMember = {StoreId, Node},
+                               case maps:is_key(PossibleMember, Cluster) of
+                                   true ->
+                                       Acc;
+                                   false ->
+                                       %% The node was removed from the
+                                       %% cluster. Consider this process to be
+                                       %% gone.
+                                       Command2 = {really_down, Pid, Reason},
+                                       SideEffect = {append, Command2},
+                                       MD1 = maps:remove(Pid, MD),
+                                       SE1 = [SideEffect | SE],
+                                       {MD1, SE1}
+                               end
+                       end, {MaybeDownProcs, SideEffects}, MaybeDownProcs),
+    AuxState1 = AuxState#khepri_machine_aux{
+                  maybe_down_procs = MaybeDownProcs1},
+    {AuxState1, SideEffects1}.
 
 restore_projection(Projection, Tree, PathPattern) ->
     _ = khepri_projection:init(Projection),
@@ -2072,7 +2152,8 @@ do_apply(
                                          action => Action,
                                          where => Where}},
     State1 = set_triggers(State, Triggers1),
-    Ret = {State1, ok},
+    SideEffects = event_filter_to_side_effect(EventFilter, []),
+    Ret = {State1, ok, SideEffects},
     post_apply(Ret, Meta, Command);
 do_apply(
   Meta,
@@ -2217,6 +2298,60 @@ do_apply(Meta, {machine_version, OldMacVer, NewMacVer} = Command, OldState) ->
     %% determine what a user of Khepri can or cannot do.
     StoreId = get_store_id(NewState),
     cache_effective_machine_version(StoreId, NewMacVer),
+    post_apply(Ret, Meta, Command);
+do_apply(Meta, {down,  _Pid, noconnection} = Command, State) ->
+    %% We lost the connection to the node that hosted the monitored `Pid'.
+    %%
+    %% The handling is made in an aux handler because we need to access the
+    %% list of cluster members to check if that node is part of the cluster or
+    %% not.
+    %%
+    %% This allows to distinguish two cases:
+    %%   1. The node is a cluster member. We need to monitor the node to be
+    %%      notified when it comes back online. At which point, we can monitor
+    %%      `Pid' again. We also pay attention to nodes being removed from the
+    %%      cluster. If that node is removed, we consider the process to be
+    %%      gone. What's next is like the initial monitoring.
+    %%
+    %%   2. The node is not a cluster member. We just consider that the node
+    %%      and thus the process are gone forever. We don't try to manage a
+    %%      timer to let a chance to come back to that node.
+    AuxEffect = Command,
+    SideEffects = [{aux, AuxEffect}],
+    Ret = {State, ok, SideEffects},
+    post_apply(Ret, Meta, Command);
+do_apply(Meta, {Down,  Pid, Reason} = Command, State)
+  when Down =:= down orelse Down =:= really_down ->
+    %% Handle triggers. We lookup triggers watching this exited process and add
+    %% the side effects to execute the corresponding actions.
+    Event = #ev_process{pid = Pid, change = {'DOWN', Reason}},
+    {State1, SideEffects} = add_trigger_side_effects(
+                              State, State, [Event], []),
+    Ret = {State1, Meta, SideEffects},
+    post_apply(Ret, Meta, Command);
+do_apply(Meta, {nodeup, Node} = Command, State) ->
+    %% We can stop monitoring this node. If we get a `noconnection' from a
+    %% process again, we'll monitor it again.
+    SideEffects1 = [{demonitor, node, Node}],
+
+    %% We need to restore monitoring of processes that are hosted on that
+    %% specific node. This will tell us if the process are still there are
+    %% gone.
+    Triggers = get_triggers(State),
+    SideEffects2 = maps:fold(
+                     fun
+                         (_TriggerId,
+                          #{event_filter :=
+                            #evf_process{pid = Pid} = EventFilter},
+                          SE) when node(Pid) =:= Node ->
+                             event_filter_to_side_effect(EventFilter, SE);
+                         (_TriggerId, _Trigger, SE) ->
+                             SE
+                     end, SideEffects1, Triggers),
+    Ret = {State, Meta, SideEffects2},
+    post_apply(Ret, Meta, Command);
+do_apply(Meta, {nodedown, _Node} = Command, State) ->
+    Ret = {State, Meta},
     post_apply(Ret, Meta, Command);
 do_apply(Meta, NonVersionedCommand, State)
   when is_record(NonVersionedCommand, put) orelse
@@ -2363,7 +2498,9 @@ convert_to_uniform_command1(NewCommand) ->
 normalize_event_filter(#evf_tree{path = Path} = EventFilter) ->
     Path1 = khepri_path:realpath(Path),
     EventFilter1 = EventFilter#evf_tree{path = Path1},
-    EventFilter1.
+    EventFilter1;
+normalize_event_filter(#evf_process{} = EventFilter) ->
+    EventFilter.
 
 -spec post_apply(ApplyRet, Meta, Command) -> {State, Result, SideEffects} when
       ApplyRet :: {State, Result} | {State, Result, SideEffects},
@@ -2545,6 +2682,11 @@ does_command_support_common_args(#dedup_ack{}) ->
     false;
 does_command_support_common_args(#drop_dedups{}) ->
     false;
+does_command_support_common_args({Down, _Pid, _Reason})
+  when Down =:= down orelse Down =:= really_down ->
+    false;
+does_command_support_common_args({nodeup, _Node}) ->
+    false;
 does_command_support_common_args({machine_version, _OldMacVer, _NewMacVer}) ->
     false;
 does_command_support_common_args(_UnknownCommand) ->
@@ -2600,6 +2742,11 @@ get_command_common_args(#dedup{}) ->
 get_command_common_args(#dedup_ack{}) ->
     none;
 get_command_common_args(#drop_dedups{}) ->
+    none;
+get_command_common_args({Down, _Pid, _Reason})
+  when Down =:= down orelse Down =:= really_down ->
+    none;
+get_command_common_args({nodeup, _Node}) ->
     none;
 get_command_common_args({machine_version, _OldMacVer, _NewMacVer}) ->
     none;
@@ -2675,8 +2822,9 @@ compute_command_size(Command) ->
 %% @private
 
 state_enter(leader, State) ->
-    SideEffects = emitted_triggers_to_side_effects(State, leader),
-    SideEffects;
+    SideEffects1 = emitted_triggers_to_side_effects(State, leader),
+    SideEffects2 = non_emitted_triggers_to_side_effects(State, SideEffects1),
+    SideEffects2;
 state_enter(recovered, _State) ->
     SideEffects = [{aux, restore_projections},
                    {aux, cache_effective_machine_version}],
@@ -2753,6 +2901,14 @@ emitted_triggers_to_side_effects(
                            [SideEffect2 | SideEffects1]
                    end,
     SideEffects2.
+
+non_emitted_triggers_to_side_effects(State, SideEffects) ->
+    Triggers = get_triggers(State),
+    SideEffects1 = maps:fold(
+                     fun(_TriggerId, #{event_filter := EventFilter}, SE) ->
+                             event_filter_to_side_effect(EventFilter, SE)
+                     end, SideEffects, Triggers),
+    SideEffects1.
 
 -spec overview(State) -> Overview when
       State :: khepri_machine:state(),
@@ -3175,6 +3331,20 @@ evaluate_projection(
     Effect = {aux, Trigger},
     [Effect | Effects].
 
+-spec event_filter_to_side_effect(EventFilter, SideEffects) ->
+    NewSideEffects when
+      EventFilter :: khepri_evf:event_filter(),
+      SideEffects :: ra_machine:effects(),
+      NewSideEffects :: ra_machine:effects().
+%% @private
+
+event_filter_to_side_effect(#evf_tree{}, SideEffects) ->
+    SideEffects;
+event_filter_to_side_effect(#evf_process{pid = Pid}, SideEffects) ->
+    SideEffect = {monitor, process, Pid},
+    SideEffects1 = [SideEffect | SideEffects],
+    SideEffects1.
+
 add_trigger_side_effects(InitialState, NewState, Events, SideEffects) ->
     %% We want to consider the new state (with the updated tree), but we want
     %% to use triggers from the initial state, in case they were updated too.
@@ -3256,7 +3426,18 @@ evaluate_trigger(
               NewState, Event, TriggerId, Trigger, TriggeredActions);
         false ->
             TriggeredActions
-    end.
+    end;
+evaluate_trigger(
+  _InitialState, NewState,
+  #ev_process{pid = Pid} = Event, TriggerId,
+  #{event_filter := #evf_process{pid = Pid}} = Trigger,
+  TriggeredActions) ->
+    %% TODO: Match the exit reason if an optional pattern was provided.
+    evaluate_action(
+      NewState, Event, TriggerId, Trigger, TriggeredActions);
+evaluate_trigger(_InitialState, _NewState, _Event, _TriggerId, _Trigger, TriggeredActions) ->
+    %% The event does not match the event filter.
+    TriggeredActions.
 
 evaluate_action(State, Event, TriggerId, Trigger, TriggeredActions)
   when is_map_key(sproc, Trigger) orelse

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -10,7 +10,8 @@
 
 -record(khepri_machine_aux,
         {store_id :: khepri:store_id(),
-         delayed_aux_queries = [] :: [khepri_machine:delayed_aux_query()]}).
+         delayed_aux_queries = [] :: [khepri_machine:delayed_aux_query()],
+         maybe_down_procs = #{}}).
 
 %% The current/latest version of the state machine is defined in this macro
 %% instead of `khepri_machine:version/0' only. This way, it can be used in

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -55,12 +55,18 @@
          spam_txs_during_election/1,
          spam_changes_during_unregister_projections/1,
          can_wait_for_effective_behaviour/1,
+         trigger_based_on_process_event_works/1,
+         process_event_is_delayed_during_node_down_1/1,
+         process_event_is_delayed_during_node_down_2/1,
+         process_event_is_delayed_during_node_down_3/1,
          trigger_runs_on_leader/1,
          trigger_runs_on_follower/1,
          trigger_runs_on_local_member/1,
          trigger_runs_on_all_members/1,
          trigger_runs_on_leader_if_non_member_target/1,
-         trigger_options_rejected_before_v3/1]).
+         trigger_options_rejected_before_v3/1,
+
+         start_monitored_proc/0]).
 
 all() ->
     [
@@ -92,7 +98,8 @@ groups() ->
            fail_to_start_with_bad_ra_server_config,
            initial_members_are_ignored,
            fail_to_join_non_existing_node,
-           can_wait_for_effective_behaviour
+           can_wait_for_effective_behaviour,
+           trigger_based_on_process_event_works
           ]}
         ]},
        {cluster, [],
@@ -118,7 +125,13 @@ groups() ->
            async_command_leader_change_in_three_node_cluster,
            spam_txs_during_election,
            spam_changes_during_unregister_projections,
-           can_wait_for_effective_behaviour,
+           can_wait_for_effective_behaviour
+          ]},
+         {set3, [parallel],
+          [
+           process_event_is_delayed_during_node_down_1,
+           process_event_is_delayed_during_node_down_2,
+           process_event_is_delayed_during_node_down_3,
            trigger_runs_on_leader,
            trigger_runs_on_follower,
            trigger_runs_on_local_member,
@@ -2857,6 +2870,314 @@ can_wait_for_effective_behaviour(Config) ->
          khepri_cluster, wait_for_effective_machine_version,
          [{StoreId, FirstNode}, 1000000, 500])).
 
+trigger_based_on_process_event_works(Config) ->
+    RaSystem = helpers:get_ra_system_name(Config),
+    StoreId = RaSystem,
+
+    ct:pal("Start database"),
+    ?assertEqual(
+       {ok, StoreId},
+       khepri:start(RaSystem, StoreId)),
+
+    TriggerId = ?FUNCTION_NAME,
+    Pid = start_monitored_proc(),
+    EventFilter = khepri_evf:process(Pid),
+    StoredProcPath = [sproc],
+
+    ct:pal("Put store procedure"),
+    SprocRet = ?FUNCTION_NAME,
+    ?assertEqual(
+       ok,
+       khepri:put(StoreId, StoredProcPath, make_sproc(self(), SprocRet))),
+
+    ct:pal("Register trigger"),
+    ?assertEqual(
+       ok,
+       khepri:register_trigger(
+         StoreId, TriggerId, EventFilter, StoredProcPath)),
+
+    ct:pal("Terminate process to trigger the stored procedure"),
+    Pid ! stop,
+
+    ct:pal("Wait for the trigger message from the leader node"),
+    receive
+        {sproc, SprocRet, Node, _Props} when Node =:= node() ->
+            ok
+    after 60000 ->
+              ct:pal(
+                "Messages in inbox:~n~p",
+                [erlang:process_info(self(), messages)]),
+              ct:fail("Did not receive the expected message from the trigger")
+    end,
+
+    ct:pal("Stop database"),
+    ?assertEqual(ok, khepri:stop(StoreId)),
+
+    ok.
+
+process_event_is_delayed_during_node_down_1(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    PeerPerNode = ?config(peer_nodes, Config),
+    [Node1, _Node2, Node3] = Nodes = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    RaSystem = helpers:get_ra_system_name(Config),
+    StoreId = RaSystem,
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 helpers:call(Config, Node, khepri, start, [RaSystem, StoreId]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 helpers:call(Config, Node, khepri_cluster, join, [StoreId, Node1]))
+      end, Nodes -- [Node1]),
+
+    TriggerId = ?FUNCTION_NAME,
+    MonitoredProcNode = Node3,
+    Pid = helpers:call(Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
+    EventFilter = khepri_evf:process(Pid),
+    StoredProcPath = [sproc],
+
+    ct:pal("Put store procedure"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, put,
+         [StoreId, StoredProcPath, make_sproc(self(), TriggerId)])),
+
+    ct:pal("Register trigger"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, register_trigger,
+         [StoreId, TriggerId, EventFilter, StoredProcPath])),
+
+    ct:pal(
+      "Stop node ~s to trigger the process monitor",
+      [MonitoredProcNode]),
+    Peer = proplists:get_value(MonitoredProcNode, PeerPerNode),
+    ?assertEqual(ok, helpers:stop_erlang_node(MonitoredProcNode, Peer)),
+
+    ct:pal(
+      "Restart node ~s to trigger the node monitor",
+      [MonitoredProcNode]),
+    {ok, NewPeer, _Node} = peer:start(#{name => MonitoredProcNode,
+                                        wait_boot => infinity,
+                                        connection => standard_io}),
+    ?assertEqual(pong, peer:call(NewPeer, net_adm, ping, [Node1])),
+    peer:stop(NewPeer),
+
+    {_, LeaderNode} = helpers:get_leader_in_store(Config, StoreId, Nodes),
+
+    ct:pal("Wait for the trigger message from the leader node"),
+    receive
+        {sproc, TriggerId, LeaderNode, Event} ->
+            ct:pal("Process event: ~p", [Event]),
+            ?assertMatch(
+               #khepri_trigger{event = #{pid := Pid,
+                                         change := {'DOWN', Reason}}}
+                 when Reason =:= noproc orelse
+                      Reason =:= noconnection,
+               Event),
+            ok
+    after 60000 ->
+              ct:pal(
+                "Messages in inbox:~n~p",
+                [erlang:process_info(self(), messages)]),
+              ct:fail(
+                "Did not receive the expected message from the "
+                "trigger from ~s",
+                [LeaderNode])
+    end,
+
+    ok.
+
+process_event_is_delayed_during_node_down_2(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    PeerPerNode = ?config(peer_nodes, Config),
+    [Node1, _Node2, Node3] = Nodes = maps:keys(PropsPerNode),
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    RaSystem = helpers:get_ra_system_name(Config),
+    StoreId = RaSystem,
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 helpers:call(Config, Node, khepri, start, [RaSystem, StoreId]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 helpers:call(Config, Node, khepri_cluster, join, [StoreId, Node1]))
+      end, Nodes -- [Node1]),
+
+    TriggerId = ?FUNCTION_NAME,
+    MonitoredProcNode = Node3,
+    Pid = helpers:call(Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
+    EventFilter = khepri_evf:process(Pid),
+    StoredProcPath = [sproc],
+
+    ct:pal("Put store procedure"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, put,
+         [StoreId, StoredProcPath, make_sproc(self(), TriggerId)])),
+
+    ct:pal("Register trigger"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, register_trigger,
+         [StoreId, TriggerId, EventFilter, StoredProcPath])),
+
+    ct:pal(
+      "Stop node ~s to trigger the process monitor",
+      [MonitoredProcNode]),
+    Peer = proplists:get_value(MonitoredProcNode, PeerPerNode),
+    ?assertEqual(ok, helpers:stop_erlang_node(MonitoredProcNode, Peer)),
+
+    receive
+        {sproc, TriggerId, _LeaderNode, _Event} ->
+            ct:fail(
+              "Received the stored proc message before the monitored node "
+              "came back up")
+    after 2000 ->
+              ok
+    end,
+
+    ct:pal("Remove node ~s from cluster", [MonitoredProcNode]),
+    ?assertMatch(
+       {ok, _, _},
+       helpers:call(
+         Config, Node1,
+         ra, remove_member,
+         [{StoreId, Node1}, {StoreId, MonitoredProcNode}, infinity])),
+
+    {_, LeaderNode} = helpers:get_leader_in_store(Config, StoreId, Nodes),
+
+    ct:pal("Wait for the trigger message from the leader node"),
+    receive
+        {sproc, TriggerId, LeaderNode, Event} ->
+            ct:pal("Process event: ~p", [Event]),
+            ?assertMatch(
+               #khepri_trigger{event = #{pid := Pid,
+                                         change := {'DOWN', Reason}}}
+                 when Reason =:= noproc orelse
+                      Reason =:= noconnection,
+               Event),
+            ok
+    after 60000 ->
+              ct:pal(
+                "Messages in inbox:~n~p",
+                [erlang:process_info(self(), messages)]),
+              ct:fail(
+                "Did not receive the expected message from the "
+                "trigger from ~s",
+                [LeaderNode])
+    end,
+
+    ok.
+
+process_event_is_delayed_during_node_down_3(Config) ->
+    PropsPerNode = ?config(ra_system_props, Config),
+    PeerPerNode = ?config(peer_nodes, Config),
+    [Node1, Node2, Node3] = maps:keys(PropsPerNode),
+
+    %% Compared to `process_event_is_delayed_during_node_down_1', we only
+    %% cluster the first two nodes. Therefore, the monitored process will run
+    %% on a node that is outside of the Khepri cluster.
+    Nodes = [Node1, Node2],
+
+    %% We assume all nodes are using the same Ra system name & store ID.
+    RaSystem = helpers:get_ra_system_name(Config),
+    StoreId = RaSystem,
+
+    ct:pal("Start database + cluster nodes"),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri:start() from node ~s", [Node]),
+              ?assertEqual(
+                 {ok, StoreId},
+                 helpers:call(Config, Node, khepri, start, [RaSystem, StoreId]))
+      end, Nodes),
+    lists:foreach(
+      fun(Node) ->
+              ct:pal("- khepri_cluster:join() from node ~s", [Node]),
+              ?assertEqual(
+                 ok,
+                 helpers:call(Config, Node, khepri_cluster, join, [StoreId, Node1]))
+      end, Nodes -- [Node1]),
+
+    TriggerId = ?FUNCTION_NAME,
+    MonitoredProcNode = Node3,
+    Pid = helpers:call(Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
+    EventFilter = khepri_evf:process(Pid),
+    StoredProcPath = [sproc],
+
+    ct:pal("Put store procedure"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, put,
+         [StoreId, StoredProcPath, make_sproc(self(), TriggerId)])),
+
+    ct:pal("Register trigger"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, register_trigger,
+         [StoreId, TriggerId, EventFilter, StoredProcPath])),
+
+    ct:pal(
+      "Stop database on leader node ~s (quorum is maintained)",
+      [Node1]),
+    Peer = proplists:get_value(MonitoredProcNode, PeerPerNode),
+    ?assertEqual(ok, helpers:stop_erlang_node(MonitoredProcNode, Peer)),
+
+    {_, LeaderNode} = helpers:get_leader_in_store(Config, StoreId, Nodes),
+
+    ct:pal("Wait for the trigger message from the leader node"),
+    receive
+        {sproc, TriggerId, LeaderNode, Event} ->
+            ct:pal("Process event: ~p", [Event]),
+            ?assertMatch(
+               #khepri_trigger{event = #{pid := Pid,
+                                         change := {'DOWN', noconnection}}},
+               Event),
+            ok
+    after 60000 ->
+              ct:pal(
+                "Messages in inbox:~n~p",
+                [erlang:process_info(self(), messages)]),
+              ct:fail(
+                "Did not receive the expected message from the "
+                "trigger from ~s",
+                [LeaderNode])
+    end,
+
+    ok.
+
 trigger_runs_on_leader(Config) ->
     trigger_runs_on_where(Config, ?FUNCTION_NAME, leader).
 
@@ -3083,6 +3404,14 @@ make_sproc(Pid, Testcase) ->
     fun(Props) ->
             Pid ! {sproc, Testcase, node(), Props}
     end.
+
+start_monitored_proc() ->
+    spawn(fun() ->
+                  receive
+                      _ ->
+                          ok
+                  end
+          end).
 
 wait_for_leader_to_be(Config, WantedLeaderId) ->
     PropsPerNode = ?config(ra_system_props, Config),

--- a/test/non_versioned_commands.erl
+++ b/test/non_versioned_commands.erl
@@ -220,9 +220,14 @@ convert_to_uniform_command_test() ->
               end
       end, Records).
 
-ra_builtin_commands_test() ->
-    MachineVersion = {machine_version, 0, 1},
-    ?assertNot(khepri_machine:does_command_support_common_args(MachineVersion)),
-    ?assertEqual(
-       none,
-       khepri_machine:get_command_common_args(MachineVersion)).
+ra_builtin_commands_test_() ->
+    RaBuiltinCommands = [{down, self(), normal},
+                         {really_down, self(), normal},
+                         {nodeup, node()},
+                         {machine_version, 0, 1}],
+    [fun() ->
+         ?assertNot(khepri_machine:does_command_support_common_args(Command)),
+         ?assertEqual(
+            none,
+            khepri_machine:get_command_common_args(Command))
+     end || Command <- RaBuiltinCommands].

--- a/test/test_ra_server_helpers.erl
+++ b/test/test_ra_server_helpers.erl
@@ -37,6 +37,8 @@ setup(Testcase, CustomConfig) ->
              end,
 
     {ok, StoreId} = khepri:start(RaSystem, RaServerConfig1),
+    ok = khepri_cluster:wait_for_effective_machine_version(
+           StoreId, khepri_machine:version()),
     Props1#{store_id => StoreId}.
 
 cleanup(#{store_id := StoreId} = Props) ->

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -655,6 +655,52 @@ a_buggy_sproc_does_not_crash_state_machine_test_() ->
          ?_assertEqual(executed, receive_sproc_msg(Key))}]
       }]}.
 
+trigger_based_on_process_event_test_() ->
+    Parent = self(),
+    Pid = spawn_link(fun() ->
+                             receive
+                                 _ ->
+                                     erlang:unlink(Parent)
+                             end
+                     end),
+    EventFilter = khepri_evf:process(Pid),
+    StoredProcPath = [sproc],
+    Key = ?FUNCTION_NAME,
+
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Store a procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath,
+              make_sproc(self(), Key)))},
+        {"Register a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              StoredProcPath))},
+        {"Terminate process",
+         ?_assert(begin
+                      MRef = erlang:monitor(process, Pid),
+                      Pid ! stop,
+                      receive
+                          {'DOWN', MRef, process, Pid, _Reason} ->
+                              true
+                      end
+                  end)},
+        {"Wait for the trigger message",
+         ?_assert(receive
+                      {sproc, Key, _Props} ->
+                          true
+                  end)}]
+      }]}.
+
 make_sproc(Pid, Key) ->
     fun(Props) ->
             case Props of
@@ -662,7 +708,10 @@ make_sproc(Pid, Key) ->
                     Pid ! {sproc, Key, {OnAction, Path}};
                 #khepri_trigger{type = tree,
                                 event = #{path := Path, change := Change}} ->
-                    Pid ! {sproc, Key, {Change, Path}}
+                    Pid ! {sproc, Key, {Change, Path}};
+                #khepri_trigger{type = process,
+                                event = #{pid := MonitoredPid, change := Change}} ->
+                    Pid ! {sproc, Key, {Change, MonitoredPid}}
             end
     end.
 


### PR DESCRIPTION
khepri_machine: Support process-lifetime-based trigger events

## Why

This allows to execute an action when a monitored process terminates.

## How

The event filter, passed to a trigger registration, is a PID.

The Ra leader will take care of monitoring this process. Once it terminates, the Khepri state machine will evaluate all triggers that monitor that process and execute the corresponding action.

There is one special case: if the exit reason of the monitored process is `noconnection`, it means it was running on a node that is unreachable now. We can't tell if the process is still running or not. In this case, if the node of that process is a Ra cluster member, the trigger is not evaluated yet. Instead, Khepri monitors the node and waits for it to be online again (and monitor the process again) or it to be removed from the members. If the node is not part of the cluster, the trigger is evaluated with the `noconnection` reason like other reasons.