### PR TITLE
khepri_tree: Pass tree node change attributes down the line

### DIFF
--- a/src/khepri_event_handler.erl
+++ b/src/khepri_event_handler.erl
@@ -171,9 +171,9 @@ event_type(#ev_tree{}) ->
 event_type(#ev_process{}) ->
     process.
 
-event_to_props(#ev_tree{path = Path, change = Change}) ->
-    #{path => Path,
-      change => Change};
+event_to_props(#ev_tree{path = Path, change = {ChangeType, ChangeAttrs}}) ->
+    ChangeAttrs#{path => Path,
+                 change => ChangeType};
 event_to_props(#ev_process{pid = Pid, change = Change}) ->
     #{pid => Pid,
       change => Change}.

--- a/src/khepri_evf.erl
+++ b/src/khepri_evf.erl
@@ -238,7 +238,7 @@
 %%
 %% It takes a path pattern to monitor and optionally properties.
 
--type tree_event_filter_props() :: #{on_actions => [create | update | delete],
+-type tree_event_filter_props() :: #{on_actions => [khepri_tree:change_type()],
                                      priority => khepri_evf:priority()}.
 %% Tree event filter properties.
 %%

--- a/src/khepri_evf.hrl
+++ b/src/khepri_evf.hrl
@@ -17,7 +17,7 @@
          is_record(EventFilter, evf_process))).
 
 -record(ev_tree, {path :: khepri_path:native_path(),
-                  change :: create | update | delete}).
+                  change :: khepri_tree:applied_change()}).
 
 -record(ev_process, {pid :: pid(),
                      change :: {'DOWN', any()}}).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -3403,19 +3403,12 @@ delete_matching_nodes(State, PathPattern, TreeOptions, SideEffects) ->
 
 add_tree_change_side_effects(
   InitialState, NewState, AppliedChanges, SideEffects) ->
-    %% We make a map where for each affected tree node, we indicate the type
-    %% of change.
+    %% We make a map where for each affected tree node, we indicate the change
+    %% (type + change arguments).
     Paths = lists:sort(maps:keys(AppliedChanges)),
     Events = lists:map(
                fun(Path) ->
-                       Change = case maps:get(Path, AppliedChanges) of
-                                    {Type, _NodeProps}
-                                      when Type =:= create orelse
-                                           Type =:= update ->
-                                        Type;
-                                    delete = Type ->
-                                        Type
-                                end,
+                       #{Path := Change} = AppliedChanges,
                        #ev_tree{path = Path, change = Change}
                end, Paths),
     NewSideEffects = create_projection_side_effects(
@@ -3445,12 +3438,9 @@ create_projection_side_effects1(
 create_projection_side_effects2(
   InitialTree, NewTree, ProjectionTree, Path, Change, Effects) ->
     PatternMatchingTree = case Change of
-                              create ->
-                                  NewTree;
-                              update ->
-                                  NewTree;
-                              delete ->
-                                  InitialTree
+                              {create, _} -> NewTree;
+                              {update, _} -> NewTree;
+                              {delete, _} -> InitialTree
                           end,
     khepri_pattern_tree:fold_matching(
       ProjectionTree,
@@ -3605,7 +3595,8 @@ list_triggered_actions(InitialState, NewState, Events, Triggers) ->
 
 evaluate_trigger(
   InitialState, NewState,
-  #ev_tree{path = Path, change = Change} = Event, TriggerId,
+  #ev_tree{path = Path,
+           change = {ChangeType, _ChangeAttrs}} = Event, TriggerId,
   #{event_filter := #evf_tree{path = PathPattern,
                               props = EventFilterProps}} = Trigger,
   TriggeredActions) ->
