### PR TITLE
khepri_machine: Introduce `{apply, MFA}` trigger action

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -2842,9 +2842,11 @@ clear_many_payloads(StoreId, PathPattern, Options) ->
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       Action :: StoredProcPath |
+                MFA |
                 Pid |
                 khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      MFA :: {module(), atom(), list()},
       Pid :: pid(),
       Ret :: ok | error().
 %% @doc Registers a trigger.
@@ -2865,18 +2867,22 @@ register_trigger(TriggerId, EventFilter, Action) ->
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       Action :: StoredProcPath |
+                MFA |
                 Pid |
                 khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      MFA :: {module(), atom(), list()},
       Pid :: pid(),
       Ret :: ok | error();
 (TriggerId, EventFilter, Action, Options) -> Ret when
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       Action :: StoredProcPath |
+                MFA |
                 Pid |
                 khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      MFA :: {module(), atom(), list()},
       Pid :: pid(),
       Options :: command_options() | khepri:trigger_options(),
       Ret :: ok | error().
@@ -2909,9 +2915,11 @@ register_trigger(TriggerId, EventFilter, Action, Options)
       TriggerId :: trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       Action :: StoredProcPath |
+                MFA |
                 Pid |
                 khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      MFA :: {module(), atom(), list()},
       Pid :: pid(),
       Options :: command_options() | khepri:trigger_options(),
       Ret :: ok | error().
