### PR TITLE
rebar.config: Update meck from 1.1.0 to 1.2.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
 
 {profiles,
  [{test,
-   [{deps, [{meck, "1.1.0"},
+   [{deps, [{meck, "1.2.0"},
             {proper, "1.5.0"},
             %% FIXME: We need to add `cth_readable' as a dependency and an
             %% extra app for Dialyzer. That's because Rebar is using that


### PR DESCRIPTION
## Why

It brings support for Erlang/OTP 29.