@@ -3614,7 +3605,7 @@ evaluate_trigger(
     %%      path pattern in the event filter.
     %%   2. we verify the type of change matches the change filter in the
     %%      event filter.
-    Tree = case Change of
+    Tree = case ChangeType of
                delete -> get_tree(InitialState);
                _      -> get_tree(NewState)
            end,
@@ -3629,7 +3620,7 @@ evaluate_trigger(
                          _ ->
                              DefaultWatchedChanges
                      end,
-    ChangeMatches = lists:member(Change, WatchedChanges),
+    ChangeMatches = lists:member(ChangeType, WatchedChanges),
     case PathMatches andalso ChangeMatches of
         true ->
             evaluate_action(
@@ -3675,9 +3666,11 @@ evaluate_action(State, Event, TriggerId, Trigger, TriggeredActions)
                             #{sproc := _} ->
                                 %% With trigger v1, the only type of event is
                                 %% a tree change.
-                                #ev_tree{path = Path, change = Change} = Event,
+                                #ev_tree{path = Path,
+                                         change = {ChangeType, _ChangeAttrs}
+                                        } = Event,
                                 EventProps = #{path => Path,
-                                               on_action => Change},
+                                               on_action => ChangeType},
                                 #triggered{
                                    id = TriggerId,
                                    event_filter = EventFilter,

--- a/src/khepri_tree.erl
+++ b/src/khepri_tree.erl
@@ -80,10 +80,39 @@
 %% matching conditions. In version 1 this type was replaced with a prefix tree
 %% which improves lookup time when the reverse index contains many entries.
 
