### PR TITLE
Documentation: Fix several warnings reported by ExDoc

### DIFF
--- a/src/khepri.erl
+++ b/src/khepri.erl
@@ -348,8 +348,8 @@
 %% `favor' computes a `condition' internally. Therefore if both options are
 %% set, `condition' takes precedence and `favor' is ignored.
 %%
-%% NOTE: When this list of query options is modified, {@link
-%% khepri_machine:split_query_options/2} must be adapted.
+%% NOTE: When this list of query options is modified,
+%% `khepri_machine:split_query_options/2' must be adapted.
 
 -type tree_options() :: #{expect_specific_node => boolean(),
                           props_to_return => [known_prop_to_return() |
@@ -375,9 +375,9 @@
 %% the effective machine version is too old.</li>
 %% </ul>
 %%
-%% NOTE: When this list of tree options is modified, {@link
-%% khepri_machine:split_query_options/2} and {@link
-%% khepri_machine:split_command_options/2} must be adapted.
+%% NOTE: When this list of tree options is modified,
+%% `khepri_machine:split_query_options/2' and
+%% `khepri_machine:split_command_options/2' must be adapted.
 
 -type known_prop_to_return() :: payload_version |
                                 child_list_version |
@@ -407,9 +407,9 @@
 %% created/updated tree node.</li>
 %% </ul>
 %%
-%% NOTE: When this list of put options is modified, {@link
-%% khepri_machine:split_command_options/2} and {@link
-%% khepri_machine:split_put_options/2} must be adapted.
+%% NOTE: When this list of put options is modified,
+%% `khepri_machine:split_command_options/2' and
+%% `khepri_machine:split_put_options/2' must be adapted.
 
 -type fold_fun() :: fun((khepri_path:native_path(),
                          khepri:node_props(),

--- a/src/khepri_adv.erl
+++ b/src/khepri_adv.erl
@@ -352,7 +352,7 @@ put(StoreId, PathPattern, Data) ->
 %% khepri:command_options()}, {@link khepri:tree_options()} and {@link
 %% khepri:put_options()}.
 %%
-%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% When doing an asynchronous update, the {@link khepri:handle_async_ret/1}
 %% function should be used to handle the message received from Ra.
 %%
 %% The returned `{ok, NodeProps}' tuple contains a map with the properties and
@@ -479,7 +479,7 @@ put_many(StoreId, PathPattern, Data) ->
 %% khepri:command_options()}, {@link khepri:tree_options()} and {@link
 %% khepri:put_options()}.
 %%
-%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% When doing an asynchronous update, the {@link khepri:handle_async_ret/1}
 %% function should be used to handle the message received from Ra.
 %%
 %% Example:
@@ -843,7 +843,7 @@ delete(PathPattern, Options) when is_map(Options) ->
 %% the `delete_reason' key set to `keep_while' instead. (See {@link
 %% khepri_condition:keep_while()}.)
 %%
-%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% When doing an asynchronous update, the {@link khepri:handle_async_ret/1}
 %% function should be used to handle the message received from Ra.
 %%
 %% Example:
@@ -941,7 +941,7 @@ delete_many(PathPattern, Options) when is_map(Options) ->
 %% the `delete_reason' key set to `keep_while' instead. (See {@link
 %% khepri_condition:keep_while()}.)
 %%
-%% When doing an asynchronous update, the {@link handle_async_ret/1}
+%% When doing an asynchronous update, the {@link khepri:handle_async_ret/1}
 %% function should be used to handle the message received from Ra.
 %%
 %% Example:

--- a/src/khepri_app.erl
+++ b/src/khepri_app.erl
@@ -6,7 +6,16 @@
 %% refers to Broadcom Inc. and/or its subsidiaries.
 %%
 
-%% @hidden
+%% @doc The Khepri application
+%%
+%% Khepri supports the following application environment variables:
+%% <ul>
+%% <li>`default_ra_system': the name of the Ra system by default for Khepri
+%% stores.</li>
+%% <li>`default_store_id': the name of the default store, used by API that
+%% don't take a `StoreId'.</li>
+%% <li>`default_timeout': the default timeout.</li>
+%% </ul>
 
 -module(khepri_app).
 -behaviour(application).

--- a/src/khepri_machine.erl
+++ b/src/khepri_machine.erl
@@ -49,8 +49,8 @@
 %% <li>Changed the data structure for the reverse index used to track
 %% keep-while conditions to be a prefix tree (see {@link khepri_prefix_tree}).
 %% </li>
-%% <li>Moved the expiration of dedups to the `tick' aux effect (see {@link
-%% handle_aux/5}). This also introduces a new command `#drop_dedups{}'.</li>
+%% <li>Moved the expiration of dedups to the `tick' aux effect. This also
+%% introduces a new command `#drop_dedups{}'.</li>
 %% <li>Added the `delete_reason' to the list of properties that can be
 %% returned. It is returned by default if the effective machine version is 2 or
 %% more.</li>


### PR DESCRIPTION
Most of them are broken links because the target was hidden or private.