### PR TITLE
khepri_machine: Introduce `{send, Pid, Priv}` trigger action

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -2838,74 +2838,88 @@ clear_many_payloads(StoreId, PathPattern, Options) ->
 %% register_trigger().
 %% -------------------------------------------------------------------
 
--spec register_trigger(TriggerId, EventFilter, StoredProcPath) -> Ret when
+-spec register_trigger(TriggerId, EventFilter, Action) -> Ret when
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
+      Action :: StoredProcPath |
+                Pid |
+                khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      Pid :: pid(),
       Ret :: ok | error().
 %% @doc Registers a trigger.
 %%
 %% Calling this function is the same as calling `register_trigger(StoreId,
-%% TriggerId, EventFilter, StoredProcPath)' with the default store ID (see
+%% TriggerId, EventFilter, Action)' with the default store ID (see
 %% {@link khepri_cluster:get_default_store_id/0}).
 %%
 %% @see register_trigger/4.
 
-register_trigger(TriggerId, EventFilter, StoredProcPath) ->
+register_trigger(TriggerId, EventFilter, Action) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath).
+    register_trigger(StoreId, TriggerId, EventFilter, Action).
 
 -spec register_trigger
-(StoreId, TriggerId, EventFilter, StoredProcPath) -> Ret when
+(StoreId, TriggerId, EventFilter, Action) -> Ret when
       StoreId :: khepri:store_id(),
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
+      Action :: StoredProcPath |
+                Pid |
+                khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      Pid :: pid(),
       Ret :: ok | error();
-(TriggerId, EventFilter, StoredProcPath, Options) -> Ret when
+(TriggerId, EventFilter, Action, Options) -> Ret when
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
+      Action :: StoredProcPath |
+                Pid |
+                khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      Pid :: pid(),
       Options :: command_options() | khepri:trigger_options(),
       Ret :: ok | error().
 %% @doc Registers a trigger.
 %%
 %% This function accepts the following two forms:
 %% <ul>
-%% <li>`register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath)'.
+%% <li>`register_trigger(StoreId, TriggerId, EventFilter, Action)'.
 %% Calling it is the same as calling `register_trigger(StoreId, TriggerId,
-%% EventFilter, StoredProcPath, #{})'.</li>
-%% <li>`register_trigger(TriggerId, EventFilter, StoredProcPath, Options)'.
+%% EventFilter, Action, #{})'.</li>
+%% <li>`register_trigger(TriggerId, EventFilter, Action, Options)'.
 %% Calling it is the same as calling `register_trigger(StoreId, TriggerId,
-%% EventFilter, StoredProcPath, Options)' with the default store ID (see
+%% EventFilter, Action, Options)' with the default store ID (see
 %% {@link khepri_cluster:get_default_store_id/0}).</li>
 %% </ul>
 %%
 %% @see register_trigger/5.
 
-register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath)
+register_trigger(StoreId, TriggerId, EventFilter, Action)
   when ?IS_KHEPRI_STORE_ID(StoreId) andalso is_atom(TriggerId) ->
-    register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, #{});
-register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
+    register_trigger(StoreId, TriggerId, EventFilter, Action, #{});
+register_trigger(TriggerId, EventFilter, Action, Options)
   when is_atom(TriggerId) andalso is_map(Options) ->
     StoreId = khepri_cluster:get_default_store_id(),
-    register_trigger(
-      StoreId, TriggerId, EventFilter, StoredProcPath, Options).
+    register_trigger(StoreId, TriggerId, EventFilter, Action, Options).
 
--spec register_trigger(
-        StoreId, TriggerId, EventFilter, StoredProcPath, Options) ->
+-spec register_trigger(StoreId, TriggerId, EventFilter, Action, Options) ->
     Ret when
       StoreId :: khepri:store_id(),
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
+      Action :: StoredProcPath |
+                Pid |
+                khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      Pid :: pid(),
       Options :: command_options() | khepri:trigger_options(),
       Ret :: ok | error().
 %% @doc Registers a trigger.
 %%
-%% A trigger is based on an event filter. It associates an event with a stored
-%% procedure. When an event matching the event filter is emitted, the stored
-%% procedure is executed.
+%% A trigger is based on an event filter. It associates an event with an
+%% action. When an event matching the event filter is emitted, the action is
+%% executed.
 %%
 %% The following event filters are documented by {@link
 %% khepri_evf:event_filter()}.
@@ -2926,8 +2940,9 @@ register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
 %% EventFilter = "/:stock/:wood/oak".
 %% '''
 %%
-%% The stored procedure is expected to accept a single argument. This argument
-%% is a map containing the event properties. Here is an example:
+%% When giving a stored procedure as the action, it is expected to accept a
+%% single argument. This argument is a map containing the event properties.
+%% Here is an example:
 %%
 %% ```
 %% my_stored_procedure(Props) ->
@@ -2937,23 +2952,26 @@ register_trigger(TriggerId, EventFilter, StoredProcPath, Options)
 %%
 %% The stored procedure is executed on the leader's Erlang node.
 %%
+%% When giving a PID as the action, a `#khepri_trigger{}' message is sent to
+%% this process.
+%%
 %% It is guaranteed to run at least once. It could be executed multiple times
-%% if the Ra leader changes, therefore the stored procedure must be
-%% idempotent.
+%% if the Ra leader changes, therefore the action must be idempotent.
 %%
 %% @param StoreId the name of the Khepri store.
 %% @param TriggerId the name of the trigger.
 %% @param EventFilter the event filter used to associate an event with a
 %%        stored procedure.
-%% @param StoredProcPath the path to the stored procedure to execute when the
-%%        corresponding event occurs.
+%% @param Action the path to a stored procedure to execute when the
+%%        corresponding event occurs, or PID to send a message to, or a
+%%        "wrapped action".
 %%
 %% @returns `ok' if the trigger was registered, an `{error, Reason}' tuple
 %% otherwise.
 
-register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options) ->
+register_trigger(StoreId, TriggerId, EventFilter, Action, Options) ->
     khepri_machine:register_trigger(
-      StoreId, TriggerId, EventFilter, StoredProcPath, Options).
+      StoreId, TriggerId, EventFilter, Action, Options).
 
 %% -------------------------------------------------------------------
 %% register_projection().

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -179,7 +179,8 @@
          reset_metrics/1,
          compute_command_size/1,
          does_command_support_common_args/1,
