### PR TITLE
GitHub Actions: Publish docs preview to GitHub Pages

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -102,7 +102,9 @@ jobs:
         run: sed -E -i -e 's/^@version.*/@version Development branch/' doc/overview.edoc
 
       - name: Generate
-        run: rebar3 edoc
+        run: |
+          rebar3 edoc
+          rm -rf doc/chunks
 
       - name: Ensure HTML files are there
         run: ls -l doc && test -f doc/index.html

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -98,8 +98,16 @@ jobs:
           otp-version: ${{ env.LATEST_ERLANG_VERSION }}
           rebar3-version: ${{ env.REBAR_VERSION }}
 
-      - name: Change doc version to "Development branch"
-        run: sed -E -i -e 's/^@version.*/@version Development branch/' doc/overview.edoc
+      - name: Change doc version based of "${{ github.ref_name }}"
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          version=$(echo ${GITHUB_REF_NAME%%/merge} | tr '/' '__')
+          case $GITHUB_REF_NAME in
+            */merge) version="Pull request $version" ;;
+          esac
+          echo "Version = $version"
+          sed -E -i -e "s/^@version.*/@version $version/" doc/overview.edoc
 
       - name: Generate
         run: |
@@ -116,13 +124,43 @@ jobs:
           path: ./doc
           if-no-files-found: error
 
+  publish_docs_preview:
+    name: Publish docs preview
+    runs-on: ubuntu-latest
+    needs: build_docs
+    if: github.ref_type == 'branch'
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download docs from previous job
+        uses: actions/download-artifact@v8
+        with:
+          name: docs_dir
+          path: ./doc
+
+      - name: Ensure HTML files are there
+        run: ls -l doc && test -f doc/index.html
+
+      - name: Publish preview
+        uses: dumbbell/preview-pages@main
+        with:
+          source-dir: doc
+          target-dir: previews
+          pr-per-commit: false
+          pr-comment: sticky
+          branch-per-commit: false
+          branch-comment: none
+
   publish_docs:
     name: Publish docs
     runs-on: ubuntu-latest
     needs: build_docs
-    if: github.repository == 'rabbitmq/khepri' && github.ref == 'refs/heads/main'
+    if: github.ref_type == 'tag'
 
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download docs from previous job
         uses: actions/download-artifact@v8
         with:
@@ -133,10 +171,14 @@ jobs:
         run: ls -l doc && test -f doc/index.html
 
       - name: Publish
-        uses: peaceiris/actions-gh-pages@v4
+        uses: dumbbell/preview-pages@main
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc
+          source-dir: doc
+          # target-dir: .
+          pr-per-commit: false
+          pr-comment: sticky
+          branch-per-commit: false
+          branch-comment: none
 
   publish_release:
     name: Publish release


### PR DESCRIPTION
GitHub Actions: Publish docs preview to GitHub Pages

## Why

Publishing docs preview for each branch, pull request and tag helps checking everything is as expected.

* Docs for tags are published to `/$tag/`; for example `/v1.2.3/`.
* Docs for branches are published to `/previews/$branch/`; for example `/previews/v1.2.x/`.
* Docs for pull requests are published to `/previews/pr-$number/`; for example `/previews/pr-1234/`.