+-type change_type() :: create | update | delete.
+%% Type of a change made to a tree node.
+
+-type create_change_attrs() :: #{new_node_props := khepri:node_props()}.
+%% Attributes of the `create' change made to a tree node.
+%%
+%% <ul>
+%% <li>`new_node_props': node properties of the the created node</li>
+%% </ul>
+
+-type update_change_attrs() :: #{old_node_props := khepri:node_props(),
+                                 new_node_props := khepri:node_props()}.
+%% Attributes of the `update' change made to a tree node.
+%%
+%% <ul>
+%% <li>`old_node_props': node properties of the replaced tree node</li>
+%% <li>`new_node_props': node properties of the new tree node</li>
+%% </ul>
+
+-type delete_change_attrs() :: #{old_node_props := khepri:node_props()}.
+%% Attributes of the `delete' change made to a tree node.
+%%
+%% <ul>
+%% <li>`old_node_props': node properties of the deleted tree node</li>
+%% </ul>
+
+-type applied_change() :: {create, create_change_attrs()} |
+                          {update, update_change_attrs()} |
+                          {delete, delete_change_attrs()}.
+%% A type of a change made to a tree node, with its attributes.
+
 -type applied_changes() :: #{khepri_path:native_path() =>
-                             {create, khepri:node_props()} |
-                             {update, khepri:node_props()} |
-                             delete}.
+                             khepri_tree:applied_change()}.
 %% Internal index of the per-node changes which happened during a traversal.
 %% This is used when the tree is walked back up to determine the list of tree
 %% nodes to remove after some keep_while condition evaluates to false.
@@ -108,6 +137,11 @@
               keep_while_conds_revidx_v0/0,
               keep_while_conds_revidx_v1/0,
               keep_while_conds_revidx/0,
+              change_type/0,
+              create_change_attrs/0,
+              update_change_attrs/0,
+              delete_change_attrs/0,
+              applied_change/0,
               applied_changes/0]).
 
 %% -------------------------------------------------------------------
@@ -328,9 +362,9 @@ squash_version_bumps_after_keep_while(
     %% the previous update of the tree.
     BumpsBefore = maps:fold(
                     fun
-                        (Path, Change, Acc)
-                          when Change =:= delete orelse
-                               element(1, Change) =:= create ->
+                        (Path, {ChangeType, _}, Acc)
+                          when ChangeType =:= create orelse
+                               ChangeType =:= delete ->
                             ParentPath = lists:droplast(Path),
                             Acc#{ParentPath => true};
                         (_Path, _Change, Acc) ->
@@ -1513,7 +1547,13 @@ walk_back_up_the_tree(
     %% Evaluate keep_while of nodes which depended on ChildName (it is
     %% removed) at the end of walk_back_up_the_tree().
     Path = lists:reverse(WholeReversedPath),
-    AppliedChangesAcc1 = AppliedChangesAcc#{Path => delete},
+    TreeOptions = #{props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
+    InitialNodeProps = gather_node_props(
+                         maps:get(ChildName, ParentNode#node.child_nodes),
+                         TreeOptions),
+    AppliedChangesAcc1 = add_change_to_applied_changes(
+                           AppliedChangesAcc, Path,
+                           delete, #{old_node_props => InitialNodeProps}),
 
     %% All children of `Path' are also added recursively to the
     %% `AppliedChangesAcc1' map.
@@ -1543,7 +1583,9 @@ walk_back_up_the_tree(
     Path = lists:reverse(WholeReversedPath),
     TreeOptions = #{props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
     NodeProps = gather_node_props(Child1, TreeOptions),
-    AppliedChangesAcc1 = AppliedChangesAcc#{Path => {create, NodeProps}},
+    AppliedChangesAcc1 = add_change_to_applied_changes(
+                           AppliedChangesAcc, Path,
+                           create, #{new_node_props => NodeProps}),
 
     %% Evaluate keep_while of parent node on itself right now (its child_count
     %% has changed).
@@ -1565,13 +1607,16 @@ walk_back_up_the_tree(
                          maps:get(ChildName, ParentNode#node.child_nodes),
                          TreeOptions),
     NodeProps = gather_node_props(Child, TreeOptions),
-    AppliedChangesAcc1 = case NodeProps of
-                             InitialNodeProps ->
-                                 AppliedChangesAcc;
-                             _ ->
-                                 AppliedChangesAcc#{
-                                   Path => {update, NodeProps}}
-                         end,
+    AppliedChangesAcc1 = (
+      case NodeProps of
+          InitialNodeProps ->
+              AppliedChangesAcc;
+          _ ->
+              add_change_to_applied_changes(
+                AppliedChangesAcc, Path,
+                update, #{old_node_props => InitialNodeProps,
+                          new_node_props => NodeProps})
+      end),
 
     %% No need to evaluate keep_while of ParentNode, its child_count is
     %% unchanged.
@@ -1596,6 +1641,27 @@ walk_back_up_the_tree(
     AppliedChanges1 = merge_applied_changes(AppliedChanges, AppliedChangesAcc),
     Walk1 = Walk#walk{applied_changes = AppliedChanges1},
     {ok, Walk1}.
+
+-spec add_change_to_applied_changes
+  (AppliedChanges, Path, create, ChangeAttrs) -> NewAppliedChanges when
+      AppliedChanges :: applied_changes(),
+      Path :: khepri_path:native_path(),
+      ChangeAttrs :: create_change_attrs(),
+      NewAppliedChanges :: applied_changes();
+  (AppliedChanges, Path, update, ChangeAttrs) -> NewAppliedChanges when
+      AppliedChanges :: applied_changes(),
+      Path :: khepri_path:native_path(),
+      ChangeAttrs :: update_change_attrs(),
+      NewAppliedChanges :: applied_changes();
+  (AppliedChanges, Path, delete, ChangeAttrs) -> NewAppliedChanges when
+      AppliedChanges :: applied_changes(),
+      Path :: khepri_path:native_path(),
+      ChangeAttrs :: delete_change_attrs(),
+      NewAppliedChanges :: applied_changes().
+
+add_change_to_applied_changes(AppliedChanges, Path, ChangeType, ChangeAttrs) ->
+    AppliedChanges1 = AppliedChanges#{Path => {ChangeType, ChangeAttrs}},
+    AppliedChanges1.
 
 handle_keep_while_for_parent_update(
   #walk{reversed_parent_tree = [{_GrandParentNode, child_created} | _]} = Walk,
@@ -1645,7 +1711,12 @@ list_deleted_nodes_recursively_from(
     maps:fold(
       fun(ChildName, ChildNode, AppliedChangesAcc1) ->
               ChildPath = Path ++ [ChildName],
-              AppliedChangesAcc2 = AppliedChangesAcc1#{ChildPath => delete},
+              TreeOptions = #{props_to_return => ?INTERNAL_LOOKUP_PROPS_TO_RETURN},
+              InitialNodeProps = gather_node_props(ChildNode, TreeOptions),
+              AppliedChangesAcc2 = add_change_to_applied_changes(
+                                     AppliedChangesAcc1, ChildPath,
+                                     delete,
+                                     #{old_node_props => InitialNodeProps}),
               list_deleted_nodes_recursively_from(
                 ChildPath, ChildNode, AppliedChangesAcc2)
       end, AppliedChangesAcc, Children).
@@ -1653,12 +1724,30 @@ list_deleted_nodes_recursively_from(
 merge_applied_changes(AppliedChanges1, AppliedChanges2) ->
     maps:fold(
       fun
-          (Path, delete, KWA1) ->
-              KWA1#{Path => delete};
-          (Path, {_, _} = TypeAndNodeProps, KWA1) ->
-              case KWA1 of
-                  #{Path := delete} -> KWA1;
-                  _                 -> KWA1#{Path => TypeAndNodeProps}
+          (Path, Change, AC1)
+            when not is_map_key(Path, AC1) ->
+              AC1#{Path => Change};
+
+          (Path, {update, #{new_node_props := NodeProps}}, AC1) ->
+              case AC1 of
+                  #{Path := {create, _}} ->
+                      NewChangeAttrs = #{new_node_props => NodeProps},
+                      AC1#{Path => {create, NewChangeAttrs}};
+                  #{Path := {update, #{old_node_props := InitialNodeProps}}} ->
+                      NewChangeAttrs = #{old_node_props => InitialNodeProps,
+                                         new_node_props => NodeProps},
+                      AC1#{Path => {update, NewChangeAttrs}}
+              end;
+
+          (Path, {delete, _}, AC1) ->
+              case AC1 of
+                  #{Path := {create, _}} ->
+                      maps:remove(Path, AC1);
+                  #{Path := {update, #{old_node_props := InitialNodeProps}}} ->
+                      NewChangeAttrs = #{old_node_props => InitialNodeProps},
+                      AC1#{Path => {delete, NewChangeAttrs}};
+                  #{Path := {delete, _}} ->
+                      AC1
               end
       end, AppliedChanges1, AppliedChanges2).
 
@@ -1675,12 +1764,12 @@ handle_applied_changes(
 
     Tree2 = maps:fold(
               fun
-                  (RemovedPath, delete, T) ->
+                  (RemovedPath, {delete, _ChangeAttrs}, T) ->
                       KW1 = maps:remove(
                               RemovedPath, T#tree.keep_while_conds),
                       T1 = update_keep_while_conds_revidx(T, RemovedPath, #{}),
                       T1#tree{keep_while_conds = KW1};
-                  (_, {_, _}, T) ->
+                  (_, {_ChangeType, _ChangeAttrs}, T) ->
                       T
               end, Tree1, AppliedChanges),
 
@@ -1714,7 +1803,7 @@ eval_keep_while_conditions_v0(
   AppliedChanges) ->
     maps:fold(
       fun
-          (RemovedPath, delete, ToDelete) ->
+          (RemovedPath, {delete, _ChangeAttrs}, ToDelete) ->
               maps:fold(
                 fun(Path, Watchers, ToDelete1) ->
                         case lists:prefix(RemovedPath, Path) of
@@ -1725,11 +1814,11 @@ eval_keep_while_conditions_v0(
                                 ToDelete1
                         end
                 end, ToDelete, KeepWhileCondsRevIdx);
-          (UpdatedPath, {_Type, NodeProps}, ToDelete) ->
+          (UpdatedPath, {_ChangeType, ChangeAttrs}, ToDelete) ->
               case KeepWhileCondsRevIdx of
                   #{UpdatedPath := Watchers} ->
                       eval_keep_while_conditions_after_update(
-                        Tree, UpdatedPath, NodeProps, Watchers, ToDelete);
+                        Tree, UpdatedPath, ChangeAttrs, Watchers, ToDelete);
                   _ ->
                       ToDelete
               end
@@ -1740,19 +1829,19 @@ eval_keep_while_conditions_v1(
   AppliedChanges) ->
     maps:fold(
       fun
-          (RemovedPath, delete, ToDelete) ->
+          (RemovedPath, {delete, _ChangeAttrs}, ToDelete) ->
               khepri_prefix_tree:fold_prefixes_of(
                 fun(Watchers, ToDelete1) ->
                         eval_keep_while_conditions_after_removal(
                           Tree, Watchers, ToDelete1)
                 end, ToDelete, RemovedPath, KeepWhileCondsRevIdx);
-          (UpdatedPath, {_Type, NodeProps}, ToDelete) ->
+          (UpdatedPath, {_ChangeType, ChangeAttrs}, ToDelete) ->
               Result = khepri_prefix_tree:find_path(
                          UpdatedPath, KeepWhileCondsRevIdx),
               case Result of
                   {ok, Watchers} ->
                       eval_keep_while_conditions_after_update(
-                        Tree, UpdatedPath, NodeProps, Watchers, ToDelete);
+                        Tree, UpdatedPath, ChangeAttrs, Watchers, ToDelete);
                   error ->
                       ToDelete
               end
@@ -1760,7 +1849,7 @@ eval_keep_while_conditions_v1(
 
 eval_keep_while_conditions_after_update(
   #tree{keep_while_conds = KeepWhileConds} = Tree,
-  UpdatedPath, NodeProps, Watchers, ToDelete) ->
+  UpdatedPath, #{new_node_props := NodeProps}, Watchers, ToDelete) ->
     maps:fold(
       fun(Watcher, ok, ToDelete1) ->
               KeepWhile = maps:get(Watcher, KeepWhileConds),
@@ -1802,7 +1891,7 @@ filter_and_sort_paths_to_delete(ToDelete, AppliedChanges) ->
     Paths2 = lists:foldl(
                fun(Path, Map) ->
                        case AppliedChanges of
-                           #{Path := delete} ->
+                           #{Path := {delete, _ChangeAttrs}} ->
                                Map;
                            _ ->
                                case is_parent_being_removed(Path, Map) of

--- a/test/triggers.erl
+++ b/test/triggers.erl
@@ -146,8 +146,8 @@ event_using_matching_pattern2_triggers_associated_sproc_test_() ->
               ?FUNCTION_NAME, [foo, bar], value))},
 
         {"Checking the procedure was executed for the grandchild node",
-         ?_assertEqual(
-          {create, [foo, bar]},
+         ?_assertMatch(
+          {create, [foo, bar], #{new_node_props := #{data := value}}},
           receive_sproc_msg_with_props(Key))},
 
         {"Updating a matching great-grandchild node; "
@@ -158,8 +158,8 @@ event_using_matching_pattern2_triggers_associated_sproc_test_() ->
               ?FUNCTION_NAME, [foo, bar, baz], value))},
 
         {"Checking the procedure was executed for the great-grandchild node",
-         ?_assertEqual(
-          {create, [foo, bar, baz]},
+         ?_assertMatch(
+          {create, [foo, bar, baz], #{new_node_props := #{data := value}}},
           receive_sproc_msg_with_props(Key))}]
       }]}.
 
@@ -707,8 +707,9 @@ make_sproc(Pid, Key) ->
                 #{path := Path, on_action := OnAction} ->
                     Pid ! {sproc, Key, {OnAction, Path}};
                 #khepri_trigger{type = tree,
-                                event = #{path := Path, change := Change}} ->
-                    Pid ! {sproc, Key, {Change, Path}};
+                                event = #{path := Path,
+                                          change := Change} = Event} ->
+                    Pid ! {sproc, Key, {Change, Path, Event}};
                 #khepri_trigger{type = process,
                                 event = #{pid := MonitoredPid,
                                           change := Change}} ->
@@ -881,4 +882,61 @@ maybe_convert_to_action_with_latest_machine_version_test_() ->
              StoreId, TriggerId, EventFilter,
              {send, Pid, priv}))
        ]
+      }]}.
+
+triggered_sproc_is_called_with_node_props_test_() ->
+    EventFilter = khepri_evf:tree([foo, ?KHEPRI_WILDCARD_STAR_STAR]),
+    StoredProcPath = [sproc],
+    Key = ?FUNCTION_NAME,
+    Path = [foo, bar],
+    {setup,
+     fun() -> test_ra_server_helpers:setup(?FUNCTION_NAME) end,
+     fun(Priv) -> test_ra_server_helpers:cleanup(Priv) end,
+     [{inorder,
+       [{"Storing a procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(
+              ?FUNCTION_NAME, StoredProcPath,
+              make_sproc(self(), Key)))},
+
+        {"Registering a trigger",
+         ?_assertEqual(
+            ok,
+            khepri:register_trigger(
+              ?FUNCTION_NAME,
+              ?FUNCTION_NAME,
+              EventFilter,
+              StoredProcPath))},
+
+        {"Creating a matching tree node; should trigger the procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(?FUNCTION_NAME, Path, value1))},
+
+        {"Checking the procedure was executed for the matching tree node",
+         ?_assertMatch(
+          {create, Path, #{new_node_props := #{data := value1}}},
+          receive_sproc_msg_with_props(Key))},
+
+        {"Updating a matching tree node; should trigger the procedure",
+         ?_assertMatch(
+            ok,
+            khepri:put(?FUNCTION_NAME, Path, value2))},
+
+        {"Checking the procedure was executed for the matching tree node",
+         ?_assertMatch(
+          {update, Path, #{old_node_props := #{data := value1},
+                           new_node_props := #{data := value2}}},
+          receive_sproc_msg_with_props(Key))},
+
+        {"Deleting a matching tree node; should trigger the procedure",
+         ?_assertMatch(
+            ok,
+            khepri:delete(?FUNCTION_NAME, Path))},
+
+        {"Checking the procedure was executed for the matching tree node",
+         ?_assertMatch(
+          {delete, Path, #{old_node_props := #{data := value2}}},
+          receive_sproc_msg_with_props(Key))}]
       }]}.


### PR DESCRIPTION
... down to trigger's stored procedure arguments for example.

## Why

A trigger's store procedure could already do things based on the tree node path and the type of change: `create`, `update` or `delete`. But it couldn't decide based on what actually changed.

## How

Khepri already tracks the type of change and how the tree node properties changed. Therefore, it makes sense to pass this information in the `ev_tree{}` reecord and to a triggered stored procedure arguments.

This change is backward-compatible and does not require a bump of the machine version.

The `#khepri_trigger{}` record passed to a triggered stored procedure already has map in its `event` field containing the path and the type of change for a tree event. This map now hold the properties of the affected tree node:
    * For the `create` event, it will have a `new_node_props` key pointing to the created tree node properties.
    * For the `update` event, it will have an `old_node_props` key pointing to the replaced tree node properties and a `new_node_props` key pointing to the modified tree node properties.
    * For the `delete` event, it will have an `old_node_props` key pointing to the delete tree node properties.

This way, the triggered stored procedure can access the payload of the tree node: for instance, the old and new payloads in case of an update, or the old payload of a deletion.

Fixes #358.