-         get_command_common_args/1]).
+         get_command_common_args/1,
+         maybe_convert_to_action/4]).
 -endif.
 
 -compile({no_auto_import, [apply/3]}).
@@ -751,12 +752,16 @@ handle_tx_exception(
     erlang:raise(Class, Reason, Stacktrace).
 
 -spec register_trigger(
-        StoreId, TriggerId, EventFilter, StoredProcPath, Options) ->
+        StoreId, TriggerId, EventFilter, Action, Options) ->
     Ret when
       StoreId :: khepri:store_id(),
       TriggerId :: khepri:trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
+      Action :: StoredProcPath |
+                Pid |
+                khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      Pid :: pid(),
       Options :: khepri:command_options() | khepri:trigger_options(),
       Ret :: ok | khepri:error().
 %% @doc Registers a trigger.
@@ -765,29 +770,28 @@ handle_tx_exception(
 %% @param TriggerId the name of the trigger.
 %% @param EventFilter the event filter used to associate an event with a
 %%        stored procedure.
-%% @param StoredProcPath the path to the stored procedure to execute when the
-%%        corresponding event occurs.
+%% @param Action the path to a stored procedure to execute when the
+%%        corresponding event occurs, or PID to send a message to, or a
+%%        "wrapped action".
 %% @param Options command and trigger options map.
 %%
 %% @returns `ok' if the trigger was registered, an `{error, Reason}' tuple
 %% otherwise.
 
-register_trigger(StoreId, TriggerId, EventFilter, StoredProcPath, Options)
-  when ?IS_KHEPRI_STORE_ID(StoreId) andalso
-       ?IS_KHEPRI_PATH_OR_COMPAT(StoredProcPath) ->
+register_trigger(StoreId, TriggerId, EventFilter, Action, Options)
+  when ?IS_KHEPRI_STORE_ID(StoreId) ->
     EventFilter1 = khepri_evf:wrap(EventFilter),
-    StoredProcPath1 = khepri_path:from_string(StoredProcPath),
-    khepri_path:ensure_is_valid(StoredProcPath1),
+    Action1 = maybe_convert_to_action(StoreId, TriggerId, EventFilter, Action),
     {CommandOptions, NonCommandOptions} = split_command_options(
                                             StoreId, Options),
     case does_api_comply_with(uniform_commands, StoreId) of
         true ->
             register_trigger_versioned(
-              StoreId, TriggerId, EventFilter1, StoredProcPath1,
+              StoreId, TriggerId, EventFilter1, Action1,
               CommandOptions, NonCommandOptions);
         false ->
             register_trigger_nonversioned(
-              StoreId, TriggerId, EventFilter1, StoredProcPath1,
+              StoreId, TriggerId, EventFilter1, Action1,
               CommandOptions, NonCommandOptions)
     end.
 
@@ -814,11 +818,9 @@ register_trigger_nonversioned(
     end.
 
 register_trigger_versioned(
-  StoreId, TriggerId, EventFilter, StoredProcPath,
+  StoreId, TriggerId, EventFilter, Action,
   CommandOptions, NonCommandOptions) ->
     ?assert(does_api_comply_with(extended_trigger, StoreId)),
-    StoredProcPath1 = khepri_path:realpath(StoredProcPath),
-    Action = {sproc, StoredProcPath1},
     NonCommandOptions1 = case NonCommandOptions of
                              #{where := local} ->
                                  %% Interpret the `local' value and replace it
@@ -835,6 +837,78 @@ register_trigger_versioned(
                      options = NonCommandOptions1},
     Command = #register_trigger_v{args = CommandArgs},
     process_command(StoreId, Command, CommandOptions).
+
+-spec maybe_convert_to_action(StoreId, TriggerId, EventFilter, Action) ->
+    NewAction when
+      StoreId :: khepri:store_id(),
+      TriggerId :: khepri:trigger_id(),
+      EventFilter :: khepri_evf:event_filter_or_compat(),
+      Action :: StoredProcPath |
+                Pid |
+                khepri_event_handler:trigger_action(),
+      StoredProcPath :: khepri_path:path(),
+      Pid :: pid(),
+      NewAction :: NewStoredProcPath |
+                   khepri_event_handler:trigger_action(),
+      NewStoredProcPath :: khepri_path:native_path().
+
+maybe_convert_to_action(StoreId, _TriggerId, _EventFilter, StoredProcPath)
+  when ?IS_KHEPRI_PATH_PATTERN(StoredProcPath) ->
+    StoredProcPath1 = khepri_path:from_string(StoredProcPath),
+    khepri_path:ensure_is_valid(StoredProcPath1),
+    case does_api_comply_with(extended_trigger, StoreId) of
+        true ->
+            StoredProcPath2 = khepri_path:realpath(StoredProcPath1),
+            {sproc, StoredProcPath2};
+        false ->
+            StoredProcPath1
+    end;
+maybe_convert_to_action(StoreId, TriggerId, EventFilter, Pid)
+  when is_pid(Pid) ->
+    case does_api_comply_with(extended_trigger, StoreId) of
+        true ->
+            {send, Pid, undefined};
+        false ->
+            ?khepri_misuse(
+               unsupported_trigger_action,
+               #{trigger_id => TriggerId,
+                 event_filter => EventFilter,
+                 action => Pid})
+    end;
+maybe_convert_to_action(StoreId, TriggerId, EventFilter, Action) ->
+    case does_api_comply_with(extended_trigger, StoreId) of
+        true ->
+            case Action of
+                {sproc, StoredProcPath}
+                  when ?IS_KHEPRI_PATH_PATTERN(StoredProcPath) ->
+                    khepri_path:ensure_is_valid(StoredProcPath),
+                    StoredProcPath1 = khepri_path:realpath(StoredProcPath),
+                    {sproc, StoredProcPath1};
+                {send, Pid, _Priv}
+                  when is_pid(Pid) ->
+                    Action;
+                _ ->
+                    ?khepri_misuse(
+                       unsupported_trigger_action,
+                       #{trigger_id => TriggerId,
+                         event_filter => EventFilter,
+                         action => Action})
+            end;
+        false ->
+            case Action of
+                {sproc, StoredProcPath}
+                  when ?IS_KHEPRI_PATH_PATTERN(StoredProcPath) ->
+                    khepri_path:ensure_is_valid(StoredProcPath),
+                    StoredProcPath1 = khepri_path:realpath(StoredProcPath),
+                    StoredProcPath1;
+                _ ->
+                    ?khepri_misuse(
+                       unsupported_trigger_action,
+                       #{trigger_id => TriggerId,
+                         event_filter => EventFilter,
+                         action => Action})
+            end
+    end.
 
 -spec register_projection(StoreId, PathPattern, Projection, Options) ->
     Ret when
@@ -3482,7 +3556,20 @@ evaluate_action(State, Event, TriggerId, Trigger, TriggeredActions)
                                    event = Event}
                         end,
             evaluate_where_option(State, Triggered, TriggeredActions)
-    end.
+    end;
+evaluate_action(
+  State, Event, TriggerId,
+  #{event_filter := EventFilter,
+    action := Action,
+    where := Where},
+  TriggeredActions) ->
+    Triggered = #triggered_v2{
+                   id = TriggerId,
+                   event_filter = EventFilter,
+                   action = Action,
+                   where = Where,
+                   event = Event},
+    evaluate_where_option(State, Triggered, TriggeredActions).
 
 evaluate_where_option(
   _State, #triggered{} = Triggered, TriggeredActions) ->

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -724,3 +724,104 @@ receive_sproc_msg_with_props(Key) ->
     receive {sproc, Key, Props} -> Props
     after 1000                  -> timeout
     end.
+
+event_triggers_message_send_test_() ->
+    EventFilter = khepri_evf:tree([foo]),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Wait for `extended_trigger` behaviour",
+         ?_assertEqual(
+            ok,
+            khepri_cluster:wait_for_effective_behaviour(
+              ?FUNCTION_NAME, extended_trigger, infinity))},
+        {"Registering a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              self()))},
+
+        {"Updating a node; should trigger the send of the message",
+         ?_assertMatch(
+            ok,
+            khepri:put(?FUNCTION_NAME, [foo], value))},
+
+        {"Checking the procedure was executed",
+         ?_assert(receive
+                      #khepri_trigger{} ->
+                          true
+                  end)}]
+      }]}.
+
+maybe_convert_to_action_with_old_machine_version_test_() ->
+    MacVer = maps:get(extended_trigger, ?API_BEHAV_MACVER_MAP) - 1,
+    StoreId = ?FUNCTION_NAME,
+    TriggerId = my_trigger,
+    EventFilter = khepri_evf:tree([]),
+    Pid = self(),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(
+                ?FUNCTION_NAME, #{machine_version => MacVer})
+     end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertEqual(
+           [foo],
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             "/:foo")),
+        ?_assertEqual(
+           [foo],
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             {sproc, [foo]})),
+
+        ?_assertError(
+           ?khepri_exception(unsupported_trigger_action, _),
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             Pid)),
+        ?_assertError(
+           ?khepri_exception(unsupported_trigger_action, _),
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             {send, Pid, priv}))
+       ]
+      }]}.
+
+maybe_convert_to_action_with_latest_machine_version_test_() ->
+    StoreId = ?FUNCTION_NAME,
+    TriggerId = my_trigger,
+    EventFilter = khepri_evf:tree([]),
+    Pid = self(),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [?_assertEqual(
+           {sproc, [foo]},
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             "/:foo")),
+        ?_assertEqual(
+           {sproc, [foo]},
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             {sproc, [foo]})),
+
+        ?_assertEqual(
+           {send, Pid, undefined},
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             Pid)),
+        ?_assertEqual(
+           {send, Pid, priv},
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             {send, Pid, priv}))
+       ]
+      }]}.


### PR DESCRIPTION
## Why

It allows to send a message to an arbitrary process when a trigger is triggered.

## How

The `khepri:register_trigger/{3,4,5}` functions can take a PID in addition to of the stored procedure path. They can also accept the following tuples:
* `{sproc, StoreProcPath}`
* `{send, Pid, Priv}`

If only the PID is passed, `Priv` is set to `undefined`.

The message send to the process is:

```erlang
#khepri_trigger{type = EventType,
                store_id = StoreId,
                trigger_id = TriggerId,
                event = EventProps,
                action = ActionProps}
```

Fixes #57.