@@ -2951,6 +2959,10 @@ register_trigger(TriggerId, EventFilter, Action, Options)
 %% '''
 %%
 %% The stored procedure is executed on the leader's Erlang node.
+%%
+%% When giving an MFA tuple (`Module, Function, ArgsList}'), the designated
+%% function is executed. The `#khepri_trigger{}' trigger descriptor is
+%% appended to the list of arguments.
 %%
 %% When giving a PID as the action, a `#khepri_trigger{}' message is sent to
 %% this process.

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -758,9 +758,11 @@ handle_tx_exception(
       TriggerId :: khepri:trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       Action :: StoredProcPath |
+                MFA |
                 Pid |
                 khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      MFA :: {module(), atom(), list()},
       Pid :: pid(),
       Options :: khepri:command_options() | khepri:trigger_options(),
       Ret :: ok | khepri:error().
@@ -844,9 +846,11 @@ register_trigger_versioned(
       TriggerId :: khepri:trigger_id(),
       EventFilter :: khepri_evf:event_filter_or_compat(),
       Action :: StoredProcPath |
+                MFA |
                 Pid |
                 khepri_event_handler:trigger_action(),
       StoredProcPath :: khepri_path:path(),
+      MFA :: {module(), atom(), list()},
       Pid :: pid(),
       NewAction :: NewStoredProcPath |
                    khepri_event_handler:trigger_action(),
@@ -862,6 +866,19 @@ maybe_convert_to_action(StoreId, _TriggerId, _EventFilter, StoredProcPath)
             {sproc, StoredProcPath2};
         false ->
             StoredProcPath1
+    end;
+maybe_convert_to_action(
+  StoreId, TriggerId, EventFilter, {Mod, Func, Args} = MFA)
+  when is_atom(Mod) andalso is_atom(Func) andalso is_list(Args) ->
+    case does_api_comply_with(extended_trigger, StoreId) of
+        true ->
+            {apply, MFA};
+        false ->
+            ?khepri_misuse(
+               unsupported_trigger_action,
+               #{trigger_id => TriggerId,
+                 event_filter => EventFilter,
+                 action => MFA})
     end;
 maybe_convert_to_action(StoreId, TriggerId, EventFilter, Pid)
   when is_pid(Pid) ->
@@ -884,6 +901,11 @@ maybe_convert_to_action(StoreId, TriggerId, EventFilter, Action) ->
                     khepri_path:ensure_is_valid(StoredProcPath),
                     StoredProcPath1 = khepri_path:realpath(StoredProcPath),
                     {sproc, StoredProcPath1};
+                {apply, {Mod, Func, Args}}
+                  when is_atom(Mod) andalso
+                       is_atom(Func) andalso
+                       is_list(Args) ->
+                    Action;
                 {send, Pid, _Priv}
                   when is_pid(Pid) ->
                     Action;

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -579,7 +579,7 @@ a_buggy_sproc_does_not_crash_state_machine_test_() ->
                                   ok, khepri:put(?FUNCTION_NAME, [foo], 1))
                         end),
                 ?assertMatch(
-                   <<"Triggered stored procedure crash", _/binary>>, Log)
+                   <<"Triggered action crash", _/binary>>, Log)
             end)},
 
         {"Checking the procedure was executed",
@@ -644,7 +644,7 @@ a_buggy_sproc_does_not_crash_state_machine_test_() ->
                                            khepri:put(?FUNCTION_NAME, [foo], 6)
                                    end),
                  ?assertSubString(
-                    <<"Triggered stored procedure crash">>, Log),
+                    <<"Triggered action crash">>, Log),
                  ?assertSubString(
                     <<"(this crash occurred 6 times in the last 10 seconds)">>,
                     Log),
@@ -725,6 +725,38 @@ receive_sproc_msg_with_props(Key) ->
     after 1000                  -> timeout
     end.
 
+event_triggers_mfa_apply_test_() ->
+    EventFilter = khepri_evf:tree([foo]),
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Wait for `extended_trigger` behaviour",
+         ?_assertEqual(
+            ok,
+            khepri_cluster:wait_for_effective_behaviour(
+              ?FUNCTION_NAME, extended_trigger, infinity))},
+        {"Registering a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              {erlang, send, [self()]}))},
+
+        {"Updating a node; should trigger the execution of the MFA",
+         ?_assertMatch(
+            ok,
+            khepri:put(?FUNCTION_NAME, [foo], value))},
+
+        {"Checking the procedure was executed",
+         ?_assert(receive
+                      #khepri_trigger{} ->
+                          true
+                  end)}]
+      }]}.
+
 event_triggers_message_send_test_() ->
     EventFilter = khepri_evf:tree([foo]),
     {setup,
@@ -762,6 +794,7 @@ maybe_convert_to_action_with_old_machine_version_test_() ->
     StoreId = ?FUNCTION_NAME,
     TriggerId = my_trigger,
     EventFilter = khepri_evf:tree([]),
+    MFA = {m, f, []},
     Pid = self(),
     {setup,
      fun() -> test_ra_server_helpers:setup(
@@ -784,6 +817,17 @@ maybe_convert_to_action_with_old_machine_version_test_() ->
            ?khepri_exception(unsupported_trigger_action, _),
            khepri_machine:maybe_convert_to_action(
              StoreId, TriggerId, EventFilter,
+             MFA)),
+        ?_assertError(
+           ?khepri_exception(unsupported_trigger_action, _),
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             {apply, MFA})),
+
+        ?_assertError(
+           ?khepri_exception(unsupported_trigger_action, _),
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
              Pid)),
         ?_assertError(
            ?khepri_exception(unsupported_trigger_action, _),
@@ -797,6 +841,7 @@ maybe_convert_to_action_with_latest_machine_version_test_() ->
     StoreId = ?FUNCTION_NAME,
     TriggerId = my_trigger,
     EventFilter = khepri_evf:tree([]),
+    MFA = {m, f, []},
     Pid = self(),
     {setup,
      fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
@@ -812,6 +857,17 @@ maybe_convert_to_action_with_latest_machine_version_test_() ->
            khepri_machine:maybe_convert_to_action(
              StoreId, TriggerId, EventFilter,
              {sproc, [foo]})),
+
+        ?_assertEqual(
+           {apply, MFA},
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             MFA)),
+        ?_assertEqual(
+           {apply, MFA},
+           khepri_machine:maybe_convert_to_action(
+             StoreId, TriggerId, EventFilter,
+             {apply, MFA})),
 
         ?_assertEqual(
            {send, Pid, undefined},


### PR DESCRIPTION
## Why

It allows to execute an arbitrary function when a trigger is triggered. This is like a stored procedure, except that the function must be available on the cluster member that will execute it.

## How

The `khepri:register_trigger/{3,4,5}` functions can take an MFA tuple in addition to a stored procedure path or a PID. They can also accept the `{sproc, StoreProcPath}`.

The function is executed with the given args list with the following trigger descriptor appended:

```erlang
#khepri_trigger{type = EventType,
                store_id = StoreId,
                trigger_id = TriggerId,
                event = EventProps,
                action = ActionProps}
```

Fixes #57.