### PR TITLE
khepri_machine: Support process-lifetime-based `keep_while` conditions

### DIFF
--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -163,6 +163,8 @@ Relative paths are useful when putting conditions on
 
 === Tree node lifetime ===
 
+==== Lifetime based on conditions on tree nodes ====
+
 A tree node's lifetime starts when it is inserted the first time and ends when
 it is removed from the tree. However, intermediary tree nodes created on the
 way remain in the tree long after the leaf node was removed.
@@ -188,6 +190,47 @@ KeepWhileCondition = #{[stock, wood] => #if_child_list_length{count = {gt, 0}}}.
 
 `keep_while' conditions on self (like the example above) are not evaluated on
 the first insert though.
+
+==== Lifetime based on an Erlang process lifetime ====
+
+In addition to `keep_while' conditions based on other tree nodes, it is also
+possible to have a `keep_while' condition pointing to an Erlang process. The
+condition is the PID of that process. In this case, the lifetime of the tree
+node is linked to that of the process: when the process exits, the tree node is
+deleted.
+
+```
+khepri:put(
+  StoreId, [stock, wood, <<"walnut">>], 200,
+
+  %% The inserted tree node will be removed as soon as the processs inserting
+  %% it exits.
+  #{keep_while => self()}
+).
+'''
+
+This feature is based on Erlang monitors created by the Ra leader of the Khepri
+cluster.
+
+If the monitored process is on a different Erlang node than the Ra leader, the
+loss of connection between the two nodes (i.e. the `noconnection' exit reason)
+is handled in a specific way:
+<ul>
+<li>If the remote node is a member of the Khepri cluster, Khepri will start to
+monitor that node after receiving the `noconnection' exit reaison. Then two
+things can happen:
+<ul>
+<li>The node comes back online. In this case, processes that are supposed to
+run on it are monitored again. If the node was restarted and the processes were
+killed, this new monitoring will detect this situation.</li>
+<li>The node is removed from the cluster. In this case, it is unlikely to come
+back. Thus, the processes that were running on it are considered as dead.</li>
+</ul></li>
+<li>If the remote node is not a member of the Khepri cluster, Khepri will
+consider that the processes supposed to run on this node are dead, even if this
+is network partition and the node and its processes could be reachable again in
+the future.</li>
+</ul>
 
 == Stores ==
 

--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -3892,16 +3892,23 @@ info(StoreId, Options) ->
             lists:foreach(
               fun(Watcher) ->
                       io:format("~n\033[1m~p depends on:\033[0m~n", [Watcher]),
-                      WatchedsMap = maps:get(Watcher, KeepWhileConds),
-                      Watcheds = lists:sort(maps:keys(WatchedsMap)),
-                      lists:foreach(
-                        fun(Watched) ->
-                                Condition = maps:get(Watched, WatchedsMap),
-                                io:format(
-                                  "    ~p:~n"
-                                  "        ~p~n",
-                                  [Watched, Condition])
-                        end, Watcheds)
+                      Watched = maps:get(Watcher, KeepWhileConds),
+                      if
+                          is_map(Watched) ->
+                              WatchedPaths = lists:sort(maps:keys(Watched)),
+                              lists:foreach(
+                                fun(WatchedPath) ->
+                                        Condition = maps:get(WatchedPath, Watched),
+                                        io:format(
+                                          "    ~p:~n"
+                                          "        ~p~n",
+                                          [WatchedPath, Condition])
+                                end, WatchedPaths);
+                          is_pid(Watched) ->
+                              io:format(
+                                "    ~0p~n",
+                                [Watched])
+                      end
               end, WatcherList);
         _ ->
             ok

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -116,9 +116,10 @@
 -include("src/khepri_error.hrl").
 -include("src/khepri_evf.hrl").
 -include("src/khepri_machine.hrl").
+-include("src/khepri_projection.hrl").
 -include("src/khepri_ret.hrl").
 -include("src/khepri_tx.hrl").
--include("src/khepri_projection.hrl").
+-include("src/khepri_tree.hrl").
 
 -export([fold/5,
          fence/2,
@@ -3101,10 +3102,7 @@ overview(State) ->
     Tree = get_tree(State),
     KeepWhileConds = get_keep_while_conds(State),
     Triggers = get_triggers(State),
-    TreeOptions = #{props_to_return => [payload,
-                                        payload_version,
-                                        child_list_version,
-                                        child_list_length],
+    TreeOptions = #{props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN,
                     include_root_props => true},
     {ok, NodePropsMap} = khepri_tree:find_matching_nodes(
                            Tree, [?KHEPRI_WILDCARD_STAR_STAR], TreeOptions),
@@ -3728,10 +3726,7 @@ evaluate_where_option(
 
 find_stored_proc(Tree, StoredProcPath) ->
     TreeOptions = #{expect_specific_node => true,
-                    props_to_return => [payload,
-                                        payload_version,
-                                        child_list_version,
-                                        child_list_length]},
+                    props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
     Ret = khepri_tree:find_matching_nodes(
             Tree, StoredProcPath, TreeOptions),
     %% Non-existing nodes and nodes which are not stored procedures are

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -92,6 +92,10 @@
 %% khepri:trigger_options()}.</li>
 %% <li>Added support for process-lifetime-based triggers. The trigger can be
 %% executed when a process exits.</li>
+%% <li>Added support for process-lifetime-based `keep_while' condition. The
+%% `keep_while' put option can take a PID. The tree node will be deleted as
+%% soon as the associated process exits. See {@link
+%% khepri_condition:keep_while()}.</li>
 %% <li>Added support for "apply MFA" and "send message" trigger actions.</li>
 %% </ul>
 %% </td>
@@ -356,7 +360,8 @@
                          uniform_commands |
                          request_snapshot |
                          extended_trigger |
-                         cached_members_list.
+                         cached_members_list |
+                         process_based_keep_while.
 %% Name of a state machine API behaviour.
 
 -export_type([write_ret/0,
@@ -492,21 +497,38 @@ put(StoreId, PathPattern, Payload, Options)
     Payload1 = khepri_payload:prepare(Payload),
     {CommandOptions, NonCommandOptions} = split_command_options(
                                             StoreId, Options),
-    Command = case does_api_comply_with(uniform_commands, StoreId) of
-                  true ->
-                      {TreeOptions, PutOptions} = split_put_options(
-                                                    NonCommandOptions),
-                      CommandArgs = #put_v1{path = PathPattern1,
-                                            payload = Payload1,
-                                            put_options = PutOptions,
-                                            tree_options = TreeOptions},
-                      #put_v{args = CommandArgs};
-                  false ->
-                      #put{path = PathPattern1,
-                           payload = Payload1,
-                           options = NonCommandOptions}
-              end,
-    process_command(StoreId, Command, CommandOptions);
+    ValidKeepWhile = case NonCommandOptions of
+                         #{keep_while := KW} when is_pid(KW) ->
+                             does_api_comply_with(
+                               process_based_keep_while, StoreId);
+                         _ ->
+                             true
+                     end,
+    case ValidKeepWhile of
+        true ->
+            Command = case does_api_comply_with(uniform_commands, StoreId) of
+                          true ->
+                              {TreeOptions, PutOptions} = split_put_options(
+                                                            NonCommandOptions),
+                              CommandArgs = #put_v1{path = PathPattern1,
+                                                    payload = Payload1,
+                                                    put_options = PutOptions,
+                                                    tree_options = TreeOptions},
+                              #put_v{args = CommandArgs};
+                          false ->
+                              #put{path = PathPattern1,
+                                   payload = Payload1,
+                                   options = NonCommandOptions}
+                      end,
+            process_command(StoreId, Command, CommandOptions);
+        false ->
+            ?khepri_misuse(
+               unsupported_process_based_keep_while,
+               #{store_id => StoreId,
+                 node_path => PathPattern,
+                 payload => Payload,
+                 options => Options})
+    end;
 put(_StoreId, PathPattern, Payload, _Options) ->
     ?khepri_misuse(invalid_payload, #{path => PathPattern,
                                       payload => Payload}).
@@ -2059,7 +2081,8 @@ handle_down_procs(
   IntState, SideEffects) ->
     %% In `maybe_down_procs', we have processes that run on a member of the
     %% cluster and we are waiting for that node to come back up to monitor
-    %% these processes again (they are referenced by triggers).
+    %% these processes again (they are referenced by triggers and/or
+    %% `keep_while' conditions).
     %%
     %% However, the member might have been removed from the cluster after
     %% going down. Therefore, we need to verify on a regular basis if this
@@ -2210,9 +2233,27 @@ do_apply(
                         put_options = PutOptions,
                         tree_options = TreeOptions}} = Command,
   State) ->
-    Ret = insert_or_update_node(
-            State, PathPattern, Payload, PutOptions, TreeOptions, []),
-    post_apply(Ret, Meta, Command);
+    Ret1 = insert_or_update_node(
+             State, PathPattern, Payload, PutOptions, TreeOptions, []),
+
+    %% If the operation was a success and the caller set a `keep_while'
+    %% condition on the inserted/updated tree node, we add the side effects
+    %% required by this condition, if any. For example, if the `keep_while'
+    %% condition is a PID, we need to monitor it.
+    Ret2 = case Ret1 of
+               {State1, {ok, _} = Result, SideEffects} ->
+                   case PutOptions of
+                       #{keep_while := KeepWhile} ->
+                           SideEffects1 = keep_while_to_side_effects(
+                                            KeepWhile, SideEffects),
+                           {State1, Result, SideEffects1};
+                       _ ->
+                           Ret1
+                   end;
+               _ ->
+                   Ret1
+           end,
+    post_apply(Ret2, Meta, Command);
 do_apply(
   Meta,
   #delete_v{args = #delete_v1{path = PathPattern,
@@ -2419,12 +2460,35 @@ do_apply(Meta, {down,  _Pid, noconnection} = Command, State) ->
     post_apply(Ret, Meta, Command);
 do_apply(Meta, {Down,  Pid, Reason} = Command, State)
   when Down =:= down orelse Down =:= really_down ->
+    %% Handle keep_while conditions. We lookup tree nodes watching this exited
+    %% process and delete them.
+    KeepWhileConds = get_keep_while_conds(State),
+    TreeOptions = #{},
+    {State1, SideEffects1} = (
+               maps:fold(
+                 fun
+                     (Watcher, KeepWhile, {S, SE})
+                       when is_pid(KeepWhile) andalso
+                            KeepWhile =:= Pid ->
+                         %% The process associated with this path
+                         %% exited. Therefore, we delete the
+                         %% corresponding tree node.
+                         %%
+                         %% We ignore the result here, because there is
+                         %% no explicit caller and no-one to return to.
+                         {S1, _R, SE1} = delete_matching_nodes(
+                                           S, Watcher, TreeOptions, SE),
+                         {S1, SE1};
+                     (_Watcher, _KeepWhile, Acc) ->
+                         Acc
+                 end, {State, []}, KeepWhileConds)),
+
     %% Handle triggers. We lookup triggers watching this exited process and add
     %% the side effects to execute the corresponding actions.
     Event = #ev_process{pid = Pid, change = {'DOWN', Reason}},
-    {State1, SideEffects} = add_trigger_side_effects(
-                              State, State, [Event], []),
-    Ret = {State1, Meta, SideEffects},
+    {State2, SideEffects2} = add_trigger_side_effects(
+                               State, State1, [Event], SideEffects1),
+    Ret = {State2, Meta, SideEffects2},
     post_apply(Ret, Meta, Command);
 do_apply(Meta, {nodeup, Node} = Command, State) ->
     %% We can stop monitoring this node. If we get a `noconnection' from a
@@ -2434,8 +2498,19 @@ do_apply(Meta, {nodeup, Node} = Command, State) ->
     %% We need to restore monitoring of processes that are hosted on that
     %% specific node. This will tell us if the process are still there are
     %% gone.
-    Triggers = get_triggers(State),
+    KeepWhileConds = get_keep_while_conds(State),
     SideEffects2 = maps:fold(
+                     fun
+                         (_Watcher, KeepWhile, SE)
+                           when is_pid(KeepWhile) andalso
+                                node(KeepWhile) =:= Node ->
+                             keep_while_to_side_effects(KeepWhile, SE);
+                         (_Watcher, _KeepWhile, SE) ->
+                             SE
+                     end, SideEffects1, KeepWhileConds),
+
+    Triggers = get_triggers(State),
+    SideEffects3 = maps:fold(
                      fun
                          (_TriggerId,
                           #{event_filter :=
@@ -2444,8 +2519,8 @@ do_apply(Meta, {nodeup, Node} = Command, State) ->
                              event_filter_to_side_effect(EventFilter, SE);
                          (_TriggerId, _Trigger, SE) ->
                              SE
-                     end, SideEffects1, Triggers),
-    Ret = {State, Meta, SideEffects2},
+                     end, SideEffects2, Triggers),
+    Ret = {State, Meta, SideEffects3},
     post_apply(Ret, Meta, Command);
 do_apply(Meta, {nodedown, _Node} = Command, State) ->
     Ret = {State, Meta},
@@ -2921,7 +2996,8 @@ compute_command_size(Command) ->
 state_enter(leader, State) ->
     SideEffects1 = emitted_triggers_to_side_effects(State, leader),
     SideEffects2 = non_emitted_triggers_to_side_effects(State, SideEffects1),
-    SideEffects2;
+    SideEffects3 = keep_while_conds_to_side_effects(State, SideEffects2),
+    SideEffects3;
 state_enter(recovered, _State) ->
     SideEffects = [{aux, restore_projections},
                    {aux, cache_effective_machine_version}],
@@ -3427,6 +3503,45 @@ evaluate_projection(
                                   projection = Projection},
     Effect = {aux, Trigger},
     [Effect | Effects].
+
+-spec keep_while_conds_to_side_effects(State, SideEffects) ->
+    NewSideEffects when
+      State :: khepri_machine:state(),
+      SideEffects :: ra_machine:effects(),
+      NewSideEffects :: ra_machine:effects().
+%% @private
+
+keep_while_conds_to_side_effects(State, SideEffects) ->
+    KeepWhileConds = get_keep_while_conds(State),
+    SideEffects1 = maps:fold(
+                     fun(_Watcher, KeepWhile, SE) ->
+                             keep_while_to_side_effects(KeepWhile, SE)
+                     end, SideEffects, KeepWhileConds),
+    SideEffects1.
+
+-spec keep_while_to_side_effects(KeepWhile, SideEffects) ->
+    NewSideEffects when
+      KeepWhile :: khepri_condition:native_keep_while(),
+      SideEffects :: ra_machine:effects(),
+      NewSideEffects :: ra_machine:effects().
+%% @private
+
+keep_while_to_side_effects(KeepWhile, SideEffects) when is_map(KeepWhile) ->
+    SideEffects;
+keep_while_to_side_effects(KeepWhile, SideEffects) when is_pid(KeepWhile) ->
+    %% FIXME: When the `keep_while' condition on a PID is deleted (i.e. when
+    %% the tree node using it is deleted), we should also demonitor the
+    %% process.
+    %%
+    %% This is not really a problem because a `DOWN' message is interpreted
+    %% using the existing `keep_while' conditions, so if the condition was
+    %% deleted, it will be a no-op. However leaving a moritor around is a waste
+    %% of resources. Demonitoring could happen lazily from a tick aux handler
+    %% for instance.
+    Pid = KeepWhile,
+    SideEffect = {monitor, process, Pid},
+    SideEffects1 = [SideEffect | SideEffects],
+    SideEffects1.
 
 -spec event_filter_to_side_effect(EventFilter, SideEffects) ->
     NewSideEffects when

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -3647,7 +3647,8 @@ evaluate_trigger(
     %% TODO: Match the exit reason if an optional pattern was provided.
     evaluate_action(
       NewState, Event, TriggerId, Trigger, TriggeredActions);
-evaluate_trigger(_InitialState, _NewState, _Event, _TriggerId, _Trigger, TriggeredActions) ->
+evaluate_trigger(
+  _InitialState, _NewState, _Event, _TriggerId, _Trigger, TriggeredActions) ->
     %% The event does not match the event filter.
     TriggeredActions.
 

--- a/src/khepri_machine.hrl
+++ b/src/khepri_machine.hrl
@@ -32,7 +32,8 @@
           uniform_commands            => 4,
           request_snapshot            => 4,
           extended_trigger            => 4,
-          cached_members_list         => 4}).
+          cached_members_list         => 4,
+          process_based_keep_while    => 4}).
 
 %% Get the state machine version the given API behaviour was introduced in.
 %% This is similar to `khepri_machine:api_behaviour_to_machine_version/1' but

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -387,7 +387,8 @@ squash_version_bumps_after_keep_while1(
 %% Keep-while functions.
 %% -------------------------------------------------------------------
 
--spec is_keep_while_met_at_insert_time(Tree, Path, Node, KeepWhile) -> IsMet when
+-spec is_keep_while_met_at_insert_time(Tree, Path, Node, KeepWhile) ->
+    IsMet when
       Tree :: khepri_tree:tree(),
       Path :: khepri_path:native_path(),
       Node :: tree_node() | {interrupted, any(), map()},

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -387,18 +387,53 @@ squash_version_bumps_after_keep_while1(
 %% Keep-while functions.
 %% -------------------------------------------------------------------
 
+-spec is_keep_while_met_at_insert_time(Tree, Path, Node, KeepWhile) -> IsMet when
+      Tree :: khepri_tree:tree(),
+      Path :: khepri_path:native_path(),
+      Node :: tree_node() | {interrupted, any(), map()},
+      KeepWhile :: khepri_condition:native_keep_while(),
+      IsMet :: true | {false, any()}.
+%% @private
+
+is_keep_while_met_at_insert_time(Tree, Path, Node, KeepWhile)
+  when is_map(KeepWhile) ->
+    AbsKeepWhile0 = to_absolute_keep_while(Path, KeepWhile),
+    AbsKeepWhile1 = filter_out_irrelevant_keep_while_conds(
+                      Path, Node, AbsKeepWhile0),
+    KWMet = are_keep_while_conditions_met(Tree, AbsKeepWhile1),
+    KWMet;
+is_keep_while_met_at_insert_time(_Tree, _Path, _Node, KeepWhile)
+  when is_pid(KeepWhile) ->
+    %% We don't check if the process is alive here at insert time for several
+    %% reasons:
+    %% * When the put command is replayed during the recovery of the machine
+    %%   state, the situation might be different compared to the initial put:
+    %%   the process might not be around anymore.
+    %% * If the process is remote, the check is complicated and can be affected
+    %%   by a network issue.
+    %%
+    %% In both cases, the state machine could compute a different state on
+    %% different cluster members on after recovery despite the same input of
+    %% state+command.
+    %%
+    %% That's why we just consider that this `keep_while' condition is met at
+    %% insert time.
+    true.
+
 -spec to_absolute_keep_while(BasePath, KeepWhile) -> AbsKeepWhile when
       BasePath :: khepri_path:native_path(),
       KeepWhile :: khepri_condition:native_keep_while(),
       AbsKeepWhile :: khepri_condition:native_keep_while().
 %% @private
 
-to_absolute_keep_while(BasePath, KeepWhile) ->
+to_absolute_keep_while(BasePath, KeepWhile) when is_map(KeepWhile) ->
     maps:fold(
       fun(Path, Cond, Acc) ->
               AbsPath = khepri_path:abspath(Path, BasePath),
               Acc#{AbsPath => Cond}
-      end, #{}, KeepWhile).
+      end, #{}, KeepWhile);
+to_absolute_keep_while(_BasePath, KeepWhile) when is_pid(KeepWhile) ->
+    KeepWhile.
 
 -spec are_keep_while_conditions_met(Tree, KeepWhile) -> Ret when
       Tree :: tree(),
@@ -476,13 +511,16 @@ update_keep_while_conds(Tree, Watcher, KeepWhile) ->
 
 update_keep_while_conds_revidx(
   #tree{keep_while_conds_revidx = KeepWhileCondsRevIdx} = Tree,
-  Watcher, KeepWhile) ->
+  Watcher, KeepWhile) when is_map(KeepWhile) ->
     case is_v1_keep_while_conds_revidx(KeepWhileCondsRevIdx) of
         true ->
             update_keep_while_conds_revidx_v1(Tree, Watcher, KeepWhile);
         false ->
             update_keep_while_conds_revidx_v0(Tree, Watcher, KeepWhile)
-    end.
+    end;
+update_keep_while_conds_revidx(Tree, _Watcher, KeepWhile)
+  when is_pid(KeepWhile) ->
+    Tree.
 
 is_v1_keep_while_conds_revidx(KeepWhileCondsRevIdx) ->
     khepri_prefix_tree:is_prefix_tree(KeepWhileCondsRevIdx).
@@ -493,7 +531,7 @@ update_keep_while_conds_revidx_v0(
   Watcher, KeepWhile) ->
     %% First, clean up reversed index where a watched path isn't watched
     %% anymore in the new keep_while.
-    OldWatcheds = maps:get(Watcher, KeepWhileConds, #{}),
+    OldWatcheds = get_watcheds(KeepWhileConds, Watcher),
     KeepWhileCondsRevIdx1 = maps:fold(
                           fun(Watched, _, KWRevIdx) ->
                                   Watchers = maps:get(Watched, KWRevIdx),
@@ -518,7 +556,7 @@ update_keep_while_conds_revidx_v1(
   Watcher, KeepWhile) ->
     %% First, clean up reversed index where a watched path isn't watched
     %% anymore in the new keep_while.
-    OldWatcheds = maps:get(Watcher, KeepWhileConds, #{}),
+    OldWatcheds = get_watcheds(KeepWhileConds, Watcher),
     KeepWhileCondsRevIdx1 = maps:fold(
                           fun(Watched, _, KWRevIdx) ->
                                   khepri_prefix_tree:update(
@@ -542,6 +580,13 @@ update_keep_while_conds_revidx_v1(
                                     end, Watched, KWRevIdx)
                           end, KeepWhileCondsRevIdx1, KeepWhile),
     Tree#tree{keep_while_conds_revidx = KeepWhileCondsRevIdx2}.
+
+get_watcheds(KeepWhileConds, Watcher) ->
+    case KeepWhileConds of
+        #{Watcher := KeepWhile} when is_map(KeepWhile) -> KeepWhile;
+        #{Watcher := KeepWhile} when is_pid(KeepWhile) -> #{};
+        _                                              -> #{}
+    end.
 
 %% -------------------------------------------------------------------
 %% Find matching nodes.
@@ -737,13 +782,8 @@ insert_or_update_node(
                           Path, Node, Payload, TreeOptions, Result),
                   case Ret of
                       {ok, Node1, Result1} when Result1 =/= #{} ->
-                          AbsKeepWhile0 = to_absolute_keep_while(
-                                            Path, KeepWhile),
-                          AbsKeepWhile1 = (
-                            filter_out_irrelevant_keep_while_conds(
-                              Path, Node, AbsKeepWhile0)),
-                          KWMet = are_keep_while_conditions_met(
-                                    Tree, AbsKeepWhile1),
+                          KWMet = is_keep_while_met_at_insert_time(
+                                    Tree, Path, Node, KeepWhile),
                           case KWMet of
                               true ->
                                   {ok, Node1, {updated, Path, Result1}};

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -446,10 +446,7 @@ are_keep_while_conditions_met(_, KeepWhile)
   when KeepWhile =:= #{} ->
     true;
 are_keep_while_conditions_met(Tree, KeepWhile) ->
-    TreeOptions = #{props_to_return => [payload,
-                                        payload_version,
-                                        child_list_version,
-                                        child_list_length]},
+    TreeOptions = #{props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
     maps:fold(
       fun
           (Path, Condition, true) ->
@@ -938,10 +935,7 @@ does_path_match(
     ReversedPath1 = [Component | ReversedPath],
     CurrentPath = lists:reverse(ReversedPath1),
     TreeOptions = #{expect_specific_node => true,
-                    props_to_return => [payload,
-                                        payload_version,
-                                        child_list_version,
-                                        child_list_length]},
+                    props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
     case find_matching_nodes(Tree, CurrentPath, TreeOptions) of
         {ok, #{CurrentPath := Node}} ->
             does_path_match_condition(
@@ -1547,10 +1541,7 @@ walk_back_up_the_tree(
     %% Evaluate keep_while of nodes which depend on ChildName (it is
     %% created) at the end of walk_back_up_the_tree().
     Path = lists:reverse(WholeReversedPath),
-    TreeOptions = #{props_to_return => [payload,
-                                        payload_version,
-                                        child_list_version,
-                                        child_list_length]},
+    TreeOptions = #{props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
     NodeProps = gather_node_props(Child1, TreeOptions),
     AppliedChangesAcc1 = AppliedChangesAcc#{Path => {create, NodeProps}},
 
@@ -1569,10 +1560,7 @@ walk_back_up_the_tree(
     %% Evaluate keep_while of nodes which depend on ChildName (it is
     %% modified) at the end of walk_back_up_the_tree().
     Path = lists:reverse(WholeReversedPath),
-    TreeOptions = #{props_to_return => [payload,
-                                        payload_version,
-                                        child_list_version,
-                                        child_list_length]},
+    TreeOptions = #{props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
     InitialNodeProps = gather_node_props(
                          maps:get(ChildName, ParentNode#node.child_nodes),
                          TreeOptions),

--- a/src/khepri_tree.hrl
+++ b/src/khepri_tree.hrl
@@ -9,3 +9,9 @@
 %% Maximum number of siblings grouped into a single `if_any' pattern by
 %% `paths_to_patterns/1'.
 -define(MAX_SIBLINGS_PER_PATTERN, 1000).
+
+-define(INTERNAL_LOOKUP_PROPS_TO_RETURN,
+        [payload,
+         payload_version,
+         child_list_version,
+         child_list_length]).

--- a/test/cluster_SUITE.erl
+++ b/test/cluster_SUITE.erl
@@ -65,6 +65,7 @@
          trigger_runs_on_all_members/1,
          trigger_runs_on_leader_if_non_member_target/1,
          trigger_options_rejected_before_v3/1,
+         process_based_keep_while_rejected_before_v3/1,
 
          start_monitored_proc/0]).
 
@@ -86,7 +87,8 @@ groups() ->
            requesting_snapshot_on_old_machine_does_not_crash,
            can_set_snapshot_interval,
            can_use_snapshot_strategy_from_macver4,
-           trigger_options_rejected_before_v3
+           trigger_options_rejected_before_v3,
+           process_based_keep_while_rejected_before_v3
           ]},
          {parallel, [parallel],
           [
@@ -2930,21 +2932,32 @@ process_event_is_delayed_during_node_down_1(Config) ->
               ct:pal("- khepri:start() from node ~s", [Node]),
               ?assertEqual(
                  {ok, StoreId},
-                 helpers:call(Config, Node, khepri, start, [RaSystem, StoreId]))
+                 helpers:call(
+                   Config, Node, khepri, start, [RaSystem, StoreId]))
       end, Nodes),
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri_cluster:join() from node ~s", [Node]),
               ?assertEqual(
                  ok,
-                 helpers:call(Config, Node, khepri_cluster, join, [StoreId, Node1]))
+                 helpers:call(
+                   Config, Node, khepri_cluster, join, [StoreId, Node1]))
       end, Nodes -- [Node1]),
 
     TriggerId = ?FUNCTION_NAME,
     MonitoredProcNode = Node3,
-    Pid = helpers:call(Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
+    Pid = helpers:call(
+            Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
     EventFilter = khepri_evf:process(Pid),
     StoredProcPath = [sproc],
+    Path = [foo],
+
+    ct:pal("Put a tree node with a keep_while condition on the process"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, put, [StoreId, Path, foo_value, #{keep_while => Pid}])),
 
     ct:pal("Put store procedure"),
     ?assertEqual(
@@ -2967,6 +2980,15 @@ process_event_is_delayed_during_node_down_1(Config) ->
       [MonitoredProcNode]),
     Peer = proplists:get_value(MonitoredProcNode, PeerPerNode),
     ?assertEqual(ok, helpers:stop_erlang_node(MonitoredProcNode, Peer)),
+
+    receive
+        {sproc, TriggerId, _LeaderNode, _Event} ->
+            ct:fail(
+              "Received the stored proc message before the monitored node "
+              "came back up")
+    after 2000 ->
+              ok
+    end,
 
     ct:pal(
       "Restart node ~s to trigger the node monitor",
@@ -3000,6 +3022,9 @@ process_event_is_delayed_during_node_down_1(Config) ->
                 [LeaderNode])
     end,
 
+    ?assertMatch(
+       {error, ?khepri_error(node_not_found, #{node_path := Path})},
+       helpers:call(Config, Node1, khepri, get, [StoreId, Path])),
     ok.
 
 process_event_is_delayed_during_node_down_2(Config) ->
@@ -3017,21 +3042,32 @@ process_event_is_delayed_during_node_down_2(Config) ->
               ct:pal("- khepri:start() from node ~s", [Node]),
               ?assertEqual(
                  {ok, StoreId},
-                 helpers:call(Config, Node, khepri, start, [RaSystem, StoreId]))
+                 helpers:call(
+                   Config, Node, khepri, start, [RaSystem, StoreId]))
       end, Nodes),
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri_cluster:join() from node ~s", [Node]),
               ?assertEqual(
                  ok,
-                 helpers:call(Config, Node, khepri_cluster, join, [StoreId, Node1]))
+                 helpers:call(
+                   Config, Node, khepri_cluster, join, [StoreId, Node1]))
       end, Nodes -- [Node1]),
 
     TriggerId = ?FUNCTION_NAME,
     MonitoredProcNode = Node3,
-    Pid = helpers:call(Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
+    Pid = helpers:call(
+            Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
     EventFilter = khepri_evf:process(Pid),
     StoredProcPath = [sproc],
+    Path = [foo],
+
+    ct:pal("Put a tree node with a keep_while condition on the process"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, put, [StoreId, Path, foo_value, #{keep_while => Pid}])),
 
     ct:pal("Put store procedure"),
     ?assertEqual(
@@ -3095,6 +3131,9 @@ process_event_is_delayed_during_node_down_2(Config) ->
                 [LeaderNode])
     end,
 
+    ?assertMatch(
+       {error, ?khepri_error(node_not_found, #{node_path := Path})},
+       helpers:call(Config, Node1, khepri, get, [StoreId, Path])),
     ok.
 
 process_event_is_delayed_during_node_down_3(Config) ->
@@ -3117,21 +3156,32 @@ process_event_is_delayed_during_node_down_3(Config) ->
               ct:pal("- khepri:start() from node ~s", [Node]),
               ?assertEqual(
                  {ok, StoreId},
-                 helpers:call(Config, Node, khepri, start, [RaSystem, StoreId]))
+                 helpers:call(
+                   Config, Node, khepri, start, [RaSystem, StoreId]))
       end, Nodes),
     lists:foreach(
       fun(Node) ->
               ct:pal("- khepri_cluster:join() from node ~s", [Node]),
               ?assertEqual(
                  ok,
-                 helpers:call(Config, Node, khepri_cluster, join, [StoreId, Node1]))
+                 helpers:call(
+                   Config, Node, khepri_cluster, join, [StoreId, Node1]))
       end, Nodes -- [Node1]),
 
     TriggerId = ?FUNCTION_NAME,
     MonitoredProcNode = Node3,
-    Pid = helpers:call(Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
+    Pid = helpers:call(
+            Config, MonitoredProcNode, ?MODULE, start_monitored_proc, []),
     EventFilter = khepri_evf:process(Pid),
     StoredProcPath = [sproc],
+    Path = [foo],
+
+    ct:pal("Put a tree node with a keep_while condition on the process"),
+    ?assertEqual(
+       ok,
+       helpers:call(
+         Config, Node1,
+         khepri, put, [StoreId, Path, foo_value, #{keep_while => Pid}])),
 
     ct:pal("Put store procedure"),
     ?assertEqual(
@@ -3176,6 +3226,9 @@ process_event_is_delayed_during_node_down_3(Config) ->
                 [LeaderNode])
     end,
 
+    ?assertMatch(
+       {error, ?khepri_error(node_not_found, #{node_path := Path})},
+       helpers:call(Config, Node1, khepri, get, [StoreId, Path])),
     ok.
 
 trigger_runs_on_leader(Config) ->
@@ -3479,6 +3532,34 @@ trigger_options_rejected_before_v3(Config) ->
     ?assertEqual(
        ok,
        khepri:stop(StoreId)),
+
+    meck:unload(khepri_machine),
+    ok.
+
+process_based_keep_while_rejected_before_v3(Config) ->
+    RaSystem = helpers:get_ra_system_name(Config),
+    StoreId = RaSystem,
+
+    MacVer = 2,
+    meck:new(khepri_machine, [passthrough, no_link]),
+    meck:expect(khepri_machine, version, fun() -> MacVer end),
+
+    ct:pal("Start database"),
+    ?assertEqual(
+       {ok, StoreId},
+       khepri:start(RaSystem, StoreId)),
+
+    Path = [foo],
+    Value = foo_value,
+
+    ?assertError(
+       ?khepri_exception(
+          unsupported_process_based_keep_while,
+          #{node_path := Path}),
+       khepri:put(StoreId, Path, Value, #{keep_while => self()})),
+
+    ct:pal("Stop database"),
+    ?assertEqual(ok, khepri:stop(StoreId)),
 
     meck:unload(khepri_machine),
     ok.

--- a/test/keep_while_conditions.erl
+++ b/test/keep_while_conditions.erl
@@ -689,6 +689,66 @@ child_list_version_bumped_by_update_and_keep_while_test() ->
        Ret),
     ?assertEqual([{aux, trigger_delayed_aux_queries_eval}], SE).
 
+keep_while_on_process_test_() ->
+    Parent = self(),
+    Pid = spawn_link(fun() ->
+                             receive
+                                 _ ->
+                                     erlang:unlink(Parent)
+                             end
+                     end),
+
+    Path = [foo],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Wait for `process_based_keep_while` behaviour",
+         ?_assertEqual(
+            ok,
+            khepri_cluster:wait_for_effective_behaviour(
+              ?FUNCTION_NAME, process_based_keep_while, infinity))
+        },
+        {"Store a tree node with a keep_while condition",
+         ?_assertMatch(
+            ok,
+            khepri:put(?FUNCTION_NAME, Path, value, #{keep_while => Pid}))},
+        {"Display store info",
+         ?_assertEqual(
+            ok,
+            khepri:info(?FUNCTION_NAME))},
+        {"Terminate process",
+         ?_assert(begin
+                      MRef = erlang:monitor(process, Pid),
+                      Pid ! stop,
+                      receive
+                          {'DOWN', MRef, process, Pid, _Reason} ->
+                              true
+                      end
+                  end)},
+        {"Check that the tree node was removed",
+         ?_assertMatch(
+            {error, ?khepri_error(node_not_found, #{node_path := Path})},
+            begin
+                wait_for_tree_node_removal(?FUNCTION_NAME, Path),
+                khepri:get(?FUNCTION_NAME, Path)
+            end)}]
+      }]}.
+
+wait_for_tree_node_removal(StoreId, Path) ->
+    wait_for_tree_node_removal(StoreId, Path, 10).
+
+wait_for_tree_node_removal(StoreId, Path, Attempts) when Attempts > 0 ->
+    case khepri:get(StoreId, Path) of
+        {ok, _} ->
+            timer:sleep(100),
+            wait_for_tree_node_removal(StoreId, Path, Attempts - 1);
+        {error, _} ->
+            ok
+    end;
+wait_for_tree_node_removal(_StoreId, _Path, 0) ->
+    ok.
+
 %% -------------------------------------------------------------------
 %% Performance testing.
 %% -------------------------------------------------------------------

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -710,7 +710,8 @@ make_sproc(Pid, Key) ->
                                 event = #{path := Path, change := Change}} ->
                     Pid ! {sproc, Key, {Change, Path}};
                 #khepri_trigger{type = process,
-                                event = #{pid := MonitoredPid, change := Change}} ->
+                                event = #{pid := MonitoredPid,
+                                          change := Change}} ->
                     Pid ! {sproc, Key, {Change, MonitoredPid}}
             end
     end.


### PR DESCRIPTION
## Why

This allows to link the lifetime of a tree node to that of a process. When the process terminates, the tree node is deleted.

## How

The `keep_while` put option now accepts a PID in addition to the combination of a path and a condition.

Like the trigger equivalent, the process indicated in a `keep_while` condition is monitored by the Ra leader. The handling of the DOWN messages is exactly the same as for triggers, except that a tree node is deleted (instead of executing a